### PR TITLE
readme: update for new repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 VLS (V Language Server) is a LSP v3.15-compatible language server for V.
 
 ## Current Status
-VLS is a work-in-progress. This version of VLS is rewritten from scratch and will be migrated to [https://github.com/vlang/vls](https://github.com/vlang/vls) once it is finalized.
-
-VLS has also issues with memory management (for now) and may not be guaranteed to work on large codebases.
+VLS is a work-in-progress. It has issues with memory management (for now) and may not be guaranteed to work on large codebases.
 
 Windows support is also unstable for now. Please file an issue if you experience problems with it.
 
@@ -14,11 +12,12 @@ Installation requires you to have Git and V installed and compile the language s
 git clone https://github.com/nedpals/vls2.git vls && cd vls/
 
 # Build the project
-v -o vls .
+v -prod cmd/vls
+# The binary will be create in the subfolder by default
 ```
 
 ## Usage
-In order to use the language server, you need to have a text editor with support for LSP. In this case, the recommended editor for testing (for now) is to have [Visual Studio Code](https://code.visualstudio.com) and the latest `master` version of [vscode-vlang](https://github.com/vlang/vscode-vlang) extension installed.
+In order to use the language server, you need to have a text editor with support for LSP. In this case, the recommended editor for testing (for now) is to have [Visual Studio Code](https://code.visualstudio.com) and the [vscode-vlang](https://github.com/vlang/vscode-vlang) extension version 0.1.4 or above installed.
 
 ![Instructions](instructions.png)
 


### PR DESCRIPTION
- Remove old comments
- Change the command to build VLS
- The latest `master` version of vscode-vlang isn't required anymore, the latest release includes VLS support