### PR TITLE
text_sync: improve parsing flow

### DIFF
--- a/vls/diagnostics.v
+++ b/vls/diagnostics.v
@@ -23,8 +23,8 @@ fn get_column(source string, init_pos int) int {
 pub fn position_to_lsp_pos(source string, pos token.Position) lsp.Position {
 	p := util.imax(0, util.imin(source.len - 1, pos.pos))
 	column := util.imax(0, pos.pos - get_column(source, p)) - 1
-	return lsp.Position{ 
-		line: pos.line_nr, 
+	return lsp.Position{
+		line: pos.line_nr
 		character: util.imax(1, column) - 1
 	}
 }
@@ -32,9 +32,12 @@ pub fn position_to_lsp_pos(source string, pos token.Position) lsp.Position {
 // position_to_lsp_pos converts the token.Position into lsp.Range
 fn position_to_lsp_range(source string, pos token.Position) lsp.Range {
 	start_pos := position_to_lsp_pos(source, pos)
-	return lsp.Range{ 
-		start: start_pos, 
-		end: { start_pos | character: start_pos.character + pos.len }
+	return lsp.Range{
+		start: start_pos
+		end: {
+			start_pos |
+			character: start_pos.character + pos.len
+		}
 	}
 }
 

--- a/vls/general.v
+++ b/vls/general.v
@@ -21,7 +21,6 @@ fn (mut ls Vls) initialize(id int, params string) {
 	// only files are supported right now
 	ls.root_path = initialize_params.root_uri.path()
 	ls.status = .initialized
-
 	// since builtin is used frequently, they should be parsed first and only once
 	scope, pref := new_scope_and_pref()
 	builtin_files := os.ls(builtin_path) or { panic(err) }
@@ -30,7 +29,6 @@ fn (mut ls Vls) initialize(id int, params string) {
 	parsed_files << ls.parse_imports(parsed_files, ls.base_table, pref, scope)
 	ls.insert_files(parsed_files)
 	ls.send(json.encode(result))
-
 	unsafe {
 		builtin_files.free()
 		files_to_parse.free()

--- a/vls/general.v
+++ b/vls/general.v
@@ -3,6 +3,8 @@ module vls
 import lsp
 import json
 import jsonrpc
+import os
+import v.parser
 
 // initialize sends the server capabilities to the client
 fn (mut ls Vls) initialize(id int, params string) {
@@ -19,18 +21,26 @@ fn (mut ls Vls) initialize(id int, params string) {
 	// only files are supported right now
 	ls.root_path = initialize_params.root_uri.path()
 	ls.status = .initialized
+
+	// since builtin is used frequently, they should be parsed first and only once
+	scope, pref := new_scope_and_pref()
+	builtin_files := os.ls(builtin_path) or { panic(err) }
+	files_to_parse := pref.should_compile_filtered_files(builtin_path, builtin_files)
+	mut parsed_files := parser.parse_files(files_to_parse, ls.base_table, pref, scope)
+	parsed_files << ls.parse_imports(parsed_files, ls.base_table, pref, scope)
+	ls.insert_files(parsed_files)
 	ls.send(json.encode(result))
+
+	unsafe {
+		builtin_files.free()
+		files_to_parse.free()
+		parsed_files.free()
+	}
 }
 
 // shutdown sets the state to shutdown but does not exit
 fn (mut ls Vls) shutdown(params string) {
 	ls.status = .shutdown
-	unsafe {
-		// ls.projects.free()
-		ls.mod_import_paths.free()
-		ls.import_graph.free()
-		ls.mod_docs.free()
-	}
 }
 
 // exit stops the process

--- a/vls/text_synchronization.v
+++ b/vls/text_synchronization.v
@@ -66,14 +66,14 @@ fn (mut ls Vls) show_diagnostics(source string, uri lsp.DocumentUri) {
 		if uri.ends_with(file.path) {
 			for _, error in file.errors {
 				diagnostics << lsp.Diagnostic{
-					range: position_to_range(source, error.pos)
+					range: position_to_lsp_range(source, error.pos)
 					severity: .error
 					message: error.message
 				}
 			}
 			for _, warning in file.warnings {
 				diagnostics << lsp.Diagnostic{
-					range: position_to_range(source, warning.pos)
+					range: position_to_lsp_range(source, warning.pos)
 					severity: .warning
 					message: warning.message
 				}

--- a/vls/text_synchronization.v
+++ b/vls/text_synchronization.v
@@ -10,10 +10,10 @@ import v.checker
 import os
 
 const (
-	vroot = os.dir(@VEXE)
-	vlib_path = os.join_path(vroot, 'vlib')
+	vroot         = os.dir(@VEXE)
+	vlib_path     = os.join_path(vroot, 'vlib')
 	vmodules_path = os.join_path(os.home_dir(), '.vmodules')
-	builtin_path = os.join_path(vlib_path, 'builtin')
+	builtin_path  = os.join_path(vlib_path, 'builtin')
 )
 
 fn (mut ls Vls) did_open(id int, params string) {
@@ -32,36 +32,31 @@ fn (mut ls Vls) show_diagnostics(source string, uri lsp.DocumentUri) {
 	file_path := uri.path()
 	target_dir := os.dir(file_path)
 	// ls.log_message(target_dir, .info)
-	scope, pref := new_scope_and_pref(target_dir, os.dir(target_dir), os.join_path(target_dir, 'modules'))
+	scope, pref := new_scope_and_pref(target_dir, os.dir(target_dir), os.join_path(target_dir,
+		'modules'))
 	table := ls.new_table()
-
 	mut has_errors := false
 	mut parsed_files := []ast.File{}
 	mut diagnostics := []lsp.Diagnostic{}
-	
 	if file_path in ls.sources {
 		ls.sources.delete(file_path)
 	}
-
 	if target_dir in ls.tables {
 		ls.tables.delete(target_dir)
-	}	
-
-	parsed_files << parser.parse_text(source, file_path, table, .skip_comments, pref, scope)
+	}
+	parsed_files <<
+		parser.parse_text(source, file_path, table, .skip_comments, pref, scope)
 	parsed_files << ls.parse_imports(parsed_files, table, pref, scope)
-
 	for parsed_file in parsed_files {
 		if parsed_file.errors.len > 0 {
 			has_errors = true
 			break
 		}
 	}
-
 	if !has_errors {
 		mut checker := checker.new_checker(table, pref)
 		checker.check_files(parsed_files)
 	}
-
 	for _, file in parsed_files {
 		if uri.ends_with(file.path) {
 			for _, error in file.errors {
@@ -80,12 +75,10 @@ fn (mut ls Vls) show_diagnostics(source string, uri lsp.DocumentUri) {
 			}
 		}
 	}
-
 	ls.sources[file_path] = source
 	ls.tables[target_dir] = table
 	ls.insert_files(parsed_files)
 	ls.publish_diagnostics(uri, diagnostics)
-
 	unsafe {
 		parsed_files.free()
 		diagnostics.free()
@@ -96,7 +89,6 @@ fn (mut ls Vls) show_diagnostics(source string, uri lsp.DocumentUri) {
 fn (ls Vls) parse_imports(parsed_files []ast.File, table &table.Table, pref &pref.Preferences, scope &ast.Scope) []ast.File {
 	mut newly_parsed_files := []ast.File{}
 	mut done_imports := parsed_files.map(it.mod.name)
-
 	// NB: b.parsed_files is appended in the loop,
 	// so we can not use the shorter `for in` form.
 	for i := 0; i < parsed_files.len; i++ {
@@ -114,7 +106,8 @@ fn (ls Vls) parse_imports(parsed_files []ast.File, table &table.Table, pref &pre
 				mut files := os.ls(mod_dir) or { []string{} }
 				files = pref.should_compile_filtered_files(mod_dir, files)
 				newly_parsed_files << parser.parse_files(files, table, pref, scope)
-				newly_parsed_files << ls.parse_imports(newly_parsed_files, table, pref, scope)
+				newly_parsed_files <<
+					ls.parse_imports(newly_parsed_files, table, pref, scope)
 				done_imports << imp.mod
 				found = true
 				break
@@ -124,9 +117,6 @@ fn (ls Vls) parse_imports(parsed_files []ast.File, table &table.Table, pref &pre
 			}
 		}
 	}
-
-	unsafe {
-		done_imports.free()
-	}
+	unsafe {done_imports.free()}
 	return newly_parsed_files
 }

--- a/vls/text_synchronization.v
+++ b/vls/text_synchronization.v
@@ -28,44 +28,40 @@ fn (mut ls Vls) did_change(id int, params string) {
 	ls.show_diagnostics(source, did_change_params.text_document.uri)
 }
 
-fn (ls Vls) show_diagnostics(source string, uri lsp.DocumentUri) {
+fn (mut ls Vls) show_diagnostics(source string, uri lsp.DocumentUri) {
 	file_path := uri.path()
 	target_dir := os.dir(file_path)
-	ls.log_message(target_dir, .info)
-	scope := ast.Scope{
-		parent: 0
-	}
-	pref := pref.Preferences{
-		output_mode: .silent
-		backend: .c
-		os: ._auto
-		lookup_path: [
-			target_dir,
-			os.dir(target_dir), //parent hack
-			os.join_path(target_dir, 'modules'),
-			vlib_path,
-			vmodules_path
-		]
-	}
-	table := table.new_table()
-	mut builtin_files := os.ls(builtin_path) or { panic(err) }
-	files_to_parse := pref.should_compile_filtered_files(builtin_path, builtin_files)
+	// ls.log_message(target_dir, .info)
+	scope, pref := new_scope_and_pref(target_dir, os.dir(target_dir), os.join_path(target_dir, 'modules'))
+	table := ls.new_table()
+
+	mut has_errors := false
 	mut parsed_files := []ast.File{}
-	parsed_files << parser.parse_text(source, file_path, table, .skip_comments, &pref, &scope)
-	parsed_files << parser.parse_files(files_to_parse, table, &pref, &scope)
-	parsed_files << ls.parse_imports(parsed_files, table, &pref, &scope)
-	mut parsing_errors := false
-	for f in parsed_files {
-		if f.errors.len > 0 {
-			parsing_errors = true
+	mut diagnostics := []lsp.Diagnostic{}
+	
+	if file_path in ls.sources {
+		ls.sources.delete(file_path)
+	}
+
+	if target_dir in ls.tables {
+		ls.tables.delete(target_dir)
+	}	
+
+	parsed_files << parser.parse_text(source, file_path, table, .skip_comments, pref, scope)
+	parsed_files << ls.parse_imports(parsed_files, table, pref, scope)
+
+	for parsed_file in parsed_files {
+		if parsed_file.errors.len > 0 {
+			has_errors = true
 			break
 		}
 	}
-	if !parsing_errors {
-		mut checker := checker.new_checker(table, &pref)
+
+	if !has_errors {
+		mut checker := checker.new_checker(table, pref)
 		checker.check_files(parsed_files)
 	}
-	mut diagnostics := []lsp.Diagnostic{}
+
 	for _, file in parsed_files {
 		if uri.ends_with(file.path) {
 			for _, error in file.errors {
@@ -84,7 +80,17 @@ fn (ls Vls) show_diagnostics(source string, uri lsp.DocumentUri) {
 			}
 		}
 	}
+
+	ls.sources[file_path] = source
+	ls.tables[target_dir] = table
+	ls.insert_files(parsed_files)
 	ls.publish_diagnostics(uri, diagnostics)
+
+	unsafe {
+		parsed_files.free()
+		diagnostics.free()
+		source.free()
+	}
 }
 
 fn (ls Vls) parse_imports(parsed_files []ast.File, table &table.Table, pref &pref.Preferences, scope &ast.Scope) []ast.File {
@@ -105,9 +111,7 @@ fn (ls Vls) parse_imports(parsed_files []ast.File, table &table.Table, pref &pre
 				if !os.exists(mod_dir) {
 					continue
 				}
-				mut files := os.ls(mod_dir) or {
-					[]string{}
-				}
+				mut files := os.ls(mod_dir) or { []string{} }
 				files = pref.should_compile_filtered_files(mod_dir, files)
 				newly_parsed_files << parser.parse_files(files, table, pref, scope)
 				newly_parsed_files << ls.parse_imports(newly_parsed_files, table, pref, scope)
@@ -119,6 +123,10 @@ fn (ls Vls) parse_imports(parsed_files []ast.File, table &table.Table, pref &pre
 				panic('cannot find module $imp.mod')
 			}
 		}
+	}
+
+	unsafe {
+		done_imports.free()
 	}
 	return newly_parsed_files
 }

--- a/vls/vls.v
+++ b/vls/vls.v
@@ -1,12 +1,10 @@
 module vls
 
 import v.table
-import v.doc
-import v.token
 import v.ast
+import v.pref
 import json
 import jsonrpc
-import strings
 
 interface ReceiveSender {
 	send(data string)
@@ -15,27 +13,34 @@ interface ReceiveSender {
 
 struct Vls {
 mut:
-	table            &table.Table = table.new_table()
-	status           ServerStatus = .off
-	// imports
-	import_graph     map[string][]string
-	mod_import_paths map[string]string
-	mod_docs         map[string]doc.Doc
-	// directory -> file name
-	// projects         map[string]Project
-	docs             map[string]doc.Doc
-	tokens           map[string]map[string][]token.Token
-	asts             map[string]map[string]ast.File
-	current_file     string
-	root_path        string
+	// NB: a base table is required since this is where we
+	// are gonna store the information for the builtin types
+	// which are only parsed once.
+	base_table				&table.Table
+	status            ServerStatus = .off
+	files							map[string]ast.File
+	sources						map[string]string
+	// NB: a separate table is required for each folder in
+	// order to do functions such as typ_to_string or when
+	// some of the features needed additional information
+	// that is mostly stored into the table.
+	//
+	// A single table is not feasible since files are always
+	// changing and there can be instances that a change might
+	// break another module/project data.
+	tables						map[string]&table.Table
+	root_path         string
 pub mut:
 	// TODO: replace with io.ReadWriter
 	io               ReceiveSender
 }
 
 pub fn new(io ReceiveSender) Vls {
+	mut tbl := table.new_table()
+	tbl.is_fmt = false
 	return Vls{
 		io: io
+		base_table: tbl
 	}
 }
 
@@ -87,8 +92,6 @@ fn (ls Vls) send(data string) {
 	ls.io.send(data)
 }
 
-fn C.fgetc(stream byteptr) int
-
 // start_loop starts an endless loop which waits for stdin and prints responses to the stdout
 pub fn (mut ls Vls) start_loop() {
 	for {
@@ -97,18 +100,52 @@ pub fn (mut ls Vls) start_loop() {
 	}
 }
 
-fn get_raw_input() string {
-	eof := C.EOF
-	mut buf := strings.new_builder(200)
-	for {
-		c := C.fgetc(C.stdin)
-		chr := byte(c)
-		if buf.len > 2 && (c == eof || chr in [`\r`, `\n`]) {
-			break
-		}
-		buf.write_b(chr)
+//
+fn new_scope_and_pref(lookup_paths ...string) (&ast.Scope, &pref.Preferences) {
+	mut lpaths := [vlib_path, vmodules_path]
+	for i := lookup_paths.len - 1; i >= 0; i-- {
+		lookup_path := lookup_paths[i]
+		lpaths.prepend(lookup_path)
 	}
-	return buf.str()
+
+	scope := &ast.Scope{
+		parent: 0
+	}
+
+	prefs := &pref.Preferences{
+		output_mode: .silent
+		backend: .c
+		os: ._auto
+		lookup_path: lpaths
+	}
+
+	return scope, prefs
+}
+
+fn (mut ls Vls) insert_files(files []ast.File) {
+	for file in files {
+		if file.path in ls.files {
+			ls.files.delete(file.path)
+		}	
+
+		ls.files[file.path] = file
+	}
+}
+
+// new_table returns a new table based on the existing data from base_table
+fn (ls Vls) new_table() &table.Table {
+	mut tbl := table.new_table()
+	tbl.types = ls.base_table.types.clone()
+	tbl.type_idxs = ls.base_table.type_idxs.clone()
+	tbl.fns = ls.base_table.fns.clone()
+	tbl.imports = ls.base_table.imports.clone()
+	tbl.modules = ls.base_table.modules.clone()
+	tbl.cflags = ls.base_table.cflags.clone()
+	tbl.redefined_fns = ls.base_table.redefined_fns.clone()
+	tbl.fn_gen_types = ls.base_table.fn_gen_types.clone()
+	tbl.cmod_prefix = ls.base_table.cmod_prefix
+	tbl.is_fmt = ls.base_table.is_fmt
+	return tbl
 }
 
 pub enum ServerStatus {

--- a/vls/vls.v
+++ b/vls/vls.v
@@ -8,7 +8,7 @@ import jsonrpc
 
 interface ReceiveSender {
 	send(data string)
-	receive() ?string 
+	receive() ?string
 }
 
 struct Vls {
@@ -16,10 +16,10 @@ mut:
 	// NB: a base table is required since this is where we
 	// are gonna store the information for the builtin types
 	// which are only parsed once.
-	base_table				&table.Table
-	status            ServerStatus = .off
-	files							map[string]ast.File
-	sources						map[string]string
+	base_table &table.Table
+	status     ServerStatus = .off
+	files      map[string]ast.File
+	sources    map[string]string
 	// NB: a separate table is required for each folder in
 	// order to do functions such as typ_to_string or when
 	// some of the features needed additional information
@@ -28,11 +28,11 @@ mut:
 	// A single table is not feasible since files are always
 	// changing and there can be instances that a change might
 	// break another module/project data.
-	tables						map[string]&table.Table
-	root_path         string
+	tables     map[string]&table.Table
+	root_path  string
 pub mut:
 	// TODO: replace with io.ReadWriter
-	io               ReceiveSender
+	io         ReceiveSender
 }
 
 pub fn new(io ReceiveSender) Vls {
@@ -107,18 +107,15 @@ fn new_scope_and_pref(lookup_paths ...string) (&ast.Scope, &pref.Preferences) {
 		lookup_path := lookup_paths[i]
 		lpaths.prepend(lookup_path)
 	}
-
 	scope := &ast.Scope{
 		parent: 0
 	}
-
 	prefs := &pref.Preferences{
 		output_mode: .silent
 		backend: .c
 		os: ._auto
 		lookup_path: lpaths
 	}
-
 	return scope, prefs
 }
 
@@ -126,8 +123,7 @@ fn (mut ls Vls) insert_files(files []ast.File) {
 	for file in files {
 		if file.path in ls.files {
 			ls.files.delete(file.path)
-		}	
-
+		}
 		ls.files[file.path] = file
 	}
 }
@@ -155,11 +151,11 @@ pub enum ServerStatus {
 }
 
 // with error
-struct JrpcResponse2<T> {
+struct JrpcResponse2 <T> {
 	jsonrpc string = jsonrpc.version
-	id int
-	error jsonrpc.ResponseError
-	result T
+	id      int
+	error   jsonrpc.ResponseError
+	result  T
 }
 
 [inline]

--- a/vls/workspace.v
+++ b/vls/workspace.v
@@ -1,6 +1,4 @@
 module vls
 
-
 fn (ls Vls) did_change_watched_files(id int, params string) {
-
 }


### PR DESCRIPTION
This reduces the memory consumption of VLS from a whopping ~180mb for simple 5-keystroke change to only 10.7mb by parsing builtin once on initialization and manual free-ing to some parts of the server