### PR TITLE
vls: add is_shared to preferences to prevent error

### DIFF
--- a/vls/vls.v
+++ b/vls/vls.v
@@ -169,6 +169,7 @@ fn new_scope_and_pref(lookup_paths ...string) (&ast.Scope, &pref.Preferences) {
 		backend: .c
 		os: ._auto
 		lookup_path: lpaths
+		is_shared: true
 	}
 	return scope, prefs
 }


### PR DESCRIPTION
this prevents an error that said: no fn main defintion.