### PR TITLE
add workspace path to lookup paths

### DIFF
--- a/vls/features.v
+++ b/vls/features.v
@@ -58,7 +58,7 @@ fn (ls Vls) formatting(id int, params string) {
 fn (mut ls Vls) workspace_symbol(id int, params string) {
 	mut symbols := []lsp.SymbolInformation{}
 	for file_uri, file in ls.files {
-		if !file_uri.starts_with(ls.root_path.str()) {
+		if !file_uri.starts_with(ls.root_uri.str()) {
 			continue
 		}
 		symbols << ls.generate_symbols(file, file_uri)

--- a/vls/general.v
+++ b/vls/general.v
@@ -27,7 +27,7 @@ fn (mut ls Vls) initialize(id int, params string) {
 		}
 	}
 	// only files are supported right now
-	ls.root_path = initialize_params.root_uri
+	ls.root_uri = initialize_params.root_uri
 	ls.status = .initialized
 	// since builtin is used frequently, they should be parsed first and only once
 	ls.process_builtin()

--- a/vls/text_synchronization.v
+++ b/vls/text_synchronization.v
@@ -52,7 +52,7 @@ fn (mut ls Vls) did_close(id int, params string) {
 	// - TODO: If a workspace has opened multiple programs with main() function and one of them is closed.
 	// - If a file opened is outside the root path or workspace.
 	// - If there are no remaining files opened on a specific folder.
-	if no_active_files || !uri.starts_with(ls.root_path) {
+	if no_active_files || !uri.starts_with(ls.root_uri) {
 		// clear diagnostics
 		ls.publish_diagnostics(uri, []lsp.Diagnostic{})
 	}
@@ -66,7 +66,7 @@ fn (mut ls Vls) process_file(source string, uri lsp.DocumentUri) {
 	target_dir_uri := os.dir(uri)
 	// ls.log_message(target_dir, .info)
 	scope, mut pref := new_scope_and_pref(target_dir, os.dir(target_dir), os.join_path(target_dir,
-		'modules'))
+		'modules'), ls.root_uri.path())
 	if uri.ends_with('_test.v') {
 		pref.is_test = true
 	}

--- a/vls/vls.v
+++ b/vls/vls.v
@@ -67,7 +67,7 @@ mut:
 	// break another module/project data.
 	// tables  map[DocumentUri]&table.Table
 	tables           map[string]&table.Table
-	root_path        lsp.DocumentUri
+	root_uri        lsp.DocumentUri
 	invalid_imports  map[string][]string // where it stores a list of invalid imports
 	doc_symbols      map[string][]lsp.SymbolInformation // doc_symbols is used for caching document symbols
 	builtin_symbols  []string // list of publicly available symbols in builtin


### PR DESCRIPTION
adds workspace directory to lookup paths.

Fixes this:
![image](https://user-images.githubusercontent.com/30751516/105489742-04d70080-5cb4-11eb-84f1-f143ab304a1c.png)
