### PR TITLE
vls: implement textDocument/foldingRange

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Afterwards, go to your editor's configuration and scroll to the V extension sect
 - [ ] `onTypeFormatting`
 - [ ] `rename`
 - [ ] `prepareRename`
-- [ ] `foldingRange`
+- [x] `foldingRange`
 
 # Contributing
 ## Submitting a pull request

--- a/lsp/capabilities.v
+++ b/lsp/capabilities.v
@@ -189,6 +189,7 @@ pub mut:
 	color_provider                       bool                            [json: colorProvider]
 	declaration_provider                 bool                            [json: declarationProvider]
 	execute_command_provder              string                          [raw; json: executeCommandProvider]
+	folding_range_provider               bool                            [json: foldingRangeProvider]
 	experimental                         map[string]bool
 }
 

--- a/lsp/folding_range.v
+++ b/lsp/folding_range.v
@@ -1,13 +1,9 @@
 module lsp
 
-// /**
-// * Folding range provider options.
-// */
-// export interface FoldingRangeProviderOptions {
-// }
 // method: ‘textDocument/foldingRange’
 // response: []FoldingRange | none
 pub struct FoldingRangeParams {
+pub:
 	text_document TextDocumentIdentifier [json: textDocument]
 }
 

--- a/vls/features.v
+++ b/vls/features.v
@@ -930,7 +930,7 @@ fn (ls Vls) folding_range(id int, params string) {
 	}
 	src := ls.sources[uri.str()]
 	mut folding_ranges := []lsp.FoldingRange{}
-	
+
 	// TODO: enable parsing with .toplevel_comments included
 	for stmt in file.stmts {
 		match stmt {

--- a/vls/general.v
+++ b/vls/general.v
@@ -24,7 +24,8 @@ fn (mut ls Vls) initialize(id int, params string) {
 		workspace_symbol_provider: Feature.workspace_symbol in ls.enabled_features
 		document_symbol_provider: Feature.document_symbol in ls.enabled_features
 		document_formatting_provider: Feature.formatting in ls.enabled_features
-		hover_provider: true // TODO
+		hover_provider: true
+		folding_range_provider: true
 	}
 
 	if Feature.completion in ls.enabled_features {

--- a/vls/general.v
+++ b/vls/general.v
@@ -25,7 +25,7 @@ fn (mut ls Vls) initialize(id int, params string) {
 		document_symbol_provider: Feature.document_symbol in ls.enabled_features
 		document_formatting_provider: Feature.formatting in ls.enabled_features
 		hover_provider: true
-		folding_range_provider: true
+		folding_range_provider: Feature.folding_range in ls.enabled_features
 	}
 
 	if Feature.completion in ls.enabled_features {

--- a/vls/general_test.v
+++ b/vls/general_test.v
@@ -47,12 +47,12 @@ fn test_set_features() {
 		assert false
 		return
 	}
-	assert ls.features() == [.diagnostics, .document_symbol, .workspace_symbol, .completion]
+	assert ls.features() == [.diagnostics, .document_symbol, .workspace_symbol, .completion, .folding_range]
 	ls.set_features(['formatting'], true) or {
 		assert false
 		return
 	}
-	assert ls.features() == [.diagnostics, .document_symbol, .workspace_symbol, .completion, .formatting]
+	assert ls.features() == [.diagnostics, .document_symbol, .workspace_symbol, .completion, .folding_range, .formatting]
 	ls.set_features(['logging'], true) or {
 		assert err == 'feature "logging" not found'
 		return

--- a/vls/tests/folding_range_test.v
+++ b/vls/tests/folding_range_test.v
@@ -5,45 +5,45 @@ import lsp
 import os
 
 // TODO: enable top level comments support in the future
-const folding_range_results = {
-	'simple.vv': [
-		lsp.FoldingRange {
+const folding_range_results = map{
+	'simple.vv':  [
+		lsp.FoldingRange{
 			start_line: 2
 			start_character: 0
 			end_line: 6
 			end_character: 11
 			kind: 'region'
 		},
-		lsp.FoldingRange {
+		lsp.FoldingRange{
 			start_line: 8
 			start_character: 0
 			end_line: 11
 			end_character: 9
 			kind: 'region'
 		},
-		lsp.FoldingRange {
+		lsp.FoldingRange{
 			start_line: 13
 			start_character: 0
 			end_line: 17
 			end_character: 10
 			kind: 'region'
 		},
-		lsp.FoldingRange {
+		lsp.FoldingRange{
 			start_line: 19
 			start_character: 0
 			end_line: 23
 			end_character: 9
 			kind: 'region'
-		}
+		},
 	]
 	'comment.vv': [
-		lsp.FoldingRange {
+		lsp.FoldingRange{
 			start_line: 0
 			start_character: 0
 			end_line: 18
 			end_character: 2
 			kind: 'comment'
-		}
+		},
 	]
 }
 

--- a/vls/tests/folding_range_test.v
+++ b/vls/tests/folding_range_test.v
@@ -1,0 +1,99 @@
+import vls
+import vls.testing
+import json
+import lsp
+import os
+
+// TODO: enable top level comments support in the future
+const folding_range_results = {
+	'simple.vv': [
+		lsp.FoldingRange {
+			start_line: 2
+			start_character: 0
+			end_line: 6
+			end_character: 11
+			kind: 'region'
+		},
+		lsp.FoldingRange {
+			start_line: 8
+			start_character: 0
+			end_line: 11
+			end_character: 9
+			kind: 'region'
+		},
+		lsp.FoldingRange {
+			start_line: 13
+			start_character: 0
+			end_line: 17
+			end_character: 10
+			kind: 'region'
+		},
+		lsp.FoldingRange {
+			start_line: 19
+			start_character: 0
+			end_line: 23
+			end_character: 9
+			kind: 'region'
+		}
+	]
+	'comment.vv': [
+		lsp.FoldingRange {
+			start_line: 0
+			start_character: 0
+			end_line: 18
+			end_character: 2
+			kind: 'comment'
+		}
+	]
+}
+
+fn test_folding_range() {
+	mut io := testing.Testio{}
+	mut ls := vls.new(io)
+	ls.dispatch(io.request_with_params('initialize', lsp.InitializeParams{
+		root_uri: lsp.document_uri_from_path(os.join_path(os.dir(@FILE), 'test_files',
+			'folding_range'))
+	}))
+	test_files := testing.load_test_file_paths('folding_range') or {
+		io.bench.fail()
+		eprintln(io.bench.step_message_fail(err))
+		assert false
+		return
+	}
+	io.bench.set_total_expected_steps(test_files.len)
+	for test_file_path in test_files {
+		io.bench.step()
+		test_name := os.base(test_file_path)
+		err_msg := if test_name !in folding_range_results {
+			'missing results for $test_name'
+		} else {
+			''
+		}
+		if err_msg.len != 0 {
+			io.bench.fail()
+			eprintln(io.bench.step_message_fail(err_msg))
+			continue
+		}
+		content := os.read_file(test_file_path) or {
+			io.bench.fail()
+			eprintln(io.bench.step_message_fail('file $test_file_path is missing'))
+			continue
+		}
+		// open document
+		req, doc_id := io.open_document(test_file_path, content)
+		ls.dispatch(req)
+		// initiate folding range request
+		ls.dispatch(io.request_with_params('textDocument/foldingRange', lsp.FoldingRangeParams{
+			text_document: doc_id
+		}))
+		// compare content
+		println(io.bench.step_message('Testing $test_file_path'))
+		assert io.result() == json.encode(folding_range_results[test_name])
+		// Delete document
+		ls.dispatch(io.close_document(doc_id))
+		io.bench.ok()
+		println(io.bench.step_message_ok(test_name))
+	}
+	assert io.bench.nfail == 0
+	io.bench.stop()
+}

--- a/vls/tests/test_files/folding_range/comment_skip.vv
+++ b/vls/tests/test_files/folding_range/comment_skip.vv
@@ -1,0 +1,19 @@
+/*
+
+This is a very very long comment range.
+
+Like very very very long.
+
+Magnis justo a a tincidunt curae nascetur viverra venenatis at 
+duis a congue lorem ultricies congue porttitor quis rhoncus nam 
+in aenean venenatis eros imperdiet eleifend convallis montes. Dis 
+a proin vitae semper suspendisse in adipiscing a 
+suspendisse suspendisse etiam a eros eget aptent suspendisse parturient 
+volutpat dui a fusce arcu urna in litora cubilia. Lacus habitasse ad id 
+massa fames curae senectus dui ullamcorper condimentum ac risus convallis 
+enim. Erat est nam est ad ullamcorper potenti bibendum maecenas a bibendum 
+fusce mi adipiscing eu suspendisse commodo a felis conubia vestibulum lacinia 
+a. Suspendisse a etiam etiam maecenas a sagittis lobortis a sed nibh cubilia 
+volutpat himenaeos potenti a tristique per sagittis vestibulum pharetra.
+
+*/

--- a/vls/tests/test_files/folding_range/simple.vv
+++ b/vls/tests/test_files/folding_range/simple.vv
@@ -1,0 +1,24 @@
+module main
+
+struct Stru {
+  name string
+  age int
+  height f32
+}
+
+interface Speaker {
+  speak(word string) string
+  silent()
+}
+
+enum Color {
+  red
+  blue
+  green
+}
+
+fn main() {
+  num := 2
+  hello := 'world'
+  foo := 10.00
+}

--- a/vls/vls.v
+++ b/vls/vls.v
@@ -41,7 +41,7 @@ pub const (
 		.document_symbol,
 		.workspace_symbol,
 		.completion,
-		.folding_range
+		.folding_range,
 	]
 )
 

--- a/vls/vls.v
+++ b/vls/vls.v
@@ -16,6 +16,7 @@ pub enum Feature {
 	workspace_symbol
 	completion
 	hover
+	folding_range
 }
 
 // feature_from_str returns the Feature-enum value equivalent of the given string.
@@ -28,6 +29,7 @@ fn feature_from_str(feature_name string) ?Feature {
 		'workspace_symbol' { return Feature.workspace_symbol }
 		'completion' { return Feature.completion }
 		'hover' { return Feature.hover }
+		'folding_range' { return Feature.folding_range }
 		else { return error('feature "$feature_name" not found') }
 	}
 }
@@ -39,6 +41,7 @@ pub const (
 		.document_symbol,
 		.workspace_symbol,
 		.completion,
+		.folding_range
 	]
 )
 
@@ -117,6 +120,7 @@ pub fn (mut ls Vls) dispatch(payload string) {
 			'workspace/symbol' { ls.workspace_symbol(request.id, request.params) }
 			'textDocument/completion' { ls.completion(request.id, request.params) }
 			'textDocument/hover' { ls.hover(request.id, request.params) }
+			'textDocument/foldingRange' { ls.folding_range(request.id, request.params) }
 			else {}
 		}
 	} else {


### PR DESCRIPTION
Add support for folding range as part of LSP spec. Closes #74 .

# Roadmap
- [x] Folding range support
  - [x] ast.StructDecl
  - [x] ast.FnDecl
  - [x] ast.EnumDecl
  - [x] ast.InterfaceDecl
  - [x] Top-level ast.Comment (Implemented but not yet enabled in parsing)