### PR TITLE
vls: properly enable hover feature

### DIFF
--- a/vls/general.v
+++ b/vls/general.v
@@ -24,7 +24,7 @@ fn (mut ls Vls) initialize(id int, params string) {
 		workspace_symbol_provider: Feature.workspace_symbol in ls.enabled_features
 		document_symbol_provider: Feature.document_symbol in ls.enabled_features
 		document_formatting_provider: Feature.formatting in ls.enabled_features
-		hover_provider: true // TODO
+		hover_provider: Feature.hover in ls.enabled_features
 	}
 
 	if Feature.completion in ls.enabled_features {

--- a/vls/general_test.v
+++ b/vls/general_test.v
@@ -47,12 +47,12 @@ fn test_set_features() {
 		assert false
 		return
 	}
-	assert ls.features() == [.diagnostics, .document_symbol, .workspace_symbol, .completion]
+	assert ls.features() == [.diagnostics, .document_symbol, .workspace_symbol, .completion, .hover]
 	ls.set_features(['formatting'], true) or {
 		assert false
 		return
 	}
-	assert ls.features() == [.diagnostics, .document_symbol, .workspace_symbol, .completion, .formatting]
+	assert ls.features() == [.diagnostics, .document_symbol, .workspace_symbol, .completion, .hover,.formatting]
 	ls.set_features(['logging'], true) or {
 		assert err == 'feature "logging" not found'
 		return

--- a/vls/vls.v
+++ b/vls/vls.v
@@ -39,6 +39,7 @@ pub const (
 		.document_symbol,
 		.workspace_symbol,
 		.completion,
+		.hover
 	]
 )
 


### PR DESCRIPTION
Extension of #58. This PR adds the hover feature to the `default_features_list` and changes the value of `hover_provider` in the `ServerCapabilities` based on the `ls.enabled_features` field 