### PR TITLE
vls: improvements to autocompletion feature

### DIFF
--- a/vls/features.v
+++ b/vls/features.v
@@ -321,10 +321,70 @@ fn (mut cfg CompletionItemConfig) completion_items_from_stmt(stmt ast.Stmt) []ls
 			cfg.show_local = false
 			dir := os.dir(cfg.file.path)
 			dir_contents := os.ls(dir) or { []string{} }
-			// list all folders
-			completion_items << cfg.completion_items_from_dir(dir, dir_contents, '')
-			// list all vlib
-			// TODO: vlib must be computed at once only
+
+			// Checks the offset if it is within the import symbol section
+			// a.k.a import <module_name> { <import symbols> }
+			if is_within_pos(cfg.offset, stmt.syms_pos) {
+				already_imported := stmt.syms.map(it.name)
+
+				for _, idx in cfg.table.type_idxs {
+					type_sym := unsafe { &cfg.table.type_symbols[idx] }
+					name := type_sym.name.all_after(type_sym.mod + '.')
+					if type_sym.mod != stmt.mod || name in already_imported {
+						continue
+					}
+					match type_sym.kind {
+						.struct_ {
+							completion_items << lsp.CompletionItem{
+								label: name
+								kind: .struct_
+								insert_text: name
+							}
+						}
+						.enum_ {
+							completion_items << lsp.CompletionItem{
+								label: name
+								kind: .enum_
+								insert_text: name
+							}
+						}
+						.interface_ {
+							completion_items << lsp.CompletionItem{
+								label: name
+								kind: .interface_
+								insert_text: name
+							}
+						}
+						.sum_type, .alias {
+							completion_items << lsp.CompletionItem{
+								label: name
+								kind: .type_parameter
+								insert_text: name
+							}
+						}
+						else {
+							continue
+						}
+					}
+				}
+
+				for _, fnn in cfg.table.fns {
+					name := fnn.name.all_after(fnn.mod + '.')
+
+					if fnn.mod == stmt.mod && name !in already_imported && fnn.is_pub {
+						completion_items << lsp.CompletionItem{
+							label: name
+							kind: .function
+							insert_text: name
+						}
+					}
+				}
+			} else {
+				// list all folders
+				completion_items << cfg.completion_items_from_dir(dir, dir_contents, '')
+				// list all vlib
+				// TODO: vlib must be computed at once only
+			}
 		}
 		ast.Module {
 			completion_items << cfg.suggest_mod_names()
@@ -483,10 +543,11 @@ fn (mut cfg CompletionItemConfig) completion_items_from_struct_init_field(field 
 fn (mut _ CompletionItemConfig) completion_items_from_fn(fnn table.Fn, is_method bool) []lsp.CompletionItem {
 	mut completion_items := []lsp.CompletionItem{}
 
-	fn_name := fnn.name.all_after(fnn.mod + '.')
-	if fn_name == 'main' {
+	if fnn.is_main {
 		return completion_items
 	}
+
+	fn_name := fnn.name.all_after(fnn.mod + '.')
 	// This will create a snippet that will automatically
 	// create a call expression based on the information of the function
 	mut insert_text := fn_name

--- a/vls/tests/completion_test.v
+++ b/vls/tests/completion_test.v
@@ -34,6 +34,10 @@ const completion_inputs = map{
 		context: lsp.CompletionContext{.trigger_character, '.'}
 		position: lsp.Position{13, 6}
 	}
+	'import_symbols.vv':                    lsp.CompletionParams{
+		context: lsp.CompletionContext{.trigger_character, ' '}
+		position: lsp.Position{2, 13}
+	}
 	'import.vv':                            lsp.CompletionParams{
 		context: lsp.CompletionContext{.trigger_character, ' '}
 		position: lsp.Position{2, 7}
@@ -156,6 +160,33 @@ const completion_results = map{
 			kind: .method
 			insert_text: 'lol()'
 			insert_text_format: .snippet
+		},
+	]
+	'import_symbols.vv':                    [
+		lsp.CompletionItem{
+			label: 'DB'
+			kind: .struct_
+			insert_text: 'DB'
+		},
+		lsp.CompletionItem{
+			label: 'Row'
+			kind: .struct_
+			insert_text: 'Row'
+		},
+		lsp.CompletionItem{
+			label: 'C.PGResult'
+			kind: .struct_
+			insert_text: 'C.PGResult'
+		},
+		lsp.CompletionItem{
+			label: 'Config'
+			kind: .struct_
+			insert_text: 'Config'
+		},
+		lsp.CompletionItem{
+			label: 'connect'
+			kind: .function
+			insert_text: 'connect'
 		},
 	]
 	'import.vv':                            [

--- a/vls/tests/completion_test.v
+++ b/vls/tests/completion_test.v
@@ -38,6 +38,10 @@ const completion_inputs = map{
 		context: lsp.CompletionContext{.invoked, ''}
 		position: lsp.Position{0, 7}
 	}
+	'incomplete_nested_selector.vv':        lsp.CompletionParams{
+		context: lsp.CompletionContext{.trigger_character, '.'}
+		position: lsp.Position{14, 10}
+	}
 	'incomplete_selector.vv':               lsp.CompletionParams{
 		context: lsp.CompletionContext{.trigger_character, '.'}
 		position: lsp.Position{12, 6}
@@ -164,6 +168,19 @@ const completion_results = map{
 			label: 'module completion'
 			kind: .variable
 			insert_text: 'module completion'
+		},
+	]
+	'incomplete_nested_selector.vv':        [
+		lsp.CompletionItem{
+			label: 'name'
+			kind: .field
+			insert_text: 'name'
+		},
+		lsp.CompletionItem{
+			label: 'theres_a_method'
+			kind: .method
+			insert_text: 'theres_a_method()'
+			insert_text_format: .snippet
 		},
 	]
 	'incomplete_selector.vv':               [

--- a/vls/tests/completion_test.v
+++ b/vls/tests/completion_test.v
@@ -22,6 +22,10 @@ const completion_inputs = map{
 		context: lsp.CompletionContext{.trigger_character, ' '}
 		position: lsp.Position{14, 20}
 	}
+	'filtered_fields_in_selector.vv':       lsp.CompletionParams{
+		context: lsp.CompletionContext{.trigger_character, '.'}
+		position: lsp.Position{6, 9}
+	}
 	'filtered_methods_in_immutable_var.vv': lsp.CompletionParams{
 		context: lsp.CompletionContext{.trigger_character, '.'}
 		position: lsp.Position{13, 6}
@@ -117,6 +121,19 @@ const completion_results = map{
 			label: '.dalmatian'
 			kind: .enum_member
 			insert_text: '.dalmatian'
+		},
+	]
+	'filtered_fields_in_selector.vv':       [
+		lsp.CompletionItem{
+			label: 'output_file_name'
+			kind: .field
+			insert_text: 'output_file_name'
+		},
+		lsp.CompletionItem{
+			label: 'log_cli'
+			kind: .method
+			insert_text: 'log_cli(\${1:s}, \${2:level})'
+			insert_text_format: .snippet
 		},
 	]
 	'filtered_methods_in_immutable_var.vv': [

--- a/vls/tests/completion_test.v
+++ b/vls/tests/completion_test.v
@@ -6,50 +6,58 @@ import os
 
 // NOTE: skip module_symbols_selector for now, see note in text_synchronization.v#parse_imports 
 const completion_inputs = map{
-	'assign.vv':                  lsp.CompletionParams{
+	'assign.vv':                            lsp.CompletionParams{
 		context: lsp.CompletionContext{.trigger_character, ' '}
 		position: lsp.Position{6, 7}
 	}
-	'blank.vv':                   lsp.CompletionParams{
+	'blank.vv':                             lsp.CompletionParams{
 		context: lsp.CompletionContext{.invoked, ''}
 		position: lsp.Position{0, 0}
 	}
-	'call_args.vv':               lsp.CompletionParams{
+	'call_args.vv':                         lsp.CompletionParams{
 		context: lsp.CompletionContext{.invoked, ''}
 		position: lsp.Position{10, 14}
 	}
-	'enum_val_in_struct.vv':      lsp.CompletionParams{
+	'enum_val_in_struct.vv':                lsp.CompletionParams{
 		context: lsp.CompletionContext{.trigger_character, ' '}
 		position: lsp.Position{14, 20}
 	}
-	'import.vv':                  lsp.CompletionParams{
+	'filtered_methods_in_immutable_var.vv': lsp.CompletionParams{
+		context: lsp.CompletionContext{.trigger_character, '.'}
+		position: lsp.Position{13, 6}
+	}
+	'filtered_methods_in_mutable_var.vv':   lsp.CompletionParams{
+		context: lsp.CompletionContext{.trigger_character, '.'}
+		position: lsp.Position{13, 6}
+	}
+	'import.vv':                            lsp.CompletionParams{
 		context: lsp.CompletionContext{.trigger_character, ' '}
 		position: lsp.Position{2, 7}
 	}
-	'incomplete_module.vv':       lsp.CompletionParams{
+	'incomplete_module.vv':                 lsp.CompletionParams{
 		context: lsp.CompletionContext{.invoked, ''}
 		position: lsp.Position{0, 7}
 	}
-	'incomplete_selector.vv':     lsp.CompletionParams{
+	'incomplete_selector.vv':               lsp.CompletionParams{
 		context: lsp.CompletionContext{.trigger_character, '.'}
 		position: lsp.Position{12, 6}
 	}
-	'local_results.vv':           lsp.CompletionParams{
+	'local_results.vv':                     lsp.CompletionParams{
 		context: lsp.CompletionContext{.invoked, ''}
 		position: lsp.Position{5, 2}
 	}
-	'module_symbols_selector.vv': lsp.CompletionParams{
+	'module_symbols_selector.vv':           lsp.CompletionParams{
 		context: lsp.CompletionContext{.trigger_character, '.'}
 		position: lsp.Position{5, 6}
 	}
-	'struct_init.vv':             lsp.CompletionParams{
+	'struct_init.vv':                       lsp.CompletionParams{
 		context: lsp.CompletionContext{.trigger_character, '{'}
 		position: lsp.Position{8, 16}
 	}
 }
 
 const completion_results = map{
-	'assign.vv':                  [
+	'assign.vv':                            [
 		lsp.CompletionItem{
 			label: 'two'
 			kind: .variable
@@ -61,7 +69,7 @@ const completion_results = map{
 			insert_text: 'zero'
 		},
 	]
-	'blank.vv':                   [
+	'blank.vv':                             [
 		lsp.CompletionItem{
 			label: 'module main'
 			kind: .variable
@@ -73,7 +81,7 @@ const completion_results = map{
 			insert_text: 'module completion'
 		},
 	]
-	'call_args.vv':               [
+	'call_args.vv':                         [
 		lsp.CompletionItem{
 			label: 'sample_num'
 			kind: .variable
@@ -85,7 +93,7 @@ const completion_results = map{
 			insert_text: 'sample_num2'
 		},
 	]
-	'enum_val_in_struct.vv':      [
+	'enum_val_in_struct.vv':                [
 		lsp.CompletionItem{
 			label: '.golden_retriever'
 			kind: .enum_member
@@ -107,7 +115,29 @@ const completion_results = map{
 			insert_text: '.dalmatian'
 		},
 	]
-	'import.vv':                  [
+	'filtered_methods_in_immutable_var.vv': [
+		lsp.CompletionItem{
+			label: 'lol'
+			kind: .method
+			insert_text: 'lol()'
+			insert_text_format: .snippet
+		},
+	]
+	'filtered_methods_in_mutable_var.vv':   [
+		lsp.CompletionItem{
+			label: 'set_name'
+			kind: .method
+			insert_text: 'set_name(\${1:name})'
+			insert_text_format: .snippet
+		},
+		lsp.CompletionItem{
+			label: 'lol'
+			kind: .method
+			insert_text: 'lol()'
+			insert_text_format: .snippet
+		},
+	]
+	'import.vv':                            [
 		lsp.CompletionItem{
 			label: 'abc'
 			kind: .folder
@@ -124,7 +154,7 @@ const completion_results = map{
 			insert_text: 'abc.def.ghi'
 		},
 	]
-	'incomplete_module.vv':       [
+	'incomplete_module.vv':                 [
 		lsp.CompletionItem{
 			label: 'module main'
 			kind: .variable
@@ -136,7 +166,7 @@ const completion_results = map{
 			insert_text: 'module completion'
 		},
 	]
-	'incomplete_selector.vv':     [
+	'incomplete_selector.vv':               [
 		lsp.CompletionItem{
 			label: 'name'
 			kind: .field
@@ -149,7 +179,7 @@ const completion_results = map{
 			insert_text_format: .snippet
 		},
 	]
-	'local_results.vv':           [
+	'local_results.vv':                     [
 		lsp.CompletionItem{
 			label: 'foo'
 			kind: .variable
@@ -161,7 +191,7 @@ const completion_results = map{
 			insert_text: 'bar'
 		},
 	]
-	'module_symbols_selector.vv': [
+	'module_symbols_selector.vv':           [
 		lsp.CompletionItem{
 			label: 'Point'
 			kind: .struct_
@@ -174,7 +204,7 @@ const completion_results = map{
 			insert_text_format: .snippet
 		},
 	]
-	'struct_init.vv':             [
+	'struct_init.vv':                       [
 		lsp.CompletionItem{
 			label: 'name:'
 			kind: .field

--- a/vls/tests/test_files/completion/filtered_fields_in_selector.vv
+++ b/vls/tests/test_files/completion/filtered_fields_in_selector.vv
@@ -1,0 +1,8 @@
+module main
+
+import log
+
+fn main() {
+  logger := log.Log{}
+  logger.
+}

--- a/vls/tests/test_files/completion/filtered_methods_in_immutable_var.vv
+++ b/vls/tests/test_files/completion/filtered_methods_in_immutable_var.vv
@@ -1,0 +1,15 @@
+module main
+
+struct Foo {}
+
+fn (mut f Foo) set_name(name string) {
+}
+
+fn (f Foo) lol() string {
+  return f.name
+}
+
+fn main() {
+  foo := Foo{'bob'}
+  foo.
+}

--- a/vls/tests/test_files/completion/filtered_methods_in_mutable_var.vv
+++ b/vls/tests/test_files/completion/filtered_methods_in_mutable_var.vv
@@ -1,0 +1,15 @@
+module main
+
+struct Foo {}
+
+fn (mut f Foo) set_name(name string) {
+}
+
+fn (f Foo) lol() string {
+  return f.name
+}
+
+fn main() {
+  mut foo := Foo{'bob'}
+  foo.
+}

--- a/vls/tests/test_files/completion/import_symbols.vv
+++ b/vls/tests/test_files/completion/import_symbols.vv
@@ -1,0 +1,3 @@
+module main
+
+import pg {  }

--- a/vls/tests/test_files/completion/incomplete_nested_selector.v
+++ b/vls/tests/test_files/completion/incomplete_nested_selector.v
@@ -1,0 +1,16 @@
+module main
+
+struct Barw {
+	name string
+}
+
+fn (b Bar) theres_a_method() {}
+
+struct Foow {
+	bar Barw
+}
+
+fn main() {
+  foo := Foow{Barw{}}
+  foo.bar.
+}


### PR DESCRIPTION
- Filter out mutable methods if the variable/field is immutable (Inspired from: https://github.com/vlang/v/issues/9013#issue-818213579)
- Support for nested SelectorExpr
- Filter out non-public struct fields when not in the same module
- Support for import symbols