### PR TITLE
vls: table freeing for slight memory leak improvement

### DIFF
--- a/vls/general.v
+++ b/vls/general.v
@@ -106,8 +106,24 @@ fn (mut ls Vls) process_builtin() {
 		}
 	}
 	unsafe {
+		for file in parsed_files {
+			file.stmts.free()
+			free_scope(file.scope)
+		}
 		builtin_files.free()
 		parsed_files.free()
+	}
+}
+
+[unsafe]
+pub fn free_scope(s ast.Scope) {
+	unsafe {
+		s.objects.free()
+		s.struct_fields.free()
+		for child in s.children {
+			free_scope(child)
+		}
+		s.children.free()
 	}
 }
 
@@ -130,5 +146,19 @@ fn (mut ls Vls) exit() {
 	// move exit to shutdown for now
 	// == .shutdown => 0
 	// != .shutdown => 1
+	unsafe {
+		for key, _ in ls.tables {
+			ls.free_table(key, '')
+		}
+		ls.base_table.type_symbols.free()
+		ls.base_table.type_idxs.free()
+		ls.base_table.fns.free()
+		ls.base_table.imports.free()
+		ls.base_table.modules.free()
+		ls.base_table.cflags.free()
+		ls.base_table.redefined_fns.free()
+		ls.base_table.fn_gen_types.free()
+		free(ls.base_table)
+	}
 	exit(int(ls.status != .shutdown))
 }

--- a/vls/text_synchronization.v
+++ b/vls/text_synchronization.v
@@ -48,7 +48,7 @@ fn (mut ls Vls) did_close(_ int, params string) {
 		}
 	}
 	if no_active_files {
-		ls.tables.delete(file_dir)
+		ls.free_table(file_dir, did_close_params.text_document.uri)
 	}
 	// NB: The diagnostics will be cleared if:
 	// - TODO: If a workspace has opened multiple programs with main() function and one of them is closed.
@@ -73,6 +73,7 @@ fn (mut ls Vls) process_file(source string, uri lsp.DocumentUri) {
 	if uri.ends_with('_test.v') {
 		pref.is_test = true
 	}
+	ls.free_table(target_dir_uri, file_path)
 	table := ls.new_table()
 	mut parsed_files := []ast.File{}
 	mut checker := checker.new_checker(table, pref)


### PR DESCRIPTION
# Additions:
Fixing memory leaks from table and some arrays not being freed between two updates

# Notes:
It **doesn't solve every** memory leaks,
There is still a considerable amount of leaks which are attributed to inner V AST/Parser/Scanner modules. Most of them are unfreed references and arrays.