### PR TITLE
Add preliminary support for "go to definition"

### DIFF
--- a/vls/vls.v
+++ b/vls/vls.v
@@ -52,7 +52,7 @@ pub const (
 		// .completion,
 		// .hover,
 		// .folding_range,
-		// .definition,
+		.definition,
 	]
 )
 


### PR DESCRIPTION
Initial steps towards #81 

Currently, <kbd>Ctrl</kbd> + clicking on an identifier will show a notification. This is to confirm that the correct node is being recognised and find cases that are misidentified.

We need to work a bit on tree traversal using tree-sitter before we can extract the location where the identifiers are defined. We'll support the current file first, then the current module, then external modules.