### PR TITLE
Initial work on textDocument/hover support

### DIFF
--- a/vls/features.v
+++ b/vls/features.v
@@ -820,304 +820,349 @@ fn (mut ls Vls) completion(id int, params string) {
 	// }
 }
 
-// struct HoverConfig {
-// mut:
-// 	file   ast.File
-// 	offset int // position of the cursor. used for finding the AST node
-// 	table  &ast.Table
-// }
+struct HoverConfig {
+mut:
+	// new tree-sitter fields
+	source []byte
+	tree   &C.TSTree
 
-// // hover_from_stmt returns the hover data for a specific ast.Stmt.
-// fn (mut cfg HoverConfig) hover_from_stmt(node ast.Stmt) ?lsp.Hover {
-// 	mut pos := node.pos
-// 	match node {
-// 		ast.Module {
-// 			name := if node.short_name.len > 0 { node.short_name } else { node.name }
-// 			return lsp.Hover{
-// 				contents: lsp.v_marked_string('module $name')
-// 				range: position_to_lsp_range(pos.extend(node.name_pos))
-// 			}
-// 		}
-// 		ast.FnDecl {
-// 			if node.return_type == ast.Type(0) {
-// 				return none
-// 			}
-// 			name := node.name.all_after(cfg.file.mod.short_name + '.')
-// 			return_type_name := cfg.table.type_to_str(node.return_type)
-// 			mut signature := 'fn'
-// 			if node.is_method {
-// 				signature += ' ('
-// 				receiver := node.params[0]
-// 				mut receiver_type_name := cfg.table.type_to_str(receiver.typ)
-// 				if receiver.is_mut {
-// 					signature += 'mut '
-// 					receiver_type_name = receiver_type_name.all_after('&')
-// 				}
-// 				signature += '$receiver.name $receiver_type_name'
-// 				signature += ') '
-// 			}
-// 			signature += ' ${name}('
-// 			for i := int(node.is_method); i < node.params.len; i++ {
-// 				param := node.params[i]
-// 				mut type_name := cfg.table.type_to_str(param.typ)
-// 				if param.is_mut {
-// 					signature += 'mut '
-// 					type_name = type_name.all_after('&')
-// 				}
-// 				signature += '$param.name $type_name'
-// 				if i != node.params.len - 1 {
-// 					signature += ', '
-// 				}
-// 			}
-// 			signature += ') $return_type_name'
-// 			return lsp.Hover{
-// 				contents: lsp.v_marked_string(signature)
-// 				range: position_to_lsp_range(pos)
-// 			}
-// 		}
-// 		ast.StructDecl {
-// 			name := node.name.all_after(cfg.file.mod.short_name + '.')
-// 			return lsp.Hover{
-// 				contents: lsp.v_marked_string('struct $name')
-// 				range: position_to_lsp_range(pos)
-// 			}
-// 		}
-// 		ast.EnumDecl {
-// 			name := node.name.all_after(cfg.file.mod.short_name + '.')
-// 			return lsp.Hover{
-// 				contents: lsp.v_marked_string('enum $name')
-// 				range: position_to_lsp_range(pos)
-// 			}
-// 		}
-// 		ast.TypeDecl {
-// 			mut name := ''
-// 			mut branches := ''
+	file   ast.File
+	offset int // position of the cursor. used for finding the AST node
+	table  &ast.Table
+}
 
-// 			match node {
-// 				ast.AliasTypeDecl {
-// 					if node.parent_type == ast.Type(0) {
-// 						return none
-// 					}
-// 					name = node.name
-// 					branches = cfg.table.type_to_str(node.parent_type)
-// 				}
-// 				ast.FnTypeDecl {
-// 					if node.typ == ast.Type(0) {
-// 						return none
-// 					}
-// 					name = node.name.all_after(cfg.file.mod.short_name + '.')
-// 					branches = cfg.table.type_to_str(node.typ)
-// 				}
-// 				ast.SumTypeDecl {
-// 					name = node.name
-// 					for i, var in node.variants {
-// 						if var.typ == ast.Type(0) {
-// 							return none
-// 						}
-// 						branches += cfg.table.type_to_str(var.typ)
-// 						if i != node.variants.len - 1 {
-// 							branches += ' | '
-// 						}
-// 					}
-// 				}
-// 			}
+// hover_from_stmt returns the hover data for a specific ast.Stmt.
+fn (mut cfg HoverConfig) hover_from_stmt(node ast.Stmt) ?lsp.Hover {
+	mut pos := node.pos
+	match node {
+		ast.Module {
+			name := if node.short_name.len > 0 { node.short_name } else { node.name }
 
-// 			return lsp.Hover{
-// 				contents: lsp.v_marked_string('type $name = $branches')
-// 				range: position_to_lsp_range(pos)
-// 			}
-// 		}
-// 		ast.Return {
-// 			// return and trigger null result for now
-// 			return none
-// 		}
-// 		ast.NodeError {
-// 			return none
-// 		}
-// 		ast.AssignStmt {
-// 			// transfer this code to v.ast module
-// 			mut left_pos := node.left[0].position()
-// 			for i, p in node.left {
-// 				if i == 0 {
-// 					continue
-// 				}
-// 				left_pos = left_pos.extend(p.position())
-// 			}
-// 			pos = left_pos.extend(pos)
-// 		}
-// 		else {}
-// 	}
-// 	return lsp.Hover{
-// 		contents: lsp.v_marked_string(node.str())
-// 		range: position_to_lsp_range(pos)
-// 	}
-// }
+			return lsp.Hover{
+				contents: lsp.v_marked_string('module $name')
+				range: tsrange_to_lsp_range(C.TSRange{
+					start_point: lsp_pos_to_tspoint(lsp.Position{pos.line_nr, pos.col})
+					end_point: lsp_pos_to_tspoint(lsp.Position{node.name_pos.line_nr, node.name_pos.col})
+				})
+			}
+		}
+		ast.FnDecl {
+			if node.return_type == ast.Type(0) {
+				return none
+			}
+			name := node.name.all_after(cfg.file.mod.short_name + '.')
+			return_type_name := cfg.table.type_to_str(node.return_type)
+			mut signature := 'fn'
+			if node.is_method {
+				signature += ' ('
+				receiver := node.params[0]
+				mut receiver_type_name := cfg.table.type_to_str(receiver.typ)
+				if receiver.is_mut {
+					signature += 'mut '
+					receiver_type_name = receiver_type_name.all_after('&')
+				}
+				signature += '$receiver.name $receiver_type_name'
+				signature += ') '
+			}
+			signature += ' ${name}('
+			for i := int(node.is_method); i < node.params.len; i++ {
+				param := node.params[i]
+				mut type_name := cfg.table.type_to_str(param.typ)
+				if param.is_mut {
+					signature += 'mut '
+					type_name = type_name.all_after('&')
+				}
+				signature += '$param.name $type_name'
+				if i != node.params.len - 1 {
+					signature += ', '
+				}
+			}
+			signature += ') $return_type_name'
+			return lsp.Hover{
+				contents: lsp.v_marked_string(signature)
+				range: tsrange_to_lsp_range(C.TSRange{
+					start_point: lsp_pos_to_tspoint(lsp.Position{pos.line_nr, pos.col})
+					end_point: lsp_pos_to_tspoint(lsp.Position{pos.line_nr, pos.col})
+				})
+			}
+		}
+		ast.StructDecl {
+			name := node.name.all_after(cfg.file.mod.short_name + '.')
+			return lsp.Hover{
+				contents: lsp.v_marked_string('struct $name')
+				range: tsrange_to_lsp_range(C.TSRange{
+					start_point: lsp_pos_to_tspoint(lsp.Position{pos.line_nr, pos.col})
+					end_point: lsp_pos_to_tspoint(lsp.Position{pos.line_nr, pos.col})
+				})
+			}
+		}
+		ast.EnumDecl {
+			name := node.name.all_after(cfg.file.mod.short_name + '.')
+			return lsp.Hover{
+				contents: lsp.v_marked_string('enum $name')
+				range: tsrange_to_lsp_range(C.TSRange{
+					start_point: lsp_pos_to_tspoint(lsp.Position{pos.line_nr, pos.col})
+					end_point: lsp_pos_to_tspoint(lsp.Position{pos.line_nr, pos.col})
+				})
+			}
+		}
+		ast.TypeDecl {
+			mut name := ''
+			mut branches := ''
 
-// // hover_from_stmt returns the hover data for a specific ast.Expr.
-// fn (mut cfg HoverConfig) hover_from_expr(node ast.Expr) ?lsp.Hover {
-// 	match node {
-// 		ast.Ident {
-// 			obj := cfg.file.scope.innermost(cfg.offset)
-// 			obj_node := obj.find_var(node.name) ?
-// 			if obj_node.typ == ast.Type(0) {
-// 				return none
-// 			}
-// 			range := position_to_lsp_range(node.pos)
-// 			// TODO: create a wrapper function that will auto-format type
-// 			// based on the VLS style.
-// 			typ_name := cfg.table.type_to_str(obj_node.typ).all_after('main.')
-// 			prefix := if obj_node.is_mut { 'mut ' } else { '' }
-// 			return lsp.Hover{
-// 				contents: lsp.v_marked_string('$prefix$obj_node.name $typ_name')
-// 				range: range
-// 			}
-// 		}
-// 		ast.CallExpr {
-// 			mut signature := ''
-// 			if node.is_method || node.is_field {
-// 				if node.left_type == ast.Type(0) {
-// 					return none
-// 				}
-// 				parent_type_name := cfg.table.type_to_str(node.left_type).all_after('main.')
-// 				signature += parent_type_name + '.'
-// 			}
+			match node {
+				ast.AliasTypeDecl {
+					if node.parent_type == ast.Type(0) {
+						return none
+					}
+					name = node.name
+					branches = cfg.table.type_to_str(node.parent_type)
+				}
+				ast.FnTypeDecl {
+					if node.typ == ast.Type(0) {
+						return none
+					}
+					name = node.name.all_after(cfg.file.mod.short_name + '.')
+					branches = cfg.table.type_to_str(node.typ)
+				}
+				ast.SumTypeDecl {
+					name = node.name
+					for i, var in node.variants {
+						if var.typ == ast.Type(0) {
+							return none
+						}
+						branches += cfg.table.type_to_str(var.typ)
+						if i != node.variants.len - 1 {
+							branches += ' | '
+						}
+					}
+				}
+			}
 
-// 			name := node.name.all_after('main.')
-// 			signature += '${name}()'
-// 			if node.return_type.is_full() {
-// 				return_type := cfg.table.type_to_str(node.return_type).all_after('main.')
-// 				signature += ' $return_type'
-// 			}
-// 			range := position_to_lsp_range(node.pos)
+			return lsp.Hover{
+				contents: lsp.v_marked_string('type $name = $branches')
+				range: tsrange_to_lsp_range(C.TSRange{
+					start_point: lsp_pos_to_tspoint(lsp.Position{pos.line_nr, pos.col})
+					end_point: lsp_pos_to_tspoint(lsp.Position{pos.line_nr, pos.col})
+				})
+			}
+		}
+		ast.Return {
+			// return and trigger null result for now
+			return none
+		}
+		ast.NodeError {
+			return none
+		}
+		ast.AssignStmt {
+			// transfer this code to v.ast module
+			mut left_pos := node.left[0].position()
+			for i, p in node.left {
+				if i == 0 {
+					continue
+				}
+				left_pos = left_pos.extend(p.position())
+			}
+			pos = left_pos.extend(pos)
+		}
+		else {}
+	}
+	return lsp.Hover{
+		contents: lsp.v_marked_string(node.str())
+		range: tsrange_to_lsp_range(C.TSRange{
+			start_point: lsp_pos_to_tspoint(lsp.Position{pos.line_nr, pos.col})
+			end_point: lsp_pos_to_tspoint(lsp.Position{pos.line_nr, pos.col})
+		})
+	}
+}
 
-// 			return lsp.Hover{
-// 				contents: lsp.v_marked_string(signature)
-// 				range: range
-// 			}
-// 		}
-// 		ast.SelectorExpr {
-// 			if node.expr is ast.Ident || is_within_pos(cfg.offset, node.pos) {
-// 				if node.typ == ast.Type(0) {
-// 					return none
-// 				}
-// 				range := position_to_lsp_range(node.pos)
-// 				typ_name := cfg.table.type_to_str(node.typ).all_after('main.')
-// 				parent_name := if node.expr_type != ast.Type(0) {
-// 					cfg.table.type_to_str(node.expr_type).all_after('main.') + '.'
-// 				} else {
-// 					''
-// 				}
-// 				field_name := '$parent_name$node.field_name'
-// 				prefix := if node.is_mut { 'mut ' } else { '' }
-// 				return lsp.Hover{
-// 					contents: lsp.v_marked_string('$prefix$field_name $typ_name')
-// 					range: range
-// 				}
-// 			}
-// 			return cfg.hover_from_expr(node.expr)
-// 		}
-// 		ast.NodeError {
-// 			return none
-// 		}
-// 		else {
-// 			return lsp.Hover{
-// 				contents: lsp.v_marked_string(node.str())
-// 				range: position_to_lsp_range(node.position())
-// 			}
-// 		}
-// 	}
-// }
+// hover_from_stmt returns the hover data for a specific ast.Expr.
+fn (mut cfg HoverConfig) hover_from_expr(node ast.Expr) ?lsp.Hover {
+	match node {
+		ast.Ident {
+			obj := cfg.file.scope.innermost(cfg.offset)
+			obj_node := obj.find_var(node.name) ?
+			if obj_node.typ == ast.Type(0) {
+				return none
+			}
+			range := tsrange_to_lsp_range(C.TSRange{
+				start_point: lsp_pos_to_tspoint(lsp.Position{node.pos.line_nr, node.pos.col})
+				end_point: lsp_pos_to_tspoint(lsp.Position{node.pos.line_nr, node.pos.col})
+			})
+			// TODO: create a wrapper function that will auto-format type
+			// based on the VLS style.
+			typ_name := cfg.table.type_to_str(obj_node.typ).all_after('main.')
+			prefix := if obj_node.is_mut { 'mut ' } else { '' }
+			return lsp.Hover{
+				contents: lsp.v_marked_string('$prefix$obj_node.name $typ_name')
+				range: range
+			}
+		}
+		ast.CallExpr {
+			mut signature := ''
+			if node.is_method || node.is_field {
+				if node.left_type == ast.Type(0) {
+					return none
+				}
+				parent_type_name := cfg.table.type_to_str(node.left_type).all_after('main.')
+				signature += parent_type_name + '.'
+			}
+
+			name := node.name.all_after('main.')
+			signature += '${name}()'
+			if node.return_type.is_full() {
+				return_type := cfg.table.type_to_str(node.return_type).all_after('main.')
+				signature += ' $return_type'
+			}
+			range := tsrange_to_lsp_range(C.TSRange{
+				start_point: lsp_pos_to_tspoint(lsp.Position{node.pos.line_nr, node.pos.col})
+				end_point: lsp_pos_to_tspoint(lsp.Position{node.pos.line_nr, node.pos.col})
+			})
+
+			return lsp.Hover{
+				contents: lsp.v_marked_string(signature)
+				range: range
+			}
+		}
+		ast.SelectorExpr {
+			if node.expr is ast.Ident || is_within_pos(cfg.offset, node.pos) {
+				if node.typ == ast.Type(0) {
+					return none
+				}
+				range := tsrange_to_lsp_range(C.TSRange{
+					start_point: lsp_pos_to_tspoint(lsp.Position{node.pos.line_nr, node.pos.col})
+					end_point: lsp_pos_to_tspoint(lsp.Position{node.pos.line_nr, node.pos.col})
+				})
+				typ_name := cfg.table.type_to_str(node.typ).all_after('main.')
+				parent_name := if node.expr_type != ast.Type(0) {
+					cfg.table.type_to_str(node.expr_type).all_after('main.') + '.'
+				} else {
+					''
+				}
+				field_name := '$parent_name$node.field_name'
+				prefix := if node.is_mut { 'mut ' } else { '' }
+				return lsp.Hover{
+					contents: lsp.v_marked_string('$prefix$field_name $typ_name')
+					range: range
+				}
+			}
+			return cfg.hover_from_expr(node.expr)
+		}
+		ast.NodeError {
+			return none
+		}
+		else {
+			return lsp.Hover{
+				contents: lsp.v_marked_string(node.str())
+				range: tsrange_to_lsp_range(C.TSRange{
+					start_point: lsp_pos_to_tspoint(lsp.Position{node.position().line_nr, node.position().col})
+					end_point: lsp_pos_to_tspoint(lsp.Position{node.position().line_nr, node.position().col})
+				})
+			}
+		}
+	}
+}
 
 fn (mut ls Vls) hover(id int, params string) {
-	// hover_params := json.decode(lsp.HoverParams, params) or {
-	// 	ls.panic(err.msg)
-	// 	ls.send_null(id)
-	// 	return
-	// }
+	hover_params := json.decode(lsp.HoverParams, params) or {
+		ls.panic(err.msg)
+		ls.send_null(id)
+		return
+	}
 
-	// uri := hover_params.text_document.uri
-	// pos := hover_params.position
+	uri := hover_params.text_document.uri
+	pos := hover_params.position
 
-	// mut cfg := HoverConfig{
-	// 	file: ls.files[uri.str()]
-	// 	table: ls.tables[uri.dir()]
-	// 	offset: compute_offset(ls.sources[uri.str()], pos.line, pos.character)
-	// }
+	mut cfg := HoverConfig{
+		source: ls.sources[uri.str()]
+		tree: ls.trees[uri.str()]
+		offset: compute_offset(ls.sources[uri.str()], pos.line, pos.character)
+		table: ls.tables[uri.dir()]
+	}
 
-	// // an AST walker will find a node based on the offset
-	// node := find_ast_by_pos(cfg.file.stmts.map(ast.Node(it)), cfg.offset) or {
-	// 	ls.send_null(id)
-	// 	return
-	// }
+	// an AST walker will find a node based on the offset
+	node := find_ast_by_pos(cfg.file.stmts.map(ast.Node(it)), cfg.offset) or {
+		ls.send_null(id)
+		return
+	}
 
-	// mut hover_data := lsp.Hover{}
+	mut hover_data := lsp.Hover{}
 
-	// // the contents of the node will be extracted and be injected
-	// // into the hover_data variable
-	// // TODO: simplify == tablt.Type(0) checking in the future
-	// match node {
-	// 	ast.Stmt {
-	// 		hover_data = cfg.hover_from_stmt(node) or {
-	// 			ls.send_null(id)
-	// 			return
-	// 		}
-	// 	}
-	// 	ast.Expr {
-	// 		hover_data = cfg.hover_from_expr(node) or {
-	// 			ls.send_null(id)
-	// 			return
-	// 		}
-	// 	}
-	// 	ast.StructField {
-	// 		if node.typ == ast.Type(0) {
-	// 			ls.send_null(id)
-	// 			return
-	// 		}
-	// 		range := position_to_lsp_range(node.pos.extend(node.type_pos))
-	// 		typ_name := cfg.table.type_to_str(node.typ).all_after('main.')
-	// 		hover_data = lsp.Hover{
-	// 			contents: lsp.v_marked_string('$node.name $typ_name')
-	// 			range: range
-	// 		}
-	// 	}
-	// 	ast.StructInitField {
-	// 		if node.expected_type == ast.Type(0) {
-	// 			ls.send_null(id)
-	// 			return
-	// 		}
-	// 		range := position_to_lsp_range(node.pos)
-	// 		typ_name := cfg.table.type_to_str(node.expected_type).all_after('main.')
-	// 		hover_data = lsp.Hover{
-	// 			contents: lsp.v_marked_string('$node.name $typ_name')
-	// 			range: range
-	// 		}
-	// 	}
-	// 	ast.Param {
-	// 		if node.typ == ast.Type(0) {
-	// 			ls.send_null(id)
-	// 			return
-	// 		}
-	// 		range := position_to_lsp_range(node.pos.extend(node.type_pos))
-	// 		mut type_name := cfg.table.type_to_str(node.typ).all_after('main.')
-	// 		if node.is_mut {
-	// 			type_name = type_name[1..]
-	// 		}
-	// 		prefix := if node.is_mut { 'mut ' } else { '' }
-	// 		hover_data = lsp.Hover{
-	// 			contents: lsp.v_marked_string('$prefix$node.name $type_name')
-	// 			range: range
-	// 		}
-	// 	}
-	// 	else {
-	// 		// returns a null result for unsupported nodes
-	// 		ls.send_null(id)
-	// 		return
-	// 	}
-	// }
-	// ls.send(jsonrpc.Response<lsp.Hover>{
-	// 	id: id
-	// 	result: hover_data
-	// })
+	// the contents of the node will be extracted and be injected
+	// into the hover_data variable
+	// TODO: simplify == tablt.Type(0) checking in the future
+	match node {
+		ast.Stmt {
+			hover_data = cfg.hover_from_stmt(node) or {
+				ls.send_null(id)
+				return
+			}
+		}
+		ast.Expr {
+			hover_data = cfg.hover_from_expr(node) or {
+				ls.send_null(id)
+				return
+			}
+		}
+		ast.StructField {
+			if node.typ == ast.Type(0) {
+				ls.send_null(id)
+				return
+			}
+			range := tsrange_to_lsp_range(C.TSRange{
+				start_point: lsp_pos_to_tspoint(lsp.Position{node.pos.line_nr, node.pos.col})
+				end_point: lsp_pos_to_tspoint(lsp.Position{node.type_pos.line_nr, node.type_pos.col})
+			})
+			typ_name := cfg.table.type_to_str(node.typ).all_after('main.')
+			hover_data = lsp.Hover{
+				contents: lsp.v_marked_string('$node.name $typ_name')
+				range: range
+			}
+		}
+		ast.StructInitField {
+			if node.expected_type == ast.Type(0) {
+				ls.send_null(id)
+				return
+			}
+			range := tsrange_to_lsp_range(C.TSRange{
+				start_point: lsp_pos_to_tspoint(lsp.Position{node.pos.line_nr, node.pos.col})
+				end_point: lsp_pos_to_tspoint(lsp.Position{node.pos.line_nr, node.pos.col})
+			})
+			typ_name := cfg.table.type_to_str(node.expected_type).all_after('main.')
+			hover_data = lsp.Hover{
+				contents: lsp.v_marked_string('$node.name $typ_name')
+				range: range
+			}
+		}
+		ast.Param {
+			if node.typ == ast.Type(0) {
+				ls.send_null(id)
+				return
+			}
+			range := tsrange_to_lsp_range(C.TSRange{
+				start_point: lsp_pos_to_tspoint(lsp.Position{node.pos.line_nr, node.pos.col})
+				end_point: lsp_pos_to_tspoint(lsp.Position{node.type_pos.line_nr, node.type_pos.col})
+			})
+			mut type_name := cfg.table.type_to_str(node.typ).all_after('main.')
+			if node.is_mut {
+				type_name = type_name[1..]
+			}
+			prefix := if node.is_mut { 'mut ' } else { '' }
+			hover_data = lsp.Hover{
+				contents: lsp.v_marked_string('$prefix$node.name $type_name')
+				range: range
+			}
+		}
+		else {
+			// returns a null result for unsupported nodes
+			ls.send_null(id)
+			return
+		}
+	}
+	ls.send(jsonrpc.Response<lsp.Hover>{
+		id: id
+		result: hover_data
+	})
 }
 
 [manualfree]

--- a/vls/vls.v
+++ b/vls/vls.v
@@ -50,7 +50,7 @@ pub const (
 		// .workspace_symbol,
 		.signature_help,
 		// .completion,
-		// .hover,
+		.hover,
 		// .folding_range,
 		.definition,
 	]
@@ -86,7 +86,7 @@ mut:
 	// changing and there can be instances that a change might
 	// break another module/project data.
 	// tables  map[DocumentUri]&ast.Table
-	// tables                   map[string]&ast.Table
+	tables                   map[string]&ast.Table
 	root_uri                 lsp.DocumentUri
 	// invalid_imports          map[string][]string // where it stores a list of invalid imports
 	// doc_symbols              map[string][]lsp.SymbolInformation // doc_symbols is used for caching document symbols


### PR DESCRIPTION
Sorry for the large diff set 😅. It was kinda hard to avoid due to the amount of fixes I had to keep implementing one after another.

Here's a summary of the changes:

- converted many calls to `position_to_lsp_range` (which no longer exists) to their counterpart with `tsrange_to_lsp_range`. I wrapped the `start_point` and `end_point` fields in `lsp_pos_to_tspoint` so that we can maintain compatibility with the rest of the APIs being used.
- added fields `source` and `tree` to `HoverConfig`
- temporarily uncommented `tables` field in `vls.v` since its absence causes many errors with a lot of the hover code. I think `tables` is technically obsolete now, but in order to not use it, we'll need to rewrite a lot of code to work without it.
- perhaps a few other minor things I've forgotten 🥴

If you want to test it / see it in action, you can place the following code at line `1075` in `features.v`:

```
ls.log_message('Hover detected at: $uri: $pos', .info)
```

And you'll see a log entry when you hover over some text in the VSCode Output panel.