### PR TITLE
Fix map warning

### DIFF
--- a/analyzer/imports_misc.v
+++ b/analyzer/imports_misc.v
@@ -21,7 +21,7 @@ const (
 		'_native',
 		// '.freestanding'
 	]
-	os_file_specific_suffix_indices = map{
+	os_file_specific_suffix_indices = {
 		'windows':   [0]
 		'linux':     [1, 11]
 		'macos':     [2, 3, 11]


### PR DESCRIPTION
Fix warnings when running `v -gc boehm cmd/vls`

```
v -gc boehm cmd/vls
analyzer/imports_misc.v:24:36: warning: deprecated map syntax, use syntax like `{'age': 20}`
   22 |         // '.freestanding'
   23 |     ]
   24 |     os_file_specific_suffix_indices = map{
      |                                       ~~~
   25 |         'windows':   [0]
   26 |         'linux':     [1, 11]
```