### PR TITLE
vls: implement textDocument/implementation

### DIFF
--- a/analyzer/store.v
+++ b/analyzer/store.v
@@ -175,7 +175,7 @@ pub fn compare_params_and_ret_type(params []&Symbol, ret_type &Symbol, fn_to_com
 		param_to_compare := params[i]
 		if param_from_sym.return_type == param_to_compare.return_type {
 			if include_param_name && param_from_sym.name != param_to_compare.name {
-				continue
+				break
 			}
 			params_left--
 			continue

--- a/analyzer/store.v
+++ b/analyzer/store.v
@@ -681,7 +681,7 @@ pub fn (mut ss Store) infer_symbol_from_node(node C.TSNode, src_text []byte) ?&S
 		}
 		'struct_field_declaration' {
 			mut parent := node.parent()
-			for parent.get_type() != 'struct_declaration' {
+			for parent.get_type() !in ['struct_declaration', 'interface_declaration'] {
 				parent = parent.parent()
 			}
 

--- a/analyzer/store.v
+++ b/analyzer/store.v
@@ -146,35 +146,46 @@ pub fn (ss &Store) find_fn_symbol(module_name string, return_type &Symbol, param
 	module_path := ss.get_module_path(module_name)
 	for sym in ss.symbols[module_path]? {
 		if sym.kind == .function_type && sym.name.starts_with(analyzer.anon_fn_prefix) && sym.generic_placeholder_len == 0 {
-			mut params_to_check := []int{cap: sym.children.len}
-			// get a list of indices that are parameters
-			for i, child in sym.children {
-				if child.kind != .variable {
-					continue
-				}
-				params_to_check << i
-			}
-			if params_to_check.len != params.len {
-				continue
-			}
-			mut params_left := params_to_check.len
-			for i, param_idx in params_to_check {
-				param_from_sym := sym.children[param_idx]
-				param_to_compare := params[i]
-				if param_from_sym.name == param_to_compare.name && param_from_sym.return_type.name == param_to_compare.return_type.name {
-					params_left--
-					continue
-				}
-				break
-			}
-			// if loop for checking params stopped or the return type does not match
-			if params_left != 0 || sym.return_type.name != return_type.name {
+			if !compare_params_and_ret_type(params, return_type, sym, true) {
 				continue
 			}
 			return sym
 		}
 	}
 	return none
+}
+
+pub fn compare_params_and_ret_type(params []&Symbol, ret_type &Symbol, fn_to_compare &Symbol, include_param_name bool) bool {
+	mut params_to_check := []int{cap: fn_to_compare.children.len}
+	defer { unsafe { params_to_check.free() } }
+
+	// get a list of indices that are parameters
+	for i, child in fn_to_compare.children {
+		if child.kind != .variable {
+			continue
+		}
+		params_to_check << i
+	}
+	if params.len != params_to_check.len {
+		return false
+	}
+	mut params_left := params_to_check.len
+	for i, param_idx in params_to_check {
+		param_from_sym := fn_to_compare.children[param_idx]
+		param_to_compare := params[i]
+		if param_from_sym.return_type == param_to_compare.return_type {
+			if include_param_name && param_from_sym.name != param_to_compare.name {
+				continue
+			}
+			params_left--
+			continue
+		}
+		break
+	}
+	if params_left != 0 || ret_type != fn_to_compare.return_type {
+		return false
+	}
+	return true
 }
 
 pub const container_symbol_kinds = [SymbolKind.chan_, .array_, .map_, .ref, .variadic, .optional, .multi_return]

--- a/analyzer/symbol.v
+++ b/analyzer/symbol.v
@@ -391,6 +391,34 @@ fn (sym &Symbol) count_ptr() int {
 	return ptr_count
 }
 
+pub fn is_interface_satisfied(sym &Symbol, interface_sym &Symbol) bool {
+	if sym.kind != .struct_ && sym.kind != .typedef && sym.kind != .sumtype {
+		return false
+	} else if interface_sym.kind != .interface_ {
+		return false
+	}
+
+	for i in 0 .. interface_sym.interface_children_len {
+		spec_sym := interface_sym.children[i]
+		selected_child_sym := sym.children.get(spec_sym.name) or {
+			return false
+		}
+		if spec_sym.kind == .field {
+			if selected_child_sym.access != spec_sym.access 
+				|| selected_child_sym.kind != spec_sym.kind 
+				|| selected_child_sym.return_type != spec_sym.return_type {
+				return false
+			}
+		} else if spec_sym.kind == .function {
+			if selected_child_sym.kind != spec_sym.kind
+				|| !compare_params_and_ret_type(selected_child_sym.children, selected_child_sym.return_type, spec_sym, false) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
 // pub fn (ars ArraySymbol) str() string {
 // 	return
 // }

--- a/analyzer/symbol.v
+++ b/analyzer/symbol.v
@@ -108,6 +108,7 @@ pub mut:
 	is_top_level						bool [required]
 	generic_placeholder_len int
 	sumtype_children_len    int
+	interface_children_len  int
 	children                []&Symbol // methods, sum types, map types, optionals, struct fields, etc.
 	file_path               string [required] // required in order to register the symbol at its appropriate directory.
 	file_version            int [required]// file version when the symbol was registered

--- a/vls/general.v
+++ b/vls/general.v
@@ -55,6 +55,7 @@ fn (mut ls Vls) initialize(id int, params string) {
 		hover_provider: Feature.hover in ls.enabled_features
 		folding_range_provider: Feature.folding_range in ls.enabled_features
 		definition_provider: Feature.definition in ls.enabled_features
+		implementation_provider: Feature.implementation in ls.enabled_features
 	}
 
 	if Feature.completion in ls.enabled_features {

--- a/vls/general_test.v
+++ b/vls/general_test.v
@@ -55,7 +55,8 @@ fn test_set_features() {
 		.completion, 
 		.hover, 
 		.folding_range, 
-		.definition
+		.definition,
+		.implementation
 	]
 	ls.set_features(['formatting'], true) or {
 		assert false
@@ -70,7 +71,8 @@ fn test_set_features() {
 		.hover, 
 		.folding_range, 
 		.definition, 
-		.formatting
+		.formatting,
+		.implementation
 	]
 	ls.set_features(['logging'], true) or {
 		assert err.msg == 'feature "logging" not found'

--- a/vls/general_test.v
+++ b/vls/general_test.v
@@ -71,8 +71,8 @@ fn test_set_features() {
 		.hover, 
 		.folding_range, 
 		.definition, 
-		.formatting,
-		.implementation
+		.implementation,
+		.formatting
 	]
 	ls.set_features(['logging'], true) or {
 		assert err.msg == 'feature "logging" not found'

--- a/vls/tests/implementation_test.v
+++ b/vls/tests/implementation_test.v
@@ -1,0 +1,107 @@
+import vls
+import vls.testing
+import json
+import lsp
+import os
+
+const base_dir = os.join_path(os.dir(@FILE), 'test_files', 'implementation')
+
+const implementation_inputs = {
+	'simple.vv':                lsp.Position{9, 8}
+}
+
+const implementation_results = {
+	'simple.vv':                [
+		lsp.LocationLink{
+			target_uri: lsp.document_uri_from_path(os.join_path(base_dir, 'simple.vv'))
+			origin_selection_range: lsp.Range{
+				start: lsp.Position{9, 7}
+				end: lsp.Position{9, 10}
+			}
+			target_range: lsp.Range{
+				start: lsp.Position{0, 10}
+				end: lsp.Position{0, 17}
+			}
+			target_selection_range: lsp.Range{
+				start: lsp.Position{0, 10}
+				end: lsp.Position{0, 17}
+			}
+		},
+		lsp.LocationLink{
+			target_uri: lsp.document_uri_from_path(os.join_path(base_dir, 'simple.vv'))
+			origin_selection_range: lsp.Range{
+				start: lsp.Position{9, 7}
+				end: lsp.Position{9, 10}
+			}
+			target_range: lsp.Range{
+				start: lsp.Position{4, 10}
+				end: lsp.Position{4, 16}
+			}
+			target_selection_range: lsp.Range{
+				start: lsp.Position{4, 10}
+				end: lsp.Position{4, 16}
+			}
+		}
+	]
+}
+
+const implementation_should_return_null = []string{}
+
+fn test_implementation() {
+	mut io := testing.Testio{}
+	mut ls := vls.new(io)
+	ls.dispatch(io.request_with_params('initialize', lsp.InitializeParams{
+		root_uri: lsp.document_uri_from_path(base_dir)
+	}))
+	test_files := testing.load_test_file_paths('implementation') or {
+		io.bench.fail()
+		eprintln(io.bench.step_message_fail(err.msg))
+		assert false
+		return
+	}
+	io.bench.set_total_expected_steps(test_files.len)
+	for test_file_path in test_files {
+		io.bench.step()
+		test_name := os.base(test_file_path)
+		err_msg := if test_name !in implementation_results
+			&& test_name !in implementation_should_return_null {
+			'missing results for $test_name'
+		} else if test_name !in implementation_inputs {
+			'missing input data for $test_name'
+		} else {
+			''
+		}
+		if err_msg.len != 0 {
+			io.bench.fail()
+			eprintln(io.bench.step_message_fail(err_msg))
+			continue
+		}
+		content := os.read_file(test_file_path) or {
+			io.bench.fail()
+			eprintln(io.bench.step_message_fail('file $test_file_path is missing'))
+			continue
+		}
+		// open document
+		req, doc_id := io.open_document(test_file_path, content)
+		ls.dispatch(req)
+		// initiate hover request
+		ls.dispatch(io.request_with_params('textDocument/implementation', lsp.TextDocumentPositionParams{
+			text_document: doc_id
+			position: implementation_inputs[test_name]
+		}))
+		// compare content
+		println(io.bench.step_message('Testing $test_file_path'))
+		result := io.result()
+		if test_name in implementation_should_return_null {
+			assert result == 'null'
+		} else {
+			assert result == json.encode(implementation_results[test_name])
+		}
+		// Delete document
+		ls.dispatch(io.close_document(doc_id))
+		io.bench.ok()
+		println(io.bench.step_message_ok(test_name))
+	}
+	assert io.bench.nfail == 0
+	io.bench.stop()
+}

--- a/vls/tests/test_files/implementation/simple.vv
+++ b/vls/tests/test_files/implementation/simple.vv
@@ -1,0 +1,20 @@
+interface Speaker {
+	speak() string
+}
+
+interface Tester {
+	random_num int
+	test(num int) int
+}
+
+struct Foo {
+	random_num int
+}
+
+fn (f Foo) speak() string {
+	return 'jk lol'
+}
+
+fn (f Foo) test(f2 int) int {
+	return num + f.random_num
+}

--- a/vls/vls.v
+++ b/vls/vls.v
@@ -37,6 +37,7 @@ pub enum Feature {
 	hover
 	folding_range
 	definition
+	implementation
 }
 
 // feature_from_str returns the Feature-enum value equivalent of the given string.
@@ -67,6 +68,7 @@ pub const (
 		.hover,
 		.folding_range,
 		.definition,
+		.implementation,
 	]
 )
 
@@ -190,6 +192,9 @@ pub fn (mut ls Vls) dispatch(payload string) {
 			}
 			'textDocument/definition' {
 				ls.definition(request.id, request.params)
+			}
+			'textDocument/implementation' {
+				ls.implementation(request.id, request.params)
 			}
 			else {}
 		}


### PR DESCRIPTION
## Missing
- ~~Unit tests~~
## Issues
- In some instances, a struct/type may appear to have been "implemented" an interface even though none of the fields and methods in the spec have been implemented by it.