### PR TITLE
gitignore: add 'build' and 'build.exe'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,6 @@
 cmd/vls/vls
 vls.exe
 vls
+build.exe
+build
 .vscode


### PR DESCRIPTION
This PR add 'build' and 'build.exe' in gitignore.

- To simplify script execution, use `v build.vsh` to generated `build`, then we can use `build` directly.
- Add `build` and `build.exe` in gitignore.