### PR TITLE
lsp: fix uri encode error on windows

### DIFF
--- a/lsp/lsp.v
+++ b/lsp/lsp.v
@@ -23,8 +23,10 @@ pub fn (du DocumentUri) dir_path() string {
 
 pub fn document_uri_from_path(path string) DocumentUri {
 	$if windows {
-		uri_path := path.replace_each(['\\', '/', ':', '%3A'])
-		return if !path.starts_with('file:///') { 'file:///' + uri_path } else { uri_path }
+		if path.contains(':') {
+			uri_path := path.replace_each(['\\', '/', ':', '%3A'])
+			return if !path.starts_with('file:///') { 'file:///' + uri_path } else { uri_path }
+		}
 	}
 	return if !path.starts_with('file://') { 'file://' + path } else { path }
 }

--- a/lsp/lsp.v
+++ b/lsp/lsp.v
@@ -22,6 +22,10 @@ pub fn (du DocumentUri) dir_path() string {
 }
 
 pub fn document_uri_from_path(path string) DocumentUri {
+	$if windows {
+		uri_path := path.replace_each(['\\', '/', ':', '%3A'])
+		return if !path.starts_with('file:///') { 'file:///' + uri_path } else { uri_path }
+	}
 	return if !path.starts_with('file://') { 'file://' + path } else { path }
 }
 


### PR DESCRIPTION
This PR fix uri encode error on windows, and vls can work on windows. 
Thanks @spytheman !!

```vlang
[Trace - 23:21:15] Received request 'textDocument/didOpen - (0)'.
Params: {"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{"uri":"file:///d%3A/vls/lsp/lsp.v","languageId":"v","version":1,"text":"module lsp\n\nimport os\n\ntype DocumentUri = string\n\npub fn (du DocumentUri) dir() string {\n\treturn os.dir(du)\n}\n\npub fn (du DocumentUri) path() string {\n\t$if windows {\n\t\tif du.contains('%3A') {\n\t\t\treturn du.all_after('file:///').replace('%3A', ':')\n\t\t}\n\t}\n\treturn if du.starts_with('file://') { du.all_after('file://') } else { '' }\n}\n\npub fn (du DocumentUri) dir_path() string {\n\treturn os.dir(du.path())\n}\n\npub fn document_uri_from_path(path string) DocumentUri {\n\t$if windows {\n\t\turi_path := path.replace_each(['\\\\', '/', ':', '%3A'])\n\t\treturn if !path.starts_with('file:///') { 'file:///' + uri_path } else { uri_path }\n\t}\n\treturn if !path.starts_with('file://') { 'file://' + path } else { path }\n}\n\npub struct NotificationMessage {\n\tmethod string\n\tparams string [raw]\n}\n\n// // method: $/cancelRequest\npub struct CancelParams {\n\tid int\n}\n\npub struct Command {\n\ttitle     string\n\tcommand   string\n\targuments []string\n}\n\npub struct DocumentFilter {\n\tlanguage string\n\tscheme   string\n\tpattern  string\n}\n\npub struct TextDocumentRegistrationOptions {\n\tdocument_selector []DocumentFilter [json: documentSelector]\n}\n"}}}

[Trace - 23:21:15] Sending notification 'textDocument/publishDiagnostics'.
Params: {"jsonrpc":"2.0","method":"textDocument/publishDiagnostics","params":{"uri":"file:///d%3A/vls/lsp/capabilities.v","diagnostics":[]}}

[Trace - 23:21:15] Sending notification 'textDocument/publishDiagnostics'.
Params: {"jsonrpc":"2.0","method":"textDocument/publishDiagnostics","params":{"uri":"file:///d%3A/vls/lsp/client.v","diagnostics":[]}}

[Trace - 23:21:15] Sending notification 'textDocument/publishDiagnostics'.
Params: {"jsonrpc":"2.0","method":"textDocument/publishDiagnostics","params":{"uri":"file:///d%3A/vls/lsp/code_action.v","diagnostics":[]}}

[Trace - 23:21:15] Sending notification 'textDocument/publishDiagnostics'.
Params: {"jsonrpc":"2.0","method":"textDocument/publishDiagnostics","params":{"uri":"file:///d%3A/vls/lsp/code_lens.v","diagnostics":[]}}

[Trace - 23:21:15] Sending notification 'textDocument/publishDiagnostics'.
Params: {"jsonrpc":"2.0","method":"textDocument/publishDiagnostics","params":{"uri":"file:///d%3A/vls/lsp/color_presentation.v","diagnostics":[]}}

[Trace - 23:21:15] Sending notification 'textDocument/publishDiagnostics'.
Params: {"jsonrpc":"2.0","method":"textDocument/publishDiagnostics","params":{"uri":"file:///d%3A/vls/lsp/completion.v","diagnostics":[]}}
```