### PR TITLE
server: add v.vet diagnostics

### DIFF
--- a/analyzer/store.v
+++ b/analyzer/store.v
@@ -53,7 +53,7 @@ pub mut:
 // clear_messages clears the stored messages
 pub fn (mut ss Store) clear_messages() {
 	for i := 0; ss.messages.len != 0; {
-		msg := ss.messages[i]
+		// msg := ss.messages[i]
 		// unsafe {
 		// 	msg.content.free()
 		// }

--- a/analyzer/symbol_registration.v
+++ b/analyzer/symbol_registration.v
@@ -159,7 +159,7 @@ fn (mut sr SymbolRegistration) struct_field_decl(field_access SymbolAccess, fiel
 
 	if field_name_node.is_null() {
 		// struct embedding
-		_, module_name, symbol_name := symbol_name_from_node(field_type_node, sr.src_text)
+		_, _, symbol_name := symbol_name_from_node(field_type_node, sr.src_text)
 		// defer {
 		// 	unsafe { module_name.free() }
 		// }

--- a/server/diagnostics.v
+++ b/server/diagnostics.v
@@ -22,16 +22,7 @@ fn (mut ls Vls) show_diagnostics(uri lsp.DocumentUri) {
 		}
 
 		diagnostics << lsp.Diagnostic{
-			range: lsp.Range{
-				start: lsp.Position{
-					line: int(msg.range.start_point.row)
-					character: int(msg.range.start_point.column)
-				}
-				end: lsp.Position{
-					line: int(msg.range.end_point.row)
-					character: int(msg.range.end_point.column)
-				}
-			}
+			range: tsrange_to_lsp_range(msg.range)
 			severity: kind
 			message: msg.content
 		}

--- a/server/features.v
+++ b/server/features.v
@@ -46,23 +46,8 @@ fn (mut ls Vls) formatting(id int, params string) {
 		os.rm(server.temp_formatting_file_path) or {}
 	}
 
-	mut v_exe_name := 'v'
-	defer {
-		unsafe { v_exe_name.free() }
-	}
-
-	$if windows {
-		v_exe_name += '.exe'
-	}
-
-	mut p := os.new_process(os.join_path(ls.vroot_path, v_exe_name))
-	defer {
-		p.close()
-		unsafe { p.free() }
-	}
-
-	p.set_args(['fmt', server.temp_formatting_file_path])
-	p.set_redirect_stdio()
+	mut p := ls.launch_v_tool('fmt', server.temp_formatting_file_path)
+	defer { p.close() }
 	p.wait()
 
 	if p.code > 0 {

--- a/server/tests/diagnostics_test.v
+++ b/server/tests/diagnostics_test.v
@@ -14,17 +14,17 @@ const diagnostics_result = lsp.PublishDiagnosticsParams{
 			severity: .error
 			range: lsp.Range{
 				start: lsp.Position{4, 10}
-				end: lsp.Position{4, 11}
+				end: lsp.Position{4, 10}
 			}
 		},
-		lsp.Diagnostic{
-			message: "module 'os' is imported but never used"
-			severity: .warning
-			range: lsp.Range{
-				start: lsp.Position{2, 7}
-				end: lsp.Position{2, 9}
-			}
-		},
+		// lsp.Diagnostic{
+		// 	message: "module 'os' is imported but never used"
+		// 	severity: .warning
+		// 	range: lsp.Range{
+		// 		start: lsp.Position{2, 7}
+		// 		end: lsp.Position{2, 9}
+		// 	}
+		// },
 	]
 }
 

--- a/server/vls.v
+++ b/server/vls.v
@@ -345,6 +345,22 @@ pub fn (mut ls Vls) set_features(features []string, enable bool) ? {
 	}
 }
 
+pub fn (ls Vls) launch_v_tool(args ...string) &os.Process {
+	mut v_exe_name := 'v'
+	defer {
+		unsafe { v_exe_name.free() }
+	}
+
+	$if windows {
+		v_exe_name += '.exe'
+	}
+
+	mut p := os.new_process(os.join_path(ls.vroot_path, v_exe_name))
+	p.set_args(args)
+	p.set_redirect_stdio()
+	return p
+}
+
 pub enum ServerStatus {
 	off
 	initialized


### PR DESCRIPTION
While PR #159 is ongoing, this PR adds diagnostics by executing `v vet`.