### PR TITLE
build.vsh: add '-cg' flag for easy debugging

### DIFF
--- a/build.vsh
+++ b/build.vsh
@@ -14,7 +14,7 @@ if os.args.len >= 2 {
 }
 println('> Building VLS...')
 
-ret := system('v -gc boehm -cc $cc cmd/vls -o vls')
+ret := system('v -gc boehm -cg -cc $cc cmd/vls -o vls')
 if ret != 0 {
 	println('Failed building VLS')
 	return


### PR DESCRIPTION
This PR add '-cg' flag for easy debugging in build.vsh.