### PR TITLE
socket: change socket.port type from string to int

### DIFF
--- a/cmd/vls/main.v
+++ b/cmd/vls/main.v
@@ -20,12 +20,12 @@ fn run_cli(cmd cli.Command) ? {
 
 	custom_vroot_path := cmd.flags.get_string('vroot') or { '' }
 	socket_mode := cmd.flags.get_bool('socket') or { false }
-	socket_port := cmd.flags.get_string('port') or { '5007' }
+	socket_port := cmd.flags.get_int('port') or { 5007 }
 
 	// Setup the comm method and build the language server.
 	mut io := if socket_mode {
 		server.ReceiveSender(Socket{ port: socket_port, debug: debug_mode })
-  } else {
+	} else {
 		server.ReceiveSender(Stdio{ debug: debug_mode })
 	}
 

--- a/cmd/vls/socket.v
+++ b/cmd/vls/socket.v
@@ -12,7 +12,7 @@ mut:
 	listener &net.TcpListener   = &net.TcpListener(0)
 	reader   &io.BufferedReader = voidptr(0)
 pub mut:
-	port  string = '5007'
+	port  int = 5007
 	debug bool
 }
 


### PR DESCRIPTION
This PR change socket.port type from `string` to `int`.