### PR TITLE
jsonrpc, server: change request/response id to raw JSON string

### DIFF
--- a/jsonrpc/jsonrpc.v
+++ b/jsonrpc/jsonrpc.v
@@ -20,7 +20,7 @@ pub const (
 pub struct Request {
 pub mut:
 	jsonrpc string = jsonrpc.version
-	id      int    = -2
+	id      string [raw]
 	method  string
 	params  string [raw]
 }
@@ -28,24 +28,16 @@ pub mut:
 pub struct Response<T> {
 pub:
 	jsonrpc string = jsonrpc.version
-	id      int
+	id      string
 	//	error   ResponseError
 	result T
+	error   ResponseError
 }
 
 pub struct NotificationMessage<T> {
 	jsonrpc string = jsonrpc.version
 	method  string
 	params  T
-}
-
-// with error
-// TODO: must be removed when omitempty JSON is supported
-pub struct Response2<T> {
-	jsonrpc string = jsonrpc.version
-	id      int
-	error   ResponseError
-	result  T
 }
 
 pub struct ResponseError {

--- a/server/features.v
+++ b/server/features.v
@@ -10,7 +10,7 @@ import strings
 const temp_formatting_file_path = os.join_path(os.temp_dir(), 'vls_temp_formatting.v')
 
 [manualfree]
-fn (mut ls Vls) formatting(id int, params string) {
+fn (mut ls Vls) formatting(id string, params string) {
 	formatting_params := json.decode(lsp.DocumentFormattingParams, params) or {
 		ls.panic(err.msg)
 		ls.send_null(id)
@@ -75,7 +75,7 @@ fn (mut ls Vls) formatting(id int, params string) {
 	})
 }
 
-fn (mut ls Vls) workspace_symbol(id int, _ string) {
+fn (mut ls Vls) workspace_symbol(id string, _ string) {
 	mut workspace_symbols := []lsp.SymbolInformation{}
 
 	for _, sym_arr in ls.store.symbols {
@@ -150,7 +150,7 @@ fn symbol_to_symbol_info(uri lsp.DocumentUri, sym &analyzer.Symbol) ?lsp.SymbolI
 	}
 }
 
-fn (mut ls Vls) document_symbol(id int, params string) {
+fn (mut ls Vls) document_symbol(id string, params string) {
 	document_symbol_params := json.decode(lsp.DocumentSymbolParams, params) or {
 		ls.panic(err.msg)
 		ls.send_null(id)
@@ -171,7 +171,7 @@ fn (mut ls Vls) document_symbol(id int, params string) {
 	})
 }
 
-fn (mut ls Vls) signature_help(id int, params string) {
+fn (mut ls Vls) signature_help(id string, params string) {
 	// Initial checks.
 	signature_params := json.decode(lsp.SignatureHelpParams, params) or {
 		ls.panic(err.msg)
@@ -695,7 +695,7 @@ fn symbol_to_completion_item(sym &analyzer.Symbol, with_snippet bool) ?lsp.Compl
 
 // TODO: make params use lsp.CompletionParams in the future
 [manualfree]
-fn (mut ls Vls) completion(id int, params string) {
+fn (mut ls Vls) completion(id string, params string) {
 	if Feature.completion !in ls.enabled_features {
 		return
 	}
@@ -818,7 +818,7 @@ fn (mut ls Vls) completion(id int, params string) {
 	})
 }
 
-fn (mut ls Vls) hover(id int, params string) {
+fn (mut ls Vls) hover(id string, params string) {
 	hover_params := json.decode(lsp.HoverParams, params) or {
 		ls.panic(err.msg)
 		ls.send_null(id)
@@ -901,7 +901,7 @@ fn get_hover_data(mut store analyzer.Store, node C.TSNode, uri lsp.DocumentUri, 
 }
 
 [manualfree]
-fn (mut ls Vls) folding_range(id int, params string) {
+fn (mut ls Vls) folding_range(id string, params string) {
 	folding_range_params := json.decode(lsp.FoldingRangeParams, params) or {
 		ls.panic(err.msg)
 		ls.send_null(id)
@@ -947,7 +947,7 @@ fn (mut ls Vls) folding_range(id int, params string) {
 	}
 }
 
-fn (mut ls Vls) definition(id int, params string) {
+fn (mut ls Vls) definition(id string, params string) {
 	goto_definition_params := json.decode(lsp.TextDocumentPositionParams, params) or {
 		ls.panic(err.msg)
 		ls.send_null(id)
@@ -1031,7 +1031,7 @@ fn get_implementation_locations_from_syms(symbols []&analyzer.Symbol, got_sym &a
 	}
 }
 
-fn (mut ls Vls) implementation(id int, params string) {
+fn (mut ls Vls) implementation(id string, params string) {
 	goto_implementation_params := json.decode(lsp.TextDocumentPositionParams, params) or {
 		ls.panic(err.msg)
 		ls.send_null(id)

--- a/server/general.v
+++ b/server/general.v
@@ -14,7 +14,7 @@ const (
 )
 
 // initialize sends the server capabilities to the client
-fn (mut ls Vls) initialize(id int, params string) {
+fn (mut ls Vls) initialize(id string, params string) {
 	// Set defaults when vroot_path is empty
 	if ls.vroot_path.len == 0 {
 		if found_vroot_path := detect_vroot_path() {
@@ -125,7 +125,7 @@ fn (mut ls Vls) process_builtin() {
 }
 
 // shutdown sets the state to shutdown but does not exit
-fn (mut ls Vls) shutdown(id int) {
+fn (mut ls Vls) shutdown(id string) {
 	ls.status = .shutdown
 	result := jsonrpc.Response<string>{
 		id: id

--- a/server/general_test.v
+++ b/server/general_test.v
@@ -3,16 +3,13 @@ import server.testing
 import lsp
 import json
 
-fn test_wrong_first_request() {
+fn test_wrong_first_request() ? {
 	mut io := &testing.Testio{}
 	mut ls := server.new(io)
 	payload := io.request('shutdown')
 	ls.dispatch(payload)
 	assert ls.status() == .off
-	err_code, err_msg := io.response_error() or {
-		assert false
-		return
-	}
+	err_code, err_msg := io.response_error() ?
 	assert err_code == -32002
 	assert err_msg == 'Server not yet initialized.'
 }

--- a/server/testing/testing_test.v
+++ b/server/testing/testing_test.v
@@ -37,39 +37,33 @@ fn test_result() {
 		'hello': 'world'
 	}
 	resp := jsonrpc.Response<map[string]string>{
-		id: 1
+		id: '1'
 		result: result
 	}
 	io.send(json.encode(resp))
 	assert io.result() == json.encode(result)
 }
 
-fn test_notification() {
+fn test_notification() ? {
 	mut io := Testio{}
 	request := json.encode(jsonrpc.NotificationMessage<string>{
 		method: 'log'
 		params: 'just a log'
 	})
 	io.send(request)
-	method, params := io.notification() or {
-		assert false
-		return
-	}
+	method, params := io.notification() ?
 	assert method == 'log'
 	assert params == '"just a log"'
 }
 
-fn test_response_error() {
+fn test_response_error() ? {
 	mut io := Testio{}
-	payload := jsonrpc.Response2<map[string]string>{
+	payload := jsonrpc.Response<map[string]string>{
 		error: jsonrpc.new_response_error(jsonrpc.method_not_found)
 	}
 	request := json.encode(payload)
 	io.send(request)
-	err_code, err_message := io.response_error() or {
-		assert false
-		return
-	}
+	err_code, err_message := io.response_error() ?
 	assert err_code == jsonrpc.method_not_found
 	assert err_message == 'Method not found.'
 }

--- a/server/text_synchronization.v
+++ b/server/text_synchronization.v
@@ -16,7 +16,7 @@ fn analyze(mut store analyzer.Store, root_uri lsp.DocumentUri, tree &C.TSTree, f
 	store.analyze(tree, file.source)
 }
 
-fn (mut ls Vls) did_open(_ int, params string) {
+fn (mut ls Vls) did_open(_ string, params string) {
 	did_open_params := json.decode(lsp.DidOpenTextDocumentParams, params) or {
 		ls.panic(err.msg)
 		return
@@ -87,7 +87,7 @@ fn (mut ls Vls) did_open(_ int, params string) {
 }
 
 [manualfree]
-fn (mut ls Vls) did_change(_ int, params string) {
+fn (mut ls Vls) did_change(_ string, params string) {
 	did_change_params := json.decode(lsp.DidChangeTextDocumentParams, params) or {
 		ls.panic(err.msg)
 		return
@@ -205,7 +205,7 @@ fn (mut ls Vls) did_change(_ int, params string) {
 }
 
 [manualfree]
-fn (mut ls Vls) did_close(_ int, params string) {
+fn (mut ls Vls) did_close(_ string, params string) {
 	did_close_params := json.decode(lsp.DidCloseTextDocumentParams, params) or {
 		ls.panic(err.msg)
 		return

--- a/server/vls.v
+++ b/server/vls.v
@@ -10,6 +10,7 @@ import tree_sitter_v as v
 import analyzer
 import time
 import v.vmod
+import strings
 
 pub const meta = meta_info()
 
@@ -261,24 +262,36 @@ fn (mut ls Vls) panic(message string) {
 	}
 }
 
-fn (mut ls Vls) send<T>(data T) {
-	str := json.encode(data)
+fn (mut ls Vls) send<T>(resp jsonrpc.Response<T>) {
+	mut resp_wr := strings.new_builder(100)
+	defer { unsafe { resp_wr.free() } }
+	resp_wr.write_string('{"jsonrpc":"${jsonrpc.version}","id":${resp.id}')
+	if resp.id.len == 0 {
+		resp_wr.write_string('null')
+	}
+	if resp.error.code != 0 {
+		err := json.encode(resp.error)
+		resp_wr.write_string(',"error":${err}')
+	} else {
+		res := json.encode(resp.result)
+		resp_wr.write_string(',"result":${res}')
+	}
+	resp_wr.write_b(`}`)
+	str := resp_wr.str()
 	ls.logger.response(str, .send)
 	ls.io.send(str)
 }
 
-// TODO: set result param type to jsonrpc.NotificationMessage<T>
-// merge notify back to send method once compile-time type introspection
-// supports base generic types (e.g $if T is jsonrpc.NotificationMessage)
-fn (mut ls Vls) notify<T>(data T) {
+// notify sends a notification to the client
+fn (mut ls Vls) notify<T>(data jsonrpc.NotificationMessage<T>) {
 	str := json.encode(data)
 	ls.logger.notification(str, .send)
 	ls.io.send(str)
 }
 
 // send_null sends a null result to the client
-fn (mut ls Vls) send_null(id int) {
-	str := '{"jsonrpc":"2.0","id":$id,"result":null}'
+fn (mut ls Vls) send_null(id string) {
+	str := '{"jsonrpc":"${jsonrpc.version}","id":$id,"result":null}'
 	ls.logger.response(str, .send)
 	ls.io.send(str)
 }

--- a/server/vls.v
+++ b/server/vls.v
@@ -381,6 +381,7 @@ pub enum ServerStatus {
 [inline]
 fn new_error(code int, id string) jsonrpc.Response<string> {
 	return jsonrpc.Response<string>{
+		id: id
 		error: jsonrpc.new_response_error(code)
 	}
 }

--- a/server/workspace.v
+++ b/server/workspace.v
@@ -1,6 +1,6 @@
 module server
 
-fn (ls Vls) did_change_watched_files(id int, params string) {
+fn (ls Vls) did_change_watched_files(id string, params string) {
 	// TODO Remove, functions can't have two args with name `_`
 	_ = ls
 	_ = id


### PR DESCRIPTION
As per [JSON-RPC](https://www.jsonrpc.org/specification#request_object) spec, the request ID does not have a definite type and it can be null. Currently in VLS, the ID data type is set `int` because this was used in VSCode. As seen in the latest comment in #52, JetBrain IDEs use string types as IDs and others might do the same as well. To solve this issue, the ID is parsed as a raw JSON string.