### PR TITLE
server: enable connection test on macos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Editor files
 *.code-workspace
 
+# Debugging
+*.dSYM
+
 # Other
 cmd/vls/vls
 vls.exe

--- a/server/connection_test.v
+++ b/server/connection_test.v
@@ -83,8 +83,8 @@ fn test_stdio_connect() ? {
 }
 
 fn test_tcp_connect() ? {
-	// TODO: fix this later. Hangs on macos (on ci and on device) and windows ci
-	$if !linux {
+	// TODO: fix this later. Hangs on windows ci
+	$if windows {
 		return
 	}
 	mut io := testing.Testio{}


### PR DESCRIPTION
Commits are put into the PR first to avoid unnecessary changes in the repo if the CI errors