### PR TITLE
analyzer: fn decl don't show void when return void

### DIFF
--- a/analyzer/symbol.v
+++ b/analyzer/symbol.v
@@ -185,8 +185,11 @@ pub fn (info &Symbol) gen_str() string {
 					sb.write_string(', ')
 				}
 			}
-			sb.write_string(') ')
-			sb.write_string(info.return_type.name)
+			sb.write_string(')')
+			if info.return_type.kind != .void {
+				sb.write_string(' ')
+				sb.write_string(info.return_type.name)
+			}
 		}
 		.variable, .field {
 			sb.write_string(info.access.str())
@@ -481,7 +484,7 @@ fn (locs []BindedSymbolLocation) get_path(sym_name string) ?string {
 		return locs[idx].module_path
 	}
 	return error('not found!')
-} 
+}
 
 fn (locs []BindedSymbolLocation) index(sym_name string) int {
 	for i, bsl in locs {

--- a/analyzer/symbol.v
+++ b/analyzer/symbol.v
@@ -186,7 +186,7 @@ pub fn (info &Symbol) gen_str() string {
 				}
 			}
 			sb.write_b(`)`)
-			if info.return_type.kind != .void {
+			if !info.return_type.is_void() {
 				sb.write_b(` `)
 				sb.write_string(info.return_type.name)
 			}

--- a/analyzer/symbol.v
+++ b/analyzer/symbol.v
@@ -185,9 +185,9 @@ pub fn (info &Symbol) gen_str() string {
 					sb.write_string(', ')
 				}
 			}
-			sb.write_string(')')
+			sb.write_b(`)`)
 			if info.return_type.kind != .void {
-				sb.write_string(' ')
+				sb.write_b(` `)
 				sb.write_string(info.return_type.name)
 			}
 		}

--- a/server/tests/completion_test.v
+++ b/server/tests/completion_test.v
@@ -182,7 +182,7 @@ const completion_results = {
 		lsp.CompletionItem{
 			label: 'set_name'
 			kind: .method
-			detail: 'mut fn (Foo) set_name(name string) void'
+			detail: 'mut fn (Foo) set_name(name string)'
 			insert_text: 'set_name(\$0)'
 			insert_text_format: .snippet
 		},
@@ -259,7 +259,7 @@ const completion_results = {
 		lsp.CompletionItem{
 			label: 'theres_a_method'
 			kind: .method
-			detail: 'fn (Barw) theres_a_method() void'
+			detail: 'fn (Barw) theres_a_method()'
 			insert_text: 'theres_a_method()'
 			insert_text_format: .plain_text
 		},

--- a/server/tests/hover_test.v
+++ b/server/tests/hover_test.v
@@ -78,7 +78,7 @@ const hover_results = {
 		}
 	}
 	'call_expr_simple.vv':      lsp.Hover{
-		contents: lsp.MarkedString{'v', 'fn greet(name string) void'}
+		contents: lsp.MarkedString{'v', 'fn greet(name string)'}
 		range: lsp.Range{
 			start: lsp.Position{5, 2}
 			end: lsp.Position{5, 7}


### PR DESCRIPTION
This PR makes fn decl don't show void when return void.

![image](https://user-images.githubusercontent.com/6949593/132190724-1a40fad6-f76f-4387-9261-5f0109e6fd1a.png)
