### PR TITLE
analyzer: fix method's receiver type is alias

### DIFF
--- a/analyzer/symbol.v
+++ b/analyzer/symbol.v
@@ -165,9 +165,8 @@ pub fn (info &Symbol) gen_str() string {
 
 			if !isnil(info.parent) && !info.parent.is_void() {
 				sb.write_b(`(`)
-				sb.write_string(info.parent.gen_str())
-				sb.write_b(`)`)
-				sb.write_b(` `)
+				sb.write_string(info.parent.name)
+				sb.write_string(') ')
 			}
 
 			if !info.name.starts_with(analyzer.anon_fn_prefix) {


### PR DESCRIPTION
This PR fix method's receiver type is alias.

before:
![image](https://user-images.githubusercontent.com/6949593/132230754-d832c2e0-2eac-4c7b-a9b5-8cc7b81c2f19.png)

now:
![image](https://user-images.githubusercontent.com/6949593/132231066-4cea575c-c346-4966-ac8f-77aa6f7862a1.png)
