### PR TITLE
server: change v diagnostics to v -check

### DIFF
--- a/server/diagnostics.v
+++ b/server/diagnostics.v
@@ -61,7 +61,8 @@ fn (ls Vls) v_msg_to_diagnostic(from_file_path string, msg string) ?lsp.Diagnost
 fn (mut ls Vls) exec_v_diagnostics(uri lsp.DocumentUri) ?[]lsp.Diagnostic {
 	dir_path := uri.dir_path()
 	file_path := uri.path()
-	mut p := ls.launch_v_tool('-check', dir_path)
+	input_path := if file_path.ends_with('.vv') { file_path } else { dir_path }
+	mut p := ls.launch_v_tool('-check', input_path)
 	defer { p.close() }
 	p.wait()
 	if p.code == 0 {

--- a/server/diagnostics.v
+++ b/server/diagnostics.v
@@ -57,10 +57,11 @@ fn (ls Vls) v_msg_to_diagnostic(from_file_path string, msg string) ?lsp.Diagnost
 	}
 }
 
-// exec_v_vet_diagnostics returns a list of errors/warnings taken from v vet
-fn (mut ls Vls) exec_v_vet_diagnostics(uri lsp.DocumentUri) ?[]lsp.Diagnostic {
+// exec_v_diagnostics returns a list of errors/warnings taken from v vet
+fn (mut ls Vls) exec_v_diagnostics(uri lsp.DocumentUri) ?[]lsp.Diagnostic {
+	dir_path := uri.dir_path()
 	file_path := uri.path()
-	mut p := ls.launch_v_tool('vet', '-force', file_path)
+	mut p := ls.launch_v_tool('-check', dir_path)
 	defer { p.close() }
 	p.wait()
 	if p.code == 0 {

--- a/server/tests/diagnostics_test.v
+++ b/server/tests/diagnostics_test.v
@@ -17,14 +17,14 @@ const diagnostics_result = lsp.PublishDiagnosticsParams{
 				end: lsp.Position{4, 10}
 			}
 		},
-		// lsp.Diagnostic{
-		// 	message: "module 'os' is imported but never used"
-		// 	severity: .warning
-		// 	range: lsp.Range{
-		// 		start: lsp.Position{2, 7}
-		// 		end: lsp.Position{2, 9}
-		// 	}
-		// },
+		lsp.Diagnostic{
+			message: "module 'os' is imported but never used"
+			severity: .warning
+			range: lsp.Range{
+				start: lsp.Position{2, 7}
+				end: lsp.Position{2, 7}
+			}
+		},
 	]
 }
 
@@ -47,9 +47,6 @@ fn test_diagnostics() {
 		// open document
 		req, _ := io.open_document(file_path, content)
 		ls.dispatch(req)
-
-		save_req, _ := io.save_document(file_path, content)
-		ls.dispatch(save_req)
 	}
 	
 	method, params := io.notification() or { '', '{}' }

--- a/server/text_synchronization.v
+++ b/server/text_synchronization.v
@@ -66,6 +66,11 @@ fn (mut ls Vls) did_open(_ string, params string) {
 			analyze(mut ls.store, ls.root_uri, ls.trees[file_uri], ls.sources[file_uri])
 			ls.show_diagnostics(file_uri)
 
+			// get diagnostic results from v_vet
+			if v_vet_results := ls.exec_v_diagnostics(uri) {
+				ls.publish_diagnostics(uri, v_vet_results)
+			}
+
 			unsafe {
 				full_path.free()
 				file_uri.free()
@@ -83,7 +88,13 @@ fn (mut ls Vls) did_open(_ string, params string) {
 		if !ls.store.has_file_path(uri.path()) || uri.path() !in ls.store.opened_scopes {
 			analyze(mut ls.store, ls.root_uri, ls.trees[uri], ls.sources[uri])
 		}
+
 		ls.show_diagnostics(uri)
+
+		// get diagnostic results from v_vet
+		if v_vet_results := ls.exec_v_diagnostics(uri) {
+			ls.publish_diagnostics(uri, v_vet_results)
+		}
 	}
 }
 
@@ -243,7 +254,7 @@ fn (mut ls Vls) did_save(id string, params string) {
 	uri := did_save_params.text_document.uri
 
 	// get diagnostic results from v_vet
-	if v_vet_results := ls.exec_v_vet_diagnostics(uri) {
+	if v_vet_results := ls.exec_v_diagnostics(uri) {
 		ls.publish_diagnostics(uri, v_vet_results)
 	}
 }

--- a/server/text_synchronization.v
+++ b/server/text_synchronization.v
@@ -66,11 +66,6 @@ fn (mut ls Vls) did_open(_ string, params string) {
 			analyze(mut ls.store, ls.root_uri, ls.trees[file_uri], ls.sources[file_uri])
 			ls.show_diagnostics(file_uri)
 
-			// get diagnostic results from v_vet
-			if v_vet_results := ls.exec_v_diagnostics(uri) {
-				ls.publish_diagnostics(uri, v_vet_results)
-			}
-
 			unsafe {
 				full_path.free()
 				file_uri.free()
@@ -90,11 +85,10 @@ fn (mut ls Vls) did_open(_ string, params string) {
 		}
 
 		ls.show_diagnostics(uri)
+	}
 
-		// get diagnostic results from v_vet
-		if v_vet_results := ls.exec_v_diagnostics(uri) {
-			ls.publish_diagnostics(uri, v_vet_results)
-		}
+	if v_check_results := ls.exec_v_diagnostics(uri) {
+		ls.publish_diagnostics(uri, v_check_results)
 	}
 }
 
@@ -253,8 +247,7 @@ fn (mut ls Vls) did_save(id string, params string) {
 	}
 	uri := did_save_params.text_document.uri
 
-	// get diagnostic results from v_vet
-	if v_vet_results := ls.exec_v_diagnostics(uri) {
-		ls.publish_diagnostics(uri, v_vet_results)
+	if v_check_results := ls.exec_v_diagnostics(uri) {
+		ls.publish_diagnostics(uri, v_check_results)
 	}
 }

--- a/server/vls.v
+++ b/server/vls.v
@@ -369,7 +369,8 @@ pub fn (ls Vls) launch_v_tool(args ...string) &os.Process {
 		v_exe_name += '.exe'
 	}
 
-	mut p := os.new_process(os.join_path(ls.vroot_path, v_exe_name))
+	full_v_path := os.join_path(ls.vroot_path, v_exe_name)
+	mut p := os.new_process(full_v_path)
 	p.set_args(args)
 	p.set_redirect_stdio()
 	return p


### PR DESCRIPTION
This PR updates the implementation of v.vet diagnostics (https://github.com/vlang/vls/commit/3c82d373ef58d86c4ddbbd271b67a440da77e192) to utilize the recently merged "check only" mode from https://github.com/vlang/v/pull/11414 which will provide comprehensive diagnostics compared to the previous one.

Aside from that, it executes the diagnostics when opening aside from saving

Related: #204 