### PR TITLE
analyzer: struct/enum type show full information

### DIFF
--- a/analyzer/symbol.v
+++ b/analyzer/symbol.v
@@ -194,7 +194,7 @@ pub fn (info &Symbol) gen_str() string {
 			sb.write_string(info.access.str())
 			if info.kind == .field {
 				sb.write_b(`(`)
-				sb.write_string(info.parent.gen_str())
+				sb.write_string(info.parent.name)
 				sb.write_b(`)`)
 				sb.write_b(`.`)
 			}
@@ -234,6 +234,16 @@ pub fn (info &Symbol) gen_str() string {
 					}
 				}
 			}
+		}
+		.struct_ {
+			sb.write_string(info.access.str())
+			sb.write_string('struct ')
+			sb.write_string(info.name)
+		}
+		.enum_ {
+			sb.write_string(info.access.str())
+			sb.write_string('enum ')
+			sb.write_string(info.name)
 		}
 		else {
 			// sb.write_string(info.kind.str())

--- a/server/tests/completion_test.v
+++ b/server/tests/completion_test.v
@@ -358,13 +358,13 @@ const completion_results = {
 		lsp.CompletionItem{
 			label: 'Foo'
 			kind: .struct_
-			detail: 'Foo'
+			detail: 'struct Foo'
 			insert_text: 'Foo'
 		},
 		lsp.CompletionItem{
 			label: 'Bar'
 			kind: .struct_
-			detail: 'Bar'
+			detail: 'struct Bar'
 			insert_text: 'Bar'
 		},
 	]

--- a/server/tests/completion_test.v
+++ b/server/tests/completion_test.v
@@ -313,7 +313,7 @@ const completion_results = {
 		lsp.CompletionItem{
 			label: 'Point'
 			kind: .struct_
-			detail: 'Point'
+			detail: 'pub struct Point'
 			insert_text: 'Point{a:\$0, b:\$1}'
 			insert_text_format: .snippet
 		},

--- a/server/tests/completion_test.v
+++ b/server/tests/completion_test.v
@@ -198,19 +198,19 @@ const completion_results = {
 		lsp.CompletionItem{
 			label: 'DB'
 			kind: .struct_
-			detail: 'DB'
+			detail: 'pub struct DB'
 			insert_text: 'DB'
 		},
 		lsp.CompletionItem{
 			label: 'Row'
 			kind: .struct_
-			detail: 'Row'
+			detail: 'pub struct Row'
 			insert_text: 'Row'
 		},
 		lsp.CompletionItem{
 			label: 'Config'
 			kind: .struct_
-			detail: 'Config'
+			detail: 'pub struct Config'
 			insert_text: 'Config'
 		},
 		lsp.CompletionItem{

--- a/server/tests/hover_test.v
+++ b/server/tests/hover_test.v
@@ -85,7 +85,7 @@ const hover_results = {
 		}
 	}
 	'enum.vv':                  lsp.Hover{
-		contents: lsp.MarkedString{'v', 'Color'}
+		contents: lsp.MarkedString{'v', 'enum Color'}
 		range: lsp.Range{
 			start: lsp.Position{0, 5}
 			end: lsp.Position{0, 10}
@@ -142,7 +142,7 @@ const hover_results = {
 		}
 	}
 	'struct.vv':                lsp.Hover{
-		contents: lsp.MarkedString{'v', 'Abc'}
+		contents: lsp.MarkedString{'v', 'struct Abc'}
 		range: lsp.Range{
 			start: lsp.Position{0, 7}
 			end: lsp.Position{0, 10}


### PR DESCRIPTION
This PR makes struct/enum type showing full information.

![image](https://user-images.githubusercontent.com/6949593/132432900-750326aa-1dd2-4b1a-80a7-bc7fc1f48d75.png)
