### PR TITLE
analyzer: selector's left type don't show parentheses

### DIFF
--- a/analyzer/symbol.v
+++ b/analyzer/symbol.v
@@ -193,9 +193,7 @@ pub fn (info &Symbol) gen_str() string {
 		.variable, .field {
 			sb.write_string(info.access.str())
 			if info.kind == .field {
-				sb.write_b(`(`)
 				sb.write_string(info.parent.name)
-				sb.write_b(`)`)
 				sb.write_b(`.`)
 			}
 

--- a/server/tests/completion_test.v
+++ b/server/tests/completion_test.v
@@ -164,7 +164,7 @@ const completion_results = {
 	'filtered_fields_in_selector.vv':       [
 		lsp.CompletionItem{
 			label: 'output_file_name'
-			detail: 'pub mut (Log).output_file_name string'
+			detail: 'pub mut Log.output_file_name string'
 			kind: .property
 			insert_text: 'output_file_name'
 		},

--- a/server/tests/completion_test.v
+++ b/server/tests/completion_test.v
@@ -138,25 +138,25 @@ const completion_results = {
 	'enum_val_in_struct.vv':                [
 		lsp.CompletionItem{
 			label: '.golden_retriever'
-			detail: '(Breed).golden_retriever int'
+			detail: 'Breed.golden_retriever int'
 			kind: .enum_member
 			insert_text: '.golden_retriever'
 		},
 		lsp.CompletionItem{
 			label: '.beagle'
-			detail: '(Breed).beagle int'
+			detail: 'Breed.beagle int'
 			kind: .enum_member
 			insert_text: '.beagle'
 		},
 		lsp.CompletionItem{
 			label: '.chihuahua'
-			detail: '(Breed).chihuahua int'
+			detail: 'Breed.chihuahua int'
 			kind: .enum_member
 			insert_text: '.chihuahua'
 		},
 		lsp.CompletionItem{
 			label: '.dalmatian'
-			detail: '(Breed).dalmatian int'
+			detail: 'Breed.dalmatian int'
 			kind: .enum_member
 			insert_text: '.dalmatian'
 		},
@@ -253,7 +253,7 @@ const completion_results = {
 		lsp.CompletionItem{
 			label: 'name'
 			kind: .property
-			detail: '(Barw).name string'
+			detail: 'Barw.name string'
 			insert_text: 'name'
 		},
 		lsp.CompletionItem{
@@ -268,7 +268,7 @@ const completion_results = {
 		lsp.CompletionItem{
 			label: 'name'
 			kind: .property
-			detail: '(Foo).name string'
+			detail: 'Foo.name string'
 			insert_text: 'name'
 		},
 		lsp.CompletionItem{
@@ -283,7 +283,7 @@ const completion_results = {
 		lsp.CompletionItem{
 			label: 'len'
 			kind: .property
-			detail: '(Bee).len int'
+			detail: 'Bee.len int'
 			insert_text: 'len'
 		},
 	]
@@ -327,14 +327,14 @@ const completion_results = {
 	'struct_init.vv':                       [
 		lsp.CompletionItem{
 			label: 'name:'
-			detail: '(Person).name string'
+			detail: 'Person.name string'
 			kind: .field
 			insert_text_format: .snippet
 			insert_text: 'name: \$0'
 		},
 		lsp.CompletionItem{
 			label: 'age:'
-			detail: '(Person).age int'
+			detail: 'Person.age int'
 			kind: .field
 			insert_text_format: .snippet
 			insert_text: 'age: \$0'

--- a/server/tests/hover_test.v
+++ b/server/tests/hover_test.v
@@ -135,7 +135,7 @@ const hover_results = {
 	}
 	'node_error.vv':            lsp.Hover{}
 	'selector_expr.vv':         lsp.Hover{
-		contents: lsp.MarkedString{'v', '(Person).name string'}
+		contents: lsp.MarkedString{'v', 'Person.name string'}
 		range: lsp.Range{
 			start: lsp.Position{6, 9}
 			end: lsp.Position{6, 13}
@@ -149,21 +149,21 @@ const hover_results = {
 		}
 	}
 	'struct_field.vv':          lsp.Hover{
-		contents: lsp.MarkedString{'v', '(Foo).bar string'}
+		contents: lsp.MarkedString{'v', 'Foo.bar string'}
 		range: lsp.Range{
 			start: lsp.Position{3, 2}
 			end: lsp.Position{3, 5}
 		}
 	}
 	'struct_init_a.vv':         lsp.Hover{
-		contents: lsp.MarkedString{'v', '(Person).name string'}
+		contents: lsp.MarkedString{'v', 'Person.name string'}
 		range: lsp.Range{
 			start: lsp.Position{8, 4}
 			end: lsp.Position{8, 8}
 		}
 	}
 	'struct_init_b.vv':         lsp.Hover{
-		contents: lsp.MarkedString{'v', 'pub mut (Command).usage string'}
+		contents: lsp.MarkedString{'v', 'pub mut Command.usage string'}
 		range: lsp.Range{
 			start: lsp.Position{7, 2}
 			end: lsp.Position{7, 20}


### PR DESCRIPTION
This PR makes selector's left type don't show parentheses.

![image](https://user-images.githubusercontent.com/6949593/132529590-29c1bd5d-f1b4-44b8-914b-38d26ee251bf.png)
