### PR TITLE
analyzer: uncomment some main free calls

### DIFF
--- a/analyzer/store.v
+++ b/analyzer/store.v
@@ -1088,7 +1088,7 @@ pub fn (mut ss Store) cleanup_imports() int {
 
 			// intentionally do not use the variables to the same scope
 			dep_node.remove_dependency(imp_module.path)
-			
+
 			// delete dir if possible
 			ss.delete(imp_module.path)
 			// unsafe { imp_module.free() }
@@ -1241,11 +1241,11 @@ pub fn (mut store Store) import_modules(mut imports []&Import) {
 				// unsafe { sr.cursor.free() }
 			}
 			parser.reset()
-			// unsafe {
-			// modules_from_dir.free()
-			// content.free()
-			// tree_from_import.free()
-			// }
+			unsafe {
+				modules_from_dir.free()
+				content.free()
+				tree_from_import.free()
+			}
 		}
 
 		if imported > 0 {

--- a/analyzer/symbol.v
+++ b/analyzer/symbol.v
@@ -124,9 +124,9 @@ pub fn (info &Symbol) gen_str() string {
 	}
 
 	mut sb := strings.new_builder(100)
-	// defer {
-	// 	unsafe { sb.free() }
-	// }
+	defer {
+		unsafe { sb.free() }
+	}
 
 	// sb.write_string(info.access.str())
 


### PR DESCRIPTION
This PR uncomment some main free calls.

- `content.free()`, content is new file's content.
- `sb.free()`, strings.new_builder(100).