### PR TITLE
vls: fix opening of big file with tcp mode

### DIFF
--- a/cmd/vls/socket.v
+++ b/cmd/vls/socket.v
@@ -26,7 +26,7 @@ pub fn (mut sck Socket) init() ? {
 		sck.listener.close() or {}
 		return err
 	}
-	sck.reader = io.new_buffered_reader(reader: sck.conn)
+	sck.reader = io.new_buffered_reader(reader: sck.conn, cap: 1024 * 1024)
 	sck.conn.set_blocking(true) or {}
 }
 


### PR DESCRIPTION
This PR fix opening of big file with tcp mode.

- The default buffer io's size is 128*1024.
- It will cause error When opening big file, .e.g  checker.v.
- Increase the cache size to 1024*1024.