### PR TITLE
tree_sitter_v: cleanup grammar.js

### DIFF
--- a/tree_sitter_v/grammar.js
+++ b/tree_sitter_v/grammar.js
@@ -934,7 +934,7 @@ module.exports = grammar({
     fn_literal: ($) =>
       prec.right(
         seq(
-          "fn",
+          fn_keyword,
           field("exposed_variables", optional($.exposed_variables_list)),
           field("parameters", $.parameter_list),
           field("result", optional($._type)),


### PR DESCRIPTION
This PR cleanup grammar.js in tree_sitter_v.

- Format grammar.js.
- Use `fn_keyword` instead of "fn" in `fn_literal`.