### PR TITLE
server: implement workspace/didChangeWatchedFiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ For other editors, please refer to the plugin's/editor's documentation for instr
 - [ ] `didChangeWorkspaceFolder`
 - [ ] `didChangeConfiguration`
 - [ ] `configuration`
-- [ ] `didChangeWatchedFiles`
+- [x] `didChangeWatchedFiles`
 - [x] `symbol`
 - [ ] `executeCommand`
 - [ ] `applyEdit`

--- a/lsp/workspace.v
+++ b/lsp/workspace.v
@@ -47,7 +47,7 @@ pub:
 pub struct FileEvent {
 pub:
 	uri   DocumentUri
-	@type int
+	typ   FileChangeType [json:'type']
 }
 
 pub enum FileChangeType {

--- a/server/testing/testing.v
+++ b/server/testing/testing.v
@@ -96,10 +96,10 @@ pub fn load_test_file_paths(folder_name string) ?[]string {
 		filtered << os.join_path(target_path, path)
 	}
 	// unsafe { dir.free() }
-	filtered.sort()
 	if filtered.len == 0 {
 		return error('no test files found for "$folder_name"')
 	}
+	filtered.sort()
 	return filtered
 }
 

--- a/server/tests/test_files/workspace_did_change/changed_be_ignored.vv
+++ b/server/tests/test_files/workspace_did_change/changed_be_ignored.vv
@@ -1,0 +1,3 @@
+module workspace_did_change
+
+const foo = 1

--- a/server/tests/test_files/workspace_did_change/should_be_deleted.vv
+++ b/server/tests/test_files/workspace_did_change/should_be_deleted.vv
@@ -1,0 +1,5 @@
+module workspace_did_change
+
+fn hello() string {
+	return 'world!'
+}

--- a/server/tests/test_files/workspace_did_change/should_be_renamed.vv
+++ b/server/tests/test_files/workspace_did_change/should_be_renamed.vv
@@ -1,0 +1,5 @@
+module workspace_did_change
+
+fn what_does_the_fox_say() int {
+	return 1
+}

--- a/server/tests/workspace_did_change_test.v
+++ b/server/tests/workspace_did_change_test.v
@@ -1,0 +1,70 @@
+import server
+import server.testing
+import json
+import lsp
+import os
+
+fn test_workspace_did_change() ? {
+	mut io := &testing.Testio{}
+	mut ls := server.new(io)
+
+	// TODO: add a mock filesystem
+	files := testing.load_test_file_paths('workspace_did_change') or {
+		io.bench.fail()
+		eprintln(io.bench.step_message_fail(err.msg))
+		return err
+	}
+
+	for file_path in files {
+		content := os.read_file(file_path) or {
+			io.bench.fail()
+			continue
+		}
+		// open document
+		req, _ := io.open_document(file_path, content)
+		ls.dispatch(req)
+	}
+
+	method_name := 'workspace/didChangeWatchedFiles' 
+	assert io.bench.nfail == 0
+
+	// delete
+	delete_ev := io.request_with_params(method_name, lsp.DidChangeWatchedFilesParams{
+		changes: [
+			lsp.FileEvent{
+				uri: lsp.document_uri_from_path(files[1])
+				typ: .deleted
+			}
+		]
+	})
+
+	ls.dispatch(delete_ev)
+
+	// rename
+	rename_ev := io.request_with_params(method_name, lsp.DidChangeWatchedFilesParams{
+		changes: [
+			lsp.FileEvent{
+				uri: lsp.document_uri_from_path(files[2])
+				typ: .deleted
+			},
+			lsp.FileEvent{
+				uri: lsp.document_uri_from_path(os.join_path(os.dir(files[2]), 'renamed.vv'))
+				typ: .created
+			}
+		]
+	})
+
+	ls.dispatch(rename_ev)
+
+	// on save
+	changed_ev := io.request_with_params(method_name, lsp.DidChangeWatchedFilesParams{
+		changes: [
+			lsp.FileEvent{
+				uri: lsp.document_uri_from_path(files[0])
+				typ: .changed
+			}
+		]
+	})
+
+	ls.dispatch(changed_ev)
+}

--- a/server/text_synchronization.v
+++ b/server/text_synchronization.v
@@ -218,11 +218,11 @@ fn (mut ls Vls) did_close(_ string, params string) {
 	}
 
 	uri := did_close_params.text_document.uri
-	unsafe {
-		ls.sources[uri].free()
-		ls.trees[uri].free()
-		ls.store.opened_scopes[uri.path()].free()
-	}
+	// unsafe {
+	// 	ls.sources[uri].free()
+	// 	ls.trees[uri].free()
+	// 	ls.store.opened_scopes[uri.path()].free()
+	// }
 	ls.sources.delete(uri)
 	ls.trees.delete(uri)
 	ls.store.opened_scopes.delete(uri.path())

--- a/server/vls.v
+++ b/server/vls.v
@@ -194,6 +194,9 @@ pub fn (mut ls Vls) dispatch(payload string) {
 			'textDocument/implementation' {
 				ls.implementation(request.id, request.params)
 			}
+			'workspace/didChangeWatchedFiles' {
+				ls.did_change_watched_files(request.params)
+			}
 			else {}
 		}
 	} else {

--- a/server/workspace.v
+++ b/server/workspace.v
@@ -12,9 +12,9 @@ fn (mut ls Vls) did_change_watched_files(params string) {
 
 	changes := did_change_watched_params.changes
 	mut is_rename := false
-	
+
 	// NOTE:
-	// 1. Renaming a file returns two events: one "deleted" event for 
+	// 1. Renaming a file returns two events: one "deleted" event for
 	//    the file with old name and one "created" event for the same
 	//    file with new name.
 	// 2. Deleting a folder does not trigger a "deleted" event. Restoring
@@ -27,7 +27,7 @@ fn (mut ls Vls) did_change_watched_files(params string) {
 				if is_rename {
 					prev_uri := changes[i - 1].uri
 					if prev_uri in ls.sources {
-						ls.sources[change.uri] = ls.sources[prev_uri] 
+						ls.sources[change.uri] = ls.sources[prev_uri]
 						ls.sources.delete(prev_uri)
 					}
 
@@ -119,7 +119,7 @@ fn (mut ls Vls) did_change_watched_files(params string) {
 				}
 			}
 		}
-		
+
 		// ls.log_message(change.str(), .info)
 	}
 }

--- a/server/workspace.v
+++ b/server/workspace.v
@@ -1,8 +1,125 @@
 module server
 
-fn (ls Vls) did_change_watched_files(id string, params string) {
-	// TODO Remove, functions can't have two args with name `_`
-	_ = ls
-	_ = id
-	_ = params
+import lsp
+import json
+import os
+
+fn (mut ls Vls) did_change_watched_files(params string) {
+	did_change_watched_params := json.decode(lsp.DidChangeWatchedFilesParams, params) or {
+		ls.panic(err.msg)
+		return
+	}
+
+	changes := did_change_watched_params.changes
+	mut is_rename := false
+	
+	// NOTE:
+	// 1. Renaming a file returns two events: one "deleted" event for 
+	//    the file with old name and one "created" event for the same
+	//    file with new name.
+	// 2. Deleting a folder does not trigger a "deleted" event. Restoring
+	//    the files of the folder however triggers the "created" event.
+	// 3. Renaming a folder triggers the "created" event for each file
+	//    but with no "deleted" event prior to it.
+	for i, change in changes {
+		match change.typ {
+			.created {
+				if is_rename {
+					prev_uri := changes[i - 1].uri
+					if prev_uri in ls.sources {
+						ls.sources[change.uri] = ls.sources[prev_uri] 
+						ls.sources.delete(prev_uri)
+					}
+
+					if prev_uri in ls.trees {
+						ls.trees[change.uri] = ls.trees[prev_uri]
+						ls.trees.delete(prev_uri)
+					}
+
+					prev_uri_path := prev_uri.path()
+					prev_uri_dir := prev_uri.dir_path()
+					prev_uri_file_name := os.base(prev_uri_path)
+					new_uri_path := change.uri.path()
+					new_uri_file_name := os.base(new_uri_path)
+					if prev_uri_path in ls.store.opened_scopes {
+						ls.store.opened_scopes[new_uri_path] = ls.store.opened_scopes[prev_uri_path]
+						ls.store.opened_scopes.delete(prev_uri_path)
+					}
+
+					// update existing symbols
+					mut symbols := ls.store.get_symbols_by_file_path(prev_uri_path)
+					for mut sym in symbols {
+						sym.file_path = new_uri_path
+					}
+
+					// update existing imports
+					for mut imp in ls.store.imports[prev_uri_dir] {
+						if prev_uri_path in imp.ranges {
+							imp.ranges[new_uri_path] = imp.ranges[prev_uri_path]
+							imp.ranges.delete(prev_uri_path)
+						}
+
+						if prev_uri_file_name in imp.aliases {
+							imp.aliases[new_uri_file_name] = imp.aliases[prev_uri_file_name]
+							imp.aliases.delete(prev_uri_file_name)
+						}
+
+						if prev_uri_file_name in imp.symbols {
+							imp.symbols[new_uri_file_name] = imp.symbols[prev_uri_file_name]
+							imp.symbols.delete(prev_uri_file_name)
+						}
+					}
+
+					is_rename = false
+				} else {
+					// TODO: let did_open do the job(?)
+				}
+			}
+			.changed {
+				// let did_change do the thing
+				continue
+			}
+			.deleted {
+				// do not proceed if type of change is a file rename
+				if next_change := changes[i + 1] {
+					// is_rename is set to true if next change event is created
+					// and the same as the current uri
+					is_rename = next_change.typ == .created && next_change.uri == change.uri
+					continue
+				}
+
+				// TODO: use did_close(?)
+				file_path := change.uri.path()
+
+				ls.sources.delete(change.uri)
+				ls.trees.delete(change.uri)
+				ls.store.opened_scopes.delete(file_path)
+
+				if ls.sources.count(change.uri.dir()) == 0 {
+					ls.store.delete(change.uri.dir_path())
+				} else {
+					// delete symbols
+					file_dir := change.uri.dir_path()
+					for j := 0; i < ls.store.symbols[file_dir].len; {
+						sym := ls.store.symbols[file_dir][j]
+						if sym.file_path == file_path {
+							ls.store.symbols[file_dir].delete(j)
+						} else {
+							j++
+						}
+					}
+
+					// delete import
+					file_name := os.base(file_path)
+					for mut imp in ls.store.imports[file_dir] {
+						imp.ranges.delete(file_path)
+						imp.aliases.delete(file_name)
+						imp.symbols.delete(file_name)
+					}
+				}
+			}
+		}
+		
+		// ls.log_message(change.str(), .info)
+	}
 }


### PR DESCRIPTION
According to [LSP 3.15 Specification:](https://microsoft.github.io/language-server-protocol/specifications/specification-3-15/#workspace_didChangeWatchedFiles)
>
>The watched files notification is sent from the client to the server when the client detects changes to files watched by the language client. It is recommended that servers register for these file events using the registration mechanism. In former implementations clients pushed file events without the server actively asking for it.
>
>Servers are allowed to run their own file watching mechanism and not rely on clients to provide file events. However this is not recommended due to the following reasons:
>
> - to our experience getting file watching on disk right is challenging, especially if it needs to be supported across multiple OSes.
> - file watching is not for free especially if the implementation uses some sort of polling and keeps a file tree in memory to compare time stamps (as for example some node modules do)
> - a client usually starts more than one server. If every server runs its own file watching it can become a CPU or memory problem.
> - in general there are more server than client implementations. So this problem is better solved on the client side.

**TL;DR**: This is an important feature in order to handle file deletion and file renaming for files not currently opened in the editor. 

## Notes
See https://github.com/vlang/vls/pull/228/files#r712674414

