### PR TITLE
server: import mod don't show as alias when using no alias

### DIFF
--- a/server/tests/hover_test.v
+++ b/server/tests/hover_test.v
@@ -106,7 +106,7 @@ const hover_results = {
 		}
 	}
 	'import.vv':                lsp.Hover{
-		contents: lsp.MarkedString{'v', 'import os as os'}
+		contents: lsp.MarkedString{'v', 'import os'}
 		range: lsp.Range{
 			start: lsp.Position{0, 7}
 			end: lsp.Position{0, 9}


### PR DESCRIPTION
This PR makes import mod don't show `as alias` when using no alias.

![image](https://user-images.githubusercontent.com/6949593/134356749-662959e8-69cd-4d22-a737-30ed50b3ab2d.png)
