### PR TITLE
cmd: fix vls crash on windows

### DIFF
--- a/cmd/vls/main.v
+++ b/cmd/vls/main.v
@@ -5,7 +5,10 @@ import server
 import os
 
 fn run_cli(cmd cli.Command) ? {
-	run_as_child := cmd.flags.get_bool('child') or { false }
+	mut run_as_child := cmd.flags.get_bool('child') or { false }
+	$if windows {
+		run_as_child = true
+	}
 	if run_as_child {
 		run_server(cmd) ?
 	} else {


### PR DESCRIPTION
This PR fix vls crash on windows.

- Use `--child` mode on windows.