### PR TITLE
tests: add diagnostics test with error highlighting

### DIFF
--- a/server/tests/test_files/diagnostics/error_highlight.vv
+++ b/server/tests/test_files/diagnostics/error_highlight.vv
@@ -1,0 +1,4 @@
+fn main() {
+	asfasf
+	println('text')
+}


### PR DESCRIPTION
This PR add diagnostics test with error highlighting.

```vlang
fn main() {
	asfasf
	println('text')
}
```