### PR TITLE
vls: rename node.get_type() to node.type_name()

### DIFF
--- a/analyzer/analyzer.v
+++ b/analyzer/analyzer.v
@@ -112,7 +112,7 @@ fn (mut an Analyzer) fn_decl(node C.TSNode) {
 
 pub fn (mut an Analyzer) top_level_statement() {
 	current_node := an.cursor.current_node()
-	node_type := current_node.get_type()
+	node_type := current_node.type_name()
 	defer {
 		an.cursor.next()
 		// unsafe { node_type.free() }

--- a/analyzer/ast.v
+++ b/analyzer/ast.v
@@ -15,7 +15,7 @@ fn get_nodes_within_range(node C.TSNode, range C.TSRange) ?[]C.TSNode {
 
 	for i in u32(0) .. child_count {
 		child := node.named_child(i)
-		child_type := child.get_type()
+		child_type := child.type_name()
 		if !child.is_null()
 			&& ((child_type.ends_with('_declaration') && child_type !in analyzer.excluded_nodes)
 			|| child_type in analyzer.included_nodes) && within_range(child.range(), range) {

--- a/server/ast.v
+++ b/server/ast.v
@@ -10,9 +10,9 @@ const other_node_types = ['if_expression', 'for_statement', 'return_statement', 
 	'binary_expression', 'unary_expression']
 
 fn traverse_node(root_node C.TSNode, offset u32) C.TSNode {
-	root_type := root_node.get_type()
+	root_type := root_node.type_name()
 	direct_named_child := root_node.first_named_child_for_byte(offset)
-	child_type := direct_named_child.get_type()
+	child_type := direct_named_child.type_name()
 	if direct_named_child.is_null() {
 		return root_node
 	}
@@ -50,10 +50,10 @@ fn traverse_node(root_node C.TSNode, offset u32) C.TSNode {
 // for auto-completion
 fn traverse_node2(starting_node C.TSNode, offset u32) C.TSNode {
 	mut root_node := starting_node
-	mut root_type := root_node.get_type()
+	mut root_type := root_node.type_name()
 
 	direct_named_child := root_node.first_named_child_for_byte(offset)
-	child_type := direct_named_child.get_type()
+	child_type := direct_named_child.type_name()
 
 	if child_type.ends_with('_literal') {
 		return root_node
@@ -104,7 +104,7 @@ fn closest_named_child(starting_node C.TSNode, offset u32) C.TSNode {
 	for i in u32(0) .. named_child_count {
 		child_node := starting_node.named_child(i)
 		if !child_node.is_null() && child_node.start_byte() <= offset
-			&& (child_node.get_type() == 'import_symbols' || child_node.end_byte() <= offset) {
+			&& (child_node.type_name() == 'import_symbols' || child_node.end_byte() <= offset) {
 			selected_node = child_node
 		} else {
 			break
@@ -122,7 +122,7 @@ const other_symbol_node_types = ['assignment_statement', 'call_expression', 'sel
 // (nodes with names, module name, and etc.)
 fn closest_symbol_node_parent(child_node C.TSNode) C.TSNode {
 	parent_node := child_node.parent()
-	parent_type := parent_node.get_type()
+	parent_type := parent_node.type_name()
 	if parent_node.is_null() || parent_type == 'source_file' || parent_type == 'block' {
 		return child_node
 	}

--- a/server/text_synchronization.v
+++ b/server/text_synchronization.v
@@ -57,7 +57,7 @@ fn (mut ls Vls) did_open(_ string, params string) {
 			// V's interop with tree sitter's parse_string is buggy sometimes
 			// especially if the code is incomplete. It reattempts to re-parse
 			// an appropriate tree by reducing decrement the source length by 1
-			if !isnil(ls.trees[file_uri]) && ls.trees[file_uri].root_node().get_type() == 'ERROR' {
+			if !isnil(ls.trees[file_uri]) && ls.trees[file_uri].root_node().type_name() == 'ERROR' {
 				unsafe { ls.trees[file_uri].free() }
 				ls.trees[file_uri] = ls.parser.parse_string_with_old_tree_and_len(src,
 					&C.TSTree(0), u32(src.len - 1))
@@ -188,7 +188,7 @@ fn (mut ls Vls) did_change(_ string, params string) {
 
 	// See comment in `did_open`.
 	mut new_tree := ls.parser.parse_string_with_old_tree(new_src.bytestr(), ls.trees[uri])
-	if !isnil(new_tree) && new_tree.root_node().get_type() == 'ERROR' {
+	if !isnil(new_tree) && new_tree.root_node().type_name() == 'ERROR' {
 		unsafe { new_tree.free() }
 		new_tree = ls.parser.parse_string_with_old_tree_and_len(new_src.bytestr(), ls.trees[uri],
 			u32(new_src.len - 1))

--- a/tree_sitter/tree_sitter.v
+++ b/tree_sitter/tree_sitter.v
@@ -191,7 +191,7 @@ pub fn (node C.TSNode) range() C.TSRange {
 	}
 }
 
-pub fn (node C.TSNode) get_type() string {
+pub fn (node C.TSNode) type_name() string {
 	if node.is_null() {
 		return '<null node>'
 	}


### PR DESCRIPTION
This PR rename node.get_type() to node.type_name() in tree_sitter.v.

- Rename node.get_type() to node.type_name() in tree_sitter.v.
- Modify all the related calls.