### PR TITLE
vls: cleanup tree-sitter.v

### DIFF
--- a/analyzer/analyzer.v
+++ b/analyzer/analyzer.v
@@ -64,7 +64,7 @@ fn (mut an Analyzer) import_decl(node C.TSNode) {
 	}
 
 	module_name_node := node.child_by_field_name('path')
-	module_name := module_name_node.get_text(an.src_text)
+	module_name := module_name_node.code(an.src_text)
 	// defer { unsafe { module_name.free() } }
 
 	module_path := an.store.get_module_path_opt(module_name) or {
@@ -80,7 +80,7 @@ fn (mut an Analyzer) import_decl(node C.TSNode) {
 			continue
 		}
 
-		symbol_name := sym.get_text(an.src_text)
+		symbol_name := sym.code(an.src_text)
 		got_sym := an.store.symbols[module_path].get(symbol_name) or {
 			an.report('Symbol `$symbol_name` not found', sym)
 			// unsafe { symbol_name.free() }
@@ -112,7 +112,7 @@ fn (mut an Analyzer) fn_decl(node C.TSNode) {
 
 pub fn (mut an Analyzer) top_level_statement() {
 	current_node := an.cursor.current_node()
-	node_type := current_node.type_name()
+	node_type := current_node.name()
 	defer {
 		an.cursor.next()
 		// unsafe { node_type.free() }

--- a/analyzer/ast.v
+++ b/analyzer/ast.v
@@ -15,7 +15,7 @@ fn get_nodes_within_range(node C.TSNode, range C.TSRange) ?[]C.TSNode {
 
 	for i in u32(0) .. child_count {
 		child := node.named_child(i)
-		child_type := child.type_name()
+		child_type := child.name()
 		if !child.is_null()
 			&& ((child_type.ends_with('_declaration') && child_type !in analyzer.excluded_nodes)
 			|| child_type in analyzer.included_nodes) && within_range(child.range(), range) {

--- a/server/ast.v
+++ b/server/ast.v
@@ -10,9 +10,9 @@ const other_node_types = ['if_expression', 'for_statement', 'return_statement', 
 	'binary_expression', 'unary_expression']
 
 fn traverse_node(root_node C.TSNode, offset u32) C.TSNode {
-	root_type := root_node.type_name()
+	root_type := root_node.name()
 	direct_named_child := root_node.first_named_child_for_byte(offset)
-	child_type := direct_named_child.type_name()
+	child_type := direct_named_child.name()
 	if direct_named_child.is_null() {
 		return root_node
 	}
@@ -50,10 +50,10 @@ fn traverse_node(root_node C.TSNode, offset u32) C.TSNode {
 // for auto-completion
 fn traverse_node2(starting_node C.TSNode, offset u32) C.TSNode {
 	mut root_node := starting_node
-	mut root_type := root_node.type_name()
+	mut root_type := root_node.name()
 
 	direct_named_child := root_node.first_named_child_for_byte(offset)
-	child_type := direct_named_child.type_name()
+	child_type := direct_named_child.name()
 
 	if child_type.ends_with('_literal') {
 		return root_node
@@ -104,7 +104,7 @@ fn closest_named_child(starting_node C.TSNode, offset u32) C.TSNode {
 	for i in u32(0) .. named_child_count {
 		child_node := starting_node.named_child(i)
 		if !child_node.is_null() && child_node.start_byte() <= offset
-			&& (child_node.type_name() == 'import_symbols' || child_node.end_byte() <= offset) {
+			&& (child_node.name() == 'import_symbols' || child_node.end_byte() <= offset) {
 			selected_node = child_node
 		} else {
 			break
@@ -122,7 +122,7 @@ const other_symbol_node_types = ['assignment_statement', 'call_expression', 'sel
 // (nodes with names, module name, and etc.)
 fn closest_symbol_node_parent(child_node C.TSNode) C.TSNode {
 	parent_node := child_node.parent()
-	parent_type := parent_node.type_name()
+	parent_type := parent_node.name()
 	if parent_node.is_null() || parent_type == 'source_file' || parent_type == 'block' {
 		return child_node
 	}

--- a/server/features.v
+++ b/server/features.v
@@ -200,14 +200,14 @@ fn (mut ls Vls) signature_help(id string, params string) {
 	off := compute_offset(source, pos.line, pos.character)
 	mut node := traverse_node(tree.root_node(), u32(off))
 	mut parent_node := node
-	if node.type_name() == 'argument_list' {
+	if node.name() == 'argument_list' {
 		parent_node = node.parent()
 		node = node.prev_named_sibling()
 	}
 
 	// signature help supports function calls for now
 	// hence checking the node if it's a call_expression node.
-	if node.is_null() || parent_node.type_name() != 'call_expression' {
+	if node.is_null() || parent_node.name() != 'call_expression' {
 		ls.send_null(id)
 		return
 	}
@@ -290,7 +290,7 @@ fn (mut builder CompletionBuilder) add(item lsp.CompletionItem) {
 }
 
 fn (builder CompletionBuilder) is_triggered(node C.TSNode, chr string) bool {
-	return node.next_sibling().get_text(builder.src) == chr || builder.ctx.trigger_character == chr
+	return node.next_sibling().code(builder.src) == chr || builder.ctx.trigger_character == chr
 }
 
 fn (builder CompletionBuilder) is_selector(node C.TSNode) bool {
@@ -316,7 +316,7 @@ fn (mut builder CompletionBuilder) build_suggestions(node C.TSNode, offset int) 
 }
 
 fn (mut builder CompletionBuilder) build_suggestions_from_node(node C.TSNode) {
-	node_type := node.type_name()
+	node_type := node.name()
 	if node_type in list_node_types {
 		builder.build_suggestions_from_list(node)
 	} else if node_type == 'module_clause' {
@@ -328,7 +328,7 @@ fn (mut builder CompletionBuilder) build_suggestions_from_node(node C.TSNode) {
 
 // suggestions_from_stmt returns a list of results from the extracted Stmt node info.
 fn (mut builder CompletionBuilder) build_suggestions_from_stmt(node C.TSNode) {
-	match node.type_name() {
+	match node.name() {
 		'short_var_declaration' {
 			builder.show_local = true
 			builder.show_global = true
@@ -353,7 +353,7 @@ fn (mut builder CompletionBuilder) build_suggestions_from_stmt(node C.TSNode) {
 
 // suggestions_from_list returns a list of results extracted from the list nodes.
 fn (mut builder CompletionBuilder) build_suggestions_from_list(node C.TSNode) {
-	match node.type_name() {
+	match node.name() {
 		'identifier_list', 'assignable_identifier_list' {
 			parent := closest_symbol_node_parent(node)
 			builder.build_suggestions_from_node(parent)
@@ -361,14 +361,14 @@ fn (mut builder CompletionBuilder) build_suggestions_from_list(node C.TSNode) {
 		'expression_list' {
 			// expr_list_count := node.named_child_count()
 			parent := closest_symbol_node_parent(node)
-			parent_type := parent.type_name()
+			parent_type := parent.name()
 			match parent_type {
 				'assignment_statement' {
 					builder.build_suggestions_from_stmt(parent)
 				}
 				else {
 					// closest_node := closest_named_child(node, u32(builder.offset))
-					// eprintln(closest_node.type_name())
+					// eprintln(closest_node.name())
 				}
 			}
 		}
@@ -391,7 +391,7 @@ fn (mut builder CompletionBuilder) build_suggestions_from_list(node C.TSNode) {
 		'import_symbols_list' {
 			import_node := closest_symbol_node_parent(node)
 			import_path_node := import_node.child_by_field_name('path')
-			import_path := import_path_node.get_text(builder.src)
+			import_path := import_path_node.code(builder.src)
 			builder.build_suggestions_from_module(import_path)
 		}
 		'type_list' {
@@ -412,25 +412,25 @@ fn (mut builder CompletionBuilder) build_suggestions_from_list(node C.TSNode) {
 
 // suggestions_from_expr returns a list of results extracted from the Expr node info.
 fn (mut builder CompletionBuilder) build_suggestions_from_expr(node C.TSNode) {
-	node_type := node.type_name()
+	node_type := node.name()
 	match node_type {
 		'binded_identifier', 'identifier', 'selector_expression', 'call_expression',
 		'index_expression' {
 			builder.show_global = false
 			builder.show_local = false
 
-			text := node.get_text(builder.src)
+			text := node.code(builder.src)
 
 			if builder.is_selector(node) {
 				mut selected_node := node
 				if node_type == 'selector_expression' {
 					operand_node := node.child_by_field_name('operand')
-					if operand_node.type_name() == 'call_expression' {
+					if operand_node.name() == 'call_expression' {
 						selected_node = node
 					}
 				}
 				if got_sym := builder.store.infer_symbol_from_node(selected_node, builder.src) {
-					builder.show_mut_only = builder.parent_node.type_name() == 'block'
+					builder.show_mut_only = builder.parent_node.name() == 'block'
 						&& got_sym.is_mutable()
 					builder.build_suggestions_from_sym(got_sym.return_type, true)
 				} else if builder.store.is_module(text) {
@@ -452,7 +452,7 @@ fn (mut builder CompletionBuilder) build_suggestions_from_expr(node C.TSNode) {
 		}
 		'literal_value' {
 			closest_element_node := closest_named_child(node, u32(builder.offset))
-			if closest_element_node.type_name() == 'keyed_element' {
+			if closest_element_node.name() == 'keyed_element' {
 				builder.build_suggestions_from_expr(closest_element_node)
 			} else if got_sym := builder.store.infer_symbol_from_node(node.parent(), builder.src) {
 				builder.build_suggestions_from_sym(got_sym, false)
@@ -677,7 +677,7 @@ fn (mut builder CompletionBuilder) build_global_suggestions() {
 			}
 
 			// is_type_decl := false
-			is_type_decl := builder.parent_node.type_name() == 'type_declaration'
+			is_type_decl := builder.parent_node.name() == 'type_declaration'
 			builder.add(symbol_to_completion_item(sym, !is_type_decl) or { continue })
 		}
 	}
@@ -877,16 +877,16 @@ fn (mut ls Vls) completion(id string, params string) {
 		mut node := traverse_node2(root_node, u32(offset))
 		mut parent_node := traverse_node(root_node, u32(offset))
 
-		if root_node.is_error() && root_node.type_name() == 'ERROR' {
+		if root_node.is_error() && root_node.name() == 'ERROR' {
 			// point to the identifier for assignment statement
 			node = traverse_node(node, node.start_byte())
-		} else if node.type_name() == 'block' {
+		} else if node.name() == 'block' {
 			node = traverse_node2(root_node, u32(offset))
-		} else if node.is_error() && node.type_name() == 'ERROR' {
+		} else if node.is_error() && node.name() == 'ERROR' {
 			node = node.prev_named_sibling()
 		} else if node.start_byte() > u32(offset) {
 			node = closest_named_child(closest_symbol_node_parent(node), u32(offset))
-		} else if node.type_name() == 'source_file' {
+		} else if node.name() == 'source_file' {
 			parent_node = closest_named_child(node, u32(offset))
 			node = closest_named_child(parent_node, u32(offset))
 		} else if parent_node.start_byte() > node.start_byte() {
@@ -947,16 +947,16 @@ fn (mut ls Vls) hover(id string, params string) {
 }
 
 fn get_hover_data(mut store analyzer.Store, node C.TSNode, uri lsp.DocumentUri, source []byte, offset u32) ?lsp.Hover {
-	node_type := node.type_name()
+	node_type := node.name()
 	if node.is_null() || node_type == 'comment' {
 		return none
 	}
 
 	mut original_range := node.range()
-	// eprintln('$node_type | ${node.get_text(source)}')
+	// eprintln('$node_type | ${node.code(source)}')
 	if node_type == 'module_clause' {
 		return lsp.Hover{
-			contents: lsp.v_marked_string(node.get_text(source))
+			contents: lsp.v_marked_string(node.code(source))
 			range: tsrange_to_lsp_range(node.range())
 		}
 	} else if node_type == 'import_path' {
@@ -984,7 +984,7 @@ fn get_hover_data(mut store analyzer.Store, node C.TSNode, uri lsp.DocumentUri, 
 		sym = store.infer_symbol_from_node(closest_parent, source) ?
 	}
 
-	// eprintln('$node_type | ${node.get_text(source)} | $sym')
+	// eprintln('$node_type | ${node.code(source)} | $sym')
 
 	// Send null if range has zero-start and end points
 	if sym.range.start_point.row == 0 && sym.range.start_point.column == 0
@@ -1068,7 +1068,7 @@ fn (mut ls Vls) definition(id string, params string) {
 	offset := compute_offset(source, pos.line, pos.character)
 	mut node := traverse_node(tree.root_node(), u32(offset))
 	mut original_range := node.range()
-	node_type := node.type_name()
+	node_type := node.name()
 	if node.is_null() || (node.parent().is_error() || node.parent().is_missing()) {
 		ls.send_null(id)
 		return
@@ -1153,7 +1153,7 @@ fn (mut ls Vls) implementation(id string, params string) {
 	offset := file.get_offset(pos.line, pos.character)
 	mut node := traverse_node(tree.root_node(), u32(offset))
 	mut original_range := node.range()
-	node_type := node.type_name()
+	node_type := node.name()
 	if node.is_null() || (node.parent().is_error() || node.parent().is_missing()) {
 		ls.send_null(id)
 		return
@@ -1162,8 +1162,8 @@ fn (mut ls Vls) implementation(id string, params string) {
 	ls.store.set_active_file_path(uri.path(), file.version)
 
 	mut got_sym := analyzer.void_type
-	if node.parent().type_name() == 'interface_declaration' {
-		got_sym = ls.store.symbols[ls.store.cur_dir].get(node.get_text(source)) or { got_sym }
+	if node.parent().name() == 'interface_declaration' {
+		got_sym = ls.store.symbols[ls.store.cur_dir].get(node.code(source)) or { got_sym }
 	} else {
 		got_sym = ls.store.infer_value_type_from_node(node, source)
 	}

--- a/server/text_synchronization.v
+++ b/server/text_synchronization.v
@@ -57,7 +57,7 @@ fn (mut ls Vls) did_open(_ string, params string) {
 			// V's interop with tree sitter's parse_string is buggy sometimes
 			// especially if the code is incomplete. It reattempts to re-parse
 			// an appropriate tree by reducing decrement the source length by 1
-			if !isnil(ls.trees[file_uri]) && ls.trees[file_uri].root_node().type_name() == 'ERROR' {
+			if !isnil(ls.trees[file_uri]) && ls.trees[file_uri].root_node().name() == 'ERROR' {
 				unsafe { ls.trees[file_uri].free() }
 				ls.trees[file_uri] = ls.parser.parse_string_with_old_tree_and_len(src,
 					&C.TSTree(0), u32(src.len - 1))
@@ -188,7 +188,7 @@ fn (mut ls Vls) did_change(_ string, params string) {
 
 	// See comment in `did_open`.
 	mut new_tree := ls.parser.parse_string_with_old_tree(new_src.bytestr(), ls.trees[uri])
-	if !isnil(new_tree) && new_tree.root_node().type_name() == 'ERROR' {
+	if !isnil(new_tree) && new_tree.root_node().name() == 'ERROR' {
 		unsafe { new_tree.free() }
 		new_tree = ls.parser.parse_string_with_old_tree_and_len(new_src.bytestr(), ls.trees[uri],
 			u32(new_src.len - 1))

--- a/tree_sitter/tree_sitter.v
+++ b/tree_sitter/tree_sitter.v
@@ -129,7 +129,7 @@ fn C.ts_node_named_descendant_for_point_range(node C.TSNode, start_point C.TSPoi
 
 fn C.ts_node_eq(node C.TSNode, another_node C.TSNode) bool
 
-pub fn (node C.TSNode) get_text(text []byte) string {
+pub fn (node C.TSNode) code(text []byte) string {
 	start_index := node.start_byte()
 	end_index := node.end_byte()
 	if start_index >= end_index || start_index >= u32(text.len) || end_index > u32(text.len) {
@@ -191,7 +191,7 @@ pub fn (node C.TSNode) range() C.TSRange {
 	}
 }
 
-pub fn (node C.TSNode) type_name() string {
+pub fn (node C.TSNode) name() string {
 	if node.is_null() {
 		return '<null node>'
 	}


### PR DESCRIPTION
This PR makes cleanup in tree-sitter.v.

- Rename `node.type_name()` to `node.name()`.
- Rename `node.get_text()` to `node.code()`.
- Modify all the related calls.