### PR TITLE
all: cleanup tree_sitter_v

### DIFF
--- a/analyzer/analyzer.v
+++ b/analyzer/analyzer.v
@@ -112,13 +112,11 @@ fn (mut an Analyzer) fn_decl(node C.TSNode) {
 
 pub fn (mut an Analyzer) top_level_statement() {
 	current_node := an.cursor.current_node()
-	node_type := current_node.name()
 	defer {
 		an.cursor.next()
-		// unsafe { node_type.free() }
 	}
 
-	match node_type {
+	match current_node.type_name() {
 		'import_declaration' {
 			an.import_decl(current_node)
 		}

--- a/analyzer/ast.v
+++ b/analyzer/ast.v
@@ -15,10 +15,10 @@ fn get_nodes_within_range(node C.TSNode, range C.TSRange) ?[]C.TSNode {
 
 	for i in u32(0) .. child_count {
 		child := node.named_child(i)
-		child_type := child.name()
+		type_name := child.type_name()
 		if !child.is_null()
-			&& ((child_type.ends_with('_declaration') && child_type !in analyzer.excluded_nodes)
-			|| child_type in analyzer.included_nodes) && within_range(child.range(), range) {
+			&& ((type_name.ends_with('_declaration') && type_name !in analyzer.excluded_nodes)
+			|| type_name in analyzer.included_nodes) && within_range(child.range(), range) {
 			nodes << child
 		} else {
 			nodes << get_nodes_within_range(child, range) or { continue }

--- a/analyzer/symbol_registration.v
+++ b/analyzer/symbol_registration.v
@@ -24,9 +24,9 @@ mut:
 }
 
 fn (sr &SymbolRegistration) new_top_level_symbol(identifier_node C.TSNode, access SymbolAccess, kind SymbolKind) ?&Symbol {
-	id_node_type := identifier_node.name()
-	if id_node_type == 'qualified_type' {
-		return report_error('Invalid top-level node type `$id_node_type`', identifier_node.range())
+	id_node_type_name := identifier_node.type_name()
+	if id_node_type_name == 'qualified_type' {
+		return report_error('Invalid top-level node type `$id_node_type_name`', identifier_node.range())
 	}
 
 	mut symbol := &Symbol{
@@ -37,10 +37,10 @@ fn (sr &SymbolRegistration) new_top_level_symbol(identifier_node C.TSNode, acces
 		file_version: sr.store.cur_version
 	}
 
-	match id_node_type {
+	match id_node_type_name {
 		'generic_type' {
-			if identifier_node.named_child(0).name() == 'generic_type' {
-				return error('Invalid top-level generic node type `$id_node_type`')
+			if identifier_node.named_child(0).type_name() == 'generic_type' {
+				return error('Invalid top-level generic node type `$id_node_type_name`')
 			}
 
 			// unsafe { symbol.free() }
@@ -52,7 +52,7 @@ fn (sr &SymbolRegistration) new_top_level_symbol(identifier_node C.TSNode, acces
 			symbol.name = identifier_node.code(sr.src_text)
 			symbol.range = identifier_node.range()
 
-			if id_node_type == 'binded_type' || id_node_type == 'binded_identifier' {
+			if id_node_type_name in ['binded_type', 'binded_identifier'] {
 				sym_language := identifier_node.child_by_field_name('language').code(sr.src_text)
 				symbol.language = match sym_language {
 					'C' { SymbolLanguage.c }
@@ -62,7 +62,7 @@ fn (sr &SymbolRegistration) new_top_level_symbol(identifier_node C.TSNode, acces
 			}
 
 			// for function names with generic parameters
-			if identifier_node.next_named_sibling().name() == 'type_parameters' {
+			if identifier_node.next_named_sibling().type_name() == 'type_parameters' {
 				symbol.generic_placeholder_len = int(identifier_node.next_named_sibling().named_child_count())
 			}
 		}
@@ -81,7 +81,7 @@ fn (mut sr SymbolRegistration) get_scope(node C.TSNode) ?&ScopeTree {
 
 fn (mut sr SymbolRegistration) const_decl(const_node C.TSNode) ?[]&Symbol {
 	mut access := SymbolAccess.private
-	if const_node.child(0).name() == 'pub' {
+	if const_node.child(0).type_name() == 'pub' {
 		access = .public
 	}
 
@@ -113,7 +113,7 @@ fn (mut sr SymbolRegistration) const_decl(const_node C.TSNode) ?[]&Symbol {
 
 fn (mut sr SymbolRegistration) struct_decl(struct_decl_node C.TSNode) ?&Symbol {
 	mut access := SymbolAccess.private
-	if struct_decl_node.child(0).name() == 'pub' {
+	if struct_decl_node.child(0).type_name() == 'pub' {
 		access = .public
 	}
 
@@ -126,8 +126,7 @@ fn (mut sr SymbolRegistration) struct_decl(struct_decl_node C.TSNode) ?&Symbol {
 	mut field_access := SymbolAccess.private
 	for i in 0 .. fields_len {
 		field_node := decl_list_node.named_child(i)
-		field_type := field_node.name()
-		match field_type {
+		match field_node.type_name() {
 			'struct_field_scope' {
 				scope_text := field_node.code(sr.src_text)
 				field_access = match scope_text {
@@ -191,7 +190,7 @@ fn (mut sr SymbolRegistration) struct_field_decl(field_access SymbolAccess, fiel
 
 fn (mut sr SymbolRegistration) interface_decl(interface_decl_node C.TSNode) ?&Symbol {
 	mut access := SymbolAccess.private
-	if interface_decl_node.child(0).name() == 'pub' {
+	if interface_decl_node.child(0).type_name() == 'pub' {
 		access = SymbolAccess.public
 	}
 
@@ -206,7 +205,7 @@ fn (mut sr SymbolRegistration) interface_decl(interface_decl_node C.TSNode) ?&Sy
 			continue
 		}
 
-		match field_node.name() {
+		match field_node.type_name() {
 			'interface_field_scope' {
 				// TODO: add if mut: check
 				access = .private_mutable
@@ -268,7 +267,7 @@ fn (mut sr SymbolRegistration) interface_decl(interface_decl_node C.TSNode) ?&Sy
 
 fn (mut sr SymbolRegistration) enum_decl(enum_decl_node C.TSNode) ?&Symbol {
 	mut access := SymbolAccess.private
-	if enum_decl_node.child(0).name() == 'pub' {
+	if enum_decl_node.child(0).type_name() == 'pub' {
 		access = SymbolAccess.public
 	}
 
@@ -278,7 +277,7 @@ fn (mut sr SymbolRegistration) enum_decl(enum_decl_node C.TSNode) ?&Symbol {
 	members_len := member_list_node.named_child_count()
 	for i in 0 .. members_len {
 		member_node := member_list_node.named_child(i)
-		if member_node.name() != 'enum_member' {
+		if member_node.type_name() != 'enum_member' {
 			continue
 		}
 
@@ -318,7 +317,7 @@ fn (mut sr SymbolRegistration) enum_decl(enum_decl_node C.TSNode) ?&Symbol {
 
 fn (mut sr SymbolRegistration) fn_decl(fn_node C.TSNode) ?&Symbol {
 	mut access := SymbolAccess.private
-	if fn_node.child(0).name() == 'pub' {
+	if fn_node.child(0).type_name() == 'pub' {
 		access = SymbolAccess.public
 	}
 
@@ -383,7 +382,7 @@ fn (mut sr SymbolRegistration) fn_decl(fn_node C.TSNode) ?&Symbol {
 
 fn (mut sr SymbolRegistration) type_decl(type_decl_node C.TSNode) ?&Symbol {
 	mut access := SymbolAccess.private
-	if type_decl_node.child(0).name() == 'pub' {
+	if type_decl_node.child(0).type_name() == 'pub' {
 		access = SymbolAccess.public
 	}
 
@@ -426,9 +425,9 @@ fn (mut sr SymbolRegistration) top_level_decl() ? {
 	}
 
 	mut global_scope := sr.store.opened_scopes[sr.store.cur_file_path]
-	node_type := sr.cursor.current_node().name()
+	node_type_name := sr.cursor.current_node().type_name()
 
-	match node_type {
+	match node_type_name {
 		// TODO: add module check
 		// 'module_clause' {
 		// 	module_name := os.base(ss.cur_dir)
@@ -474,7 +473,7 @@ fn (mut sr SymbolRegistration) top_level_decl() ? {
 		}
 		else {
 			stmt_node := sr.cursor.current_node()
-			if node_type == 'short_var_declaration' {
+			if node_type_name == 'short_var_declaration' {
 				sr.is_script = true
 				sr.first_var_decl_pos = stmt_node.range()
 
@@ -506,11 +505,11 @@ fn (mut sr SymbolRegistration) short_var_decl(var_decl C.TSNode) ?[]&Symbol {
 			left := left_expr_lists.named_child(j)
 			right := right_expr_lists.named_child(j)
 			prev_left := left.prev_sibling()
-			if !prev_left.is_null() && prev_left.name() == 'mut' {
+			if !prev_left.is_null() && prev_left.type_name() == 'mut' {
 				var_access = .private_mutable
 			}
 
-			if right.name() == 'fn_literal' {
+			if right.type_name() == 'fn_literal' {
 				sr.fn_literal(right) or {}
 			}
 
@@ -576,7 +575,7 @@ fn (mut sr SymbolRegistration) if_expression(if_stmt_node C.TSNode) ? {
 		return
 	}
 
-	if alternative_node.name() == 'block' {
+	if alternative_node.type_name() == 'block' {
 		mut local_scope := sr.get_scope(if_stmt_node) or { &ScopeTree(0) }
 		sr.extract_block(if_stmt_node, mut local_scope) ?
 	} else {
@@ -591,7 +590,7 @@ fn (mut sr SymbolRegistration) for_statement(for_stmt_node C.TSNode) ? {
 
 	if named_child_count == 2 {
 		cond_node := for_stmt_node.named_child(0)
-		cond_node_type := cond_node.name()
+		cond_node_type := cond_node.type_name()
 
 		if cond_node_type == 'for_in_operator' {
 			left_node := cond_node.child_by_field_name('left')
@@ -663,8 +662,7 @@ fn (mut sr SymbolRegistration) for_statement(for_stmt_node C.TSNode) ? {
 }
 
 fn (mut sr SymbolRegistration) expression(node C.TSNode) ? {
-	expr_type := node.name()
-	match expr_type {
+	match node.type_name() {
 		'if_expression' {
 			sr.if_expression(node) ?
 		}
@@ -675,8 +673,7 @@ fn (mut sr SymbolRegistration) expression(node C.TSNode) ? {
 }
 
 fn (mut sr SymbolRegistration) statement(node C.TSNode, mut scope ScopeTree) ? {
-	stmt_type := node.name()
-	match stmt_type {
+	match node.type_name() {
 		'short_var_declaration' {
 			vars := sr.short_var_decl(node) ?
 			for var in vars {
@@ -697,7 +694,7 @@ fn (mut sr SymbolRegistration) statement(node C.TSNode, mut scope ScopeTree) ? {
 }
 
 fn (mut sr SymbolRegistration) extract_block(node C.TSNode, mut scope ScopeTree) ? {
-	if node.name() != 'block' || sr.is_import {
+	if node.type_name() != 'block' || sr.is_import {
 		return error('node should be a `block` and cannot be used in `is_import` mode.')
 	}
 
@@ -715,7 +712,7 @@ fn extract_parameter_list(node C.TSNode, mut store Store, src_text []byte) []&Sy
 	for i := u32(0); i < params_len; i++ {
 		mut access := SymbolAccess.private
 		param_node := node.named_child(i)
-		if param_node.child(0).name() == 'mut' {
+		if param_node.child(0).type_name() == 'mut' {
 			access = SymbolAccess.private_mutable
 		}
 

--- a/server/ast.v
+++ b/server/ast.v
@@ -10,17 +10,17 @@ const other_node_types = ['if_expression', 'for_statement', 'return_statement', 
 	'binary_expression', 'unary_expression']
 
 fn traverse_node(root_node C.TSNode, offset u32) C.TSNode {
-	root_type := root_node.name()
+	root_type_name := root_node.type_name()
 	direct_named_child := root_node.first_named_child_for_byte(offset)
-	child_type := direct_named_child.name()
+	child_type_name := direct_named_child.type_name()
 	if direct_named_child.is_null() {
 		return root_node
 	}
 
-	if (!root_type.ends_with('_declaration') && root_type !in server.list_node_types
-		&& root_type !in server.other_node_types)
-		&& (child_type.ends_with('identifier') || child_type == 'builtin_type') {
-		if root_type == 'selector_expression' {
+	if (!root_type_name.ends_with('_declaration') && root_type_name !in server.list_node_types
+		&& root_type_name !in server.other_node_types)
+		&& (child_type_name.ends_with('identifier') || child_type_name == 'builtin_type') {
+		if root_type_name == 'selector_expression' {
 			root_children_count := root_node.named_child_count()
 			for i := u32(0); i < root_children_count; i++ {
 				selected_child_node := root_node.named_child(i)
@@ -28,7 +28,7 @@ fn traverse_node(root_node C.TSNode, offset u32) C.TSNode {
 					return direct_named_child
 				}
 			}
-		} else if root_type == 'index_expression' {
+		} else if root_type_name == 'index_expression' {
 			index_node := root_node.child_by_field_name('index')
 			if index_node.range().eq(direct_named_child.range()) {
 				return direct_named_child
@@ -50,12 +50,12 @@ fn traverse_node(root_node C.TSNode, offset u32) C.TSNode {
 // for auto-completion
 fn traverse_node2(starting_node C.TSNode, offset u32) C.TSNode {
 	mut root_node := starting_node
-	mut root_type := root_node.name()
+	mut root_type_name := root_node.type_name()
 
 	direct_named_child := root_node.first_named_child_for_byte(offset)
-	child_type := direct_named_child.name()
+	child_type_name := direct_named_child.type_name()
 
-	if child_type.ends_with('_literal') {
+	if child_type_name.ends_with('_literal') {
 		return root_node
 	}
 
@@ -68,10 +68,10 @@ fn traverse_node2(starting_node C.TSNode, offset u32) C.TSNode {
 		return root_node
 	}
 
-	if (!root_type.ends_with('_declaration') && root_type !in server.list_node_types
-		&& root_type != 'block')
-		&& (child_type.ends_with('identifier') || child_type == 'builtin_type') {
-		if root_type == 'selector_expression' {
+	if (!root_type_name.ends_with('_declaration') && root_type_name !in server.list_node_types
+		&& root_type_name != 'block')
+		&& (child_type_name.ends_with('identifier') || child_type_name == 'builtin_type') {
+		if root_type_name == 'selector_expression' {
 			root_children_count := root_node.named_child_count()
 			for i := u32(0); i < root_children_count; i++ {
 				selected_child_node := root_node.named_child(i)
@@ -79,7 +79,7 @@ fn traverse_node2(starting_node C.TSNode, offset u32) C.TSNode {
 					return direct_named_child
 				}
 			}
-		} else if root_type == 'index_expression' {
+		} else if root_type_name == 'index_expression' {
 			index_node := root_node.child_by_field_name('index')
 			if index_node.range().eq(direct_named_child.range()) {
 				return direct_named_child
@@ -104,7 +104,7 @@ fn closest_named_child(starting_node C.TSNode, offset u32) C.TSNode {
 	for i in u32(0) .. named_child_count {
 		child_node := starting_node.named_child(i)
 		if !child_node.is_null() && child_node.start_byte() <= offset
-			&& (child_node.name() == 'import_symbols' || child_node.end_byte() <= offset) {
+			&& (child_node.type_name() == 'import_symbols' || child_node.end_byte() <= offset) {
 			selected_node = child_node
 		} else {
 			break
@@ -122,12 +122,13 @@ const other_symbol_node_types = ['assignment_statement', 'call_expression', 'sel
 // (nodes with names, module name, and etc.)
 fn closest_symbol_node_parent(child_node C.TSNode) C.TSNode {
 	parent_node := child_node.parent()
-	parent_type := parent_node.name()
-	if parent_node.is_null() || parent_type == 'source_file' || parent_type == 'block' {
+	parent_type_name := parent_node.type_name()
+	if parent_node.is_null() || parent_type_name == 'source_file' || parent_type_name == 'block' {
 		return child_node
 	}
 
-	if parent_type.ends_with('_declaration') || parent_type in server.other_symbol_node_types {
+	if parent_type_name.ends_with('_declaration')
+		|| parent_type_name in server.other_symbol_node_types {
 		return parent_node
 	}
 

--- a/server/text_synchronization.v
+++ b/server/text_synchronization.v
@@ -57,7 +57,7 @@ fn (mut ls Vls) did_open(_ string, params string) {
 			// V's interop with tree sitter's parse_string is buggy sometimes
 			// especially if the code is incomplete. It reattempts to re-parse
 			// an appropriate tree by reducing decrement the source length by 1
-			if !isnil(ls.trees[file_uri]) && ls.trees[file_uri].root_node().name() == 'ERROR' {
+			if !isnil(ls.trees[file_uri]) && ls.trees[file_uri].root_node().type_name() == 'ERROR' {
 				unsafe { ls.trees[file_uri].free() }
 				ls.trees[file_uri] = ls.parser.parse_string_with_old_tree_and_len(src,
 					&C.TSTree(0), u32(src.len - 1))
@@ -188,7 +188,7 @@ fn (mut ls Vls) did_change(_ string, params string) {
 
 	// See comment in `did_open`.
 	mut new_tree := ls.parser.parse_string_with_old_tree(new_src.bytestr(), ls.trees[uri])
-	if !isnil(new_tree) && new_tree.root_node().name() == 'ERROR' {
+	if !isnil(new_tree) && new_tree.root_node().type_name() == 'ERROR' {
 		unsafe { new_tree.free() }
 		new_tree = ls.parser.parse_string_with_old_tree_and_len(new_src.bytestr(), ls.trees[uri],
 			u32(new_src.len - 1))

--- a/tree_sitter/tree_sitter.v
+++ b/tree_sitter/tree_sitter.v
@@ -191,7 +191,7 @@ pub fn (node C.TSNode) range() C.TSRange {
 	}
 }
 
-pub fn (node C.TSNode) name() string {
+pub fn (node C.TSNode) type_name() string {
 	if node.is_null() {
 		return '<null node>'
 	}


### PR DESCRIPTION
This PR makes cleanup in tree_sitter_v.

- Restore `node.name()` to `node.type_name()`.
- Modify all the related calls.