### PR TITLE
vls: cleanup symbol definition

### DIFF
--- a/analyzer/builtin.v
+++ b/analyzer/builtin.v
@@ -68,7 +68,7 @@ pub fn register_builtin_symbols(mut ss Store, builtin_import &Import) {
 				kind: .array_
 				access: .public
 				is_top_level: true
-				children: [returned_sym]
+				children_syms: [returned_sym]
 				file_path: os.join_path(builtin_path, 'array.vv')
 				file_version: 0
 			}

--- a/analyzer/symbol_registration.v
+++ b/analyzer/symbol_registration.v
@@ -608,7 +608,7 @@ fn (mut sr SymbolRegistration) for_statement(for_stmt_node C.TSNode) ? {
 						idx_node := left_node.named_child(end_idx - 1)
 						mut return_sym := sr.store.find_symbol('', 'int') or { void_sym }
 						if right_sym.kind == .map_ {
-							return_sym = right_sym.children[1] or { void_sym }
+							return_sym = right_sym.children_syms[1] or { void_sym }
 						}
 
 						mut idx_sym := Symbol{


### PR DESCRIPTION
This PR makes cleanup of symbol definition.

- `Symbol.children` change to `Symbol.children_syms`.