### PR TITLE
server: move `testing` module outside of server/, rename to `test_utils`

### DIFF
--- a/server/connection_test.v
+++ b/server/connection_test.v
@@ -1,6 +1,6 @@
 import server
 import os
-import server.testing
+import test_utils
 import net
 
 fn launch_cmd(exec_path string, args ...string) &os.Process {
@@ -64,7 +64,7 @@ fn compile_and_start_vls(args ...string) ?&os.Process {
 }
 
 fn test_stdio_connect() ? {
-	mut io := testing.Testio{}
+	mut io := test_utils.Testio{}
 	mut p := compile_and_start_vls() ?
 	defer {
 		p.close()
@@ -85,7 +85,7 @@ fn test_tcp_connect() ? {
 	$if windows {
 		return
 	}
-	mut io := testing.Testio{}
+	mut io := test_utils.Testio{}
 	mut p := compile_and_start_vls('--socket', '--port=5007') ?
 	defer {
 		p.close()

--- a/server/general_test.v
+++ b/server/general_test.v
@@ -1,10 +1,10 @@
 import server
-import server.testing
+import test_utils
 import lsp
 import json
 
 fn test_wrong_first_request() ? {
-	mut io := &testing.Testio{}
+	mut io := &test_utils.Testio{}
 	mut ls := server.new(io)
 	payload := io.request('shutdown')
 	ls.dispatch(payload)
@@ -37,7 +37,7 @@ fn test_initialized() {
 // 	assert status == .shutdown
 // }
 fn test_set_features() {
-	mut io := &testing.Testio{}
+	mut io := &test_utils.Testio{}
 	mut ls := server.new(io)
 	assert ls.features() == server.default_features_list
 	ls.set_features(['formatting'], false) or {
@@ -77,8 +77,8 @@ fn test_set_features() {
 	}
 }
 
-fn init_tests() (&testing.Testio, server.Vls) {
-	mut io := &testing.Testio{}
+fn init_tests() (&test_utils.Testio, server.Vls) {
+	mut io := &test_utils.Testio{}
 	mut ls := server.new(io)
 	payload := io.request('initialize')
 	ls.dispatch(payload)

--- a/server/tests/completion_test.v
+++ b/server/tests/completion_test.v
@@ -1,5 +1,5 @@
 import server
-import server.testing
+import test_utils
 import json
 import lsp
 import os
@@ -425,13 +425,13 @@ const completion_results = {
 }
 
 fn test_completion() {
-	mut io := &testing.Testio{}
+	mut io := &test_utils.Testio{}
 	mut ls := server.new(io)
 	ls.dispatch(io.request_with_params('initialize', lsp.InitializeParams{
 		root_uri: lsp.document_uri_from_path(os.join_path(os.dir(@FILE), 'test_files',
 			'completion'))
 	}))
-	test_files := testing.load_test_file_paths('completion') or {
+	test_files := test_utils.load_test_file_paths('completion') or {
 		io.bench.fail()
 		eprintln(io.bench.step_message_fail(err.msg))
 		assert false

--- a/server/tests/completion_test.v
+++ b/server/tests/completion_test.v
@@ -425,7 +425,9 @@ const completion_results = {
 }
 
 fn test_completion() {
-	mut io := &test_utils.Testio{ test_files_dir: test_utils.get_test_files_path(@FILE) }
+	mut io := &test_utils.Testio{
+		test_files_dir: test_utils.get_test_files_path(@FILE)
+	}
 	mut ls := server.new(io)
 	ls.dispatch(io.request_with_params('initialize', lsp.InitializeParams{
 		root_uri: lsp.document_uri_from_path(os.join_path(os.dir(@FILE), 'test_files',

--- a/server/tests/completion_test.v
+++ b/server/tests/completion_test.v
@@ -425,13 +425,13 @@ const completion_results = {
 }
 
 fn test_completion() {
-	mut io := &test_utils.Testio{}
+	mut io := &test_utils.Testio{ test_files_dir: test_utils.get_test_files_path(@FILE) }
 	mut ls := server.new(io)
 	ls.dispatch(io.request_with_params('initialize', lsp.InitializeParams{
 		root_uri: lsp.document_uri_from_path(os.join_path(os.dir(@FILE), 'test_files',
 			'completion'))
 	}))
-	test_files := test_utils.load_test_file_paths('completion') or {
+	test_files := io.load_test_file_paths('completion') or {
 		io.bench.fail()
 		eprintln(io.bench.step_message_fail(err.msg))
 		assert false

--- a/server/tests/definition_test.v
+++ b/server/tests/definition_test.v
@@ -380,12 +380,12 @@ const definition_results = {
 }
 
 fn test_definition() {
-	mut io := test_utils.Testio{}
+	mut io := test_utils.Testio{ test_files_dir: test_utils.get_test_files_path(@FILE) }
 	mut ls := server.new(io)
 	ls.dispatch(io.request_with_params('initialize', lsp.InitializeParams{
 		root_uri: lsp.document_uri_from_path(base_dir)
 	}))
-	test_files := test_utils.load_test_file_paths('definition') or {
+	test_files := io.load_test_file_paths('definition') or {
 		io.bench.fail()
 		eprintln(io.bench.step_message_fail(err.msg))
 		assert false

--- a/server/tests/definition_test.v
+++ b/server/tests/definition_test.v
@@ -380,7 +380,9 @@ const definition_results = {
 }
 
 fn test_definition() {
-	mut io := test_utils.Testio{ test_files_dir: test_utils.get_test_files_path(@FILE) }
+	mut io := test_utils.Testio{
+		test_files_dir: test_utils.get_test_files_path(@FILE)
+	}
 	mut ls := server.new(io)
 	ls.dispatch(io.request_with_params('initialize', lsp.InitializeParams{
 		root_uri: lsp.document_uri_from_path(base_dir)

--- a/server/tests/definition_test.v
+++ b/server/tests/definition_test.v
@@ -1,5 +1,5 @@
 import server
-import server.testing
+import test_utils
 import json
 import lsp
 import os
@@ -380,12 +380,12 @@ const definition_results = {
 }
 
 fn test_definition() {
-	mut io := testing.Testio{}
+	mut io := test_utils.Testio{}
 	mut ls := server.new(io)
 	ls.dispatch(io.request_with_params('initialize', lsp.InitializeParams{
 		root_uri: lsp.document_uri_from_path(base_dir)
 	}))
-	test_files := testing.load_test_file_paths('definition') or {
+	test_files := test_utils.load_test_file_paths('definition') or {
 		io.bench.fail()
 		eprintln(io.bench.step_message_fail(err.msg))
 		assert false

--- a/server/tests/diagnostics_test.v
+++ b/server/tests/diagnostics_test.v
@@ -44,7 +44,9 @@ const diagnostics_results = {
 }
 
 fn test_diagnostics() {
-	mut io := &test_utils.Testio{ test_files_dir: test_utils.get_test_files_path(@FILE) }
+	mut io := &test_utils.Testio{
+		test_files_dir: test_utils.get_test_files_path(@FILE)
+	}
 	mut ls := server.new(io)
 	ls.dispatch(io.request('initialize'))
 	files := io.load_test_file_paths('diagnostics') or {

--- a/server/tests/diagnostics_test.v
+++ b/server/tests/diagnostics_test.v
@@ -1,5 +1,5 @@
 import server
-import server.testing
+import test_utils
 import json
 import lsp
 import os
@@ -44,10 +44,10 @@ const diagnostics_results = {
 }
 
 fn test_diagnostics() {
-	mut io := &testing.Testio{}
+	mut io := &test_utils.Testio{}
 	mut ls := server.new(io)
 	ls.dispatch(io.request('initialize'))
-	files := testing.load_test_file_paths('diagnostics') or {
+	files := test_utils.load_test_file_paths('diagnostics') or {
 		io.bench.fail()
 		eprintln(io.bench.step_message_fail(err.msg))
 		assert false

--- a/server/tests/diagnostics_test.v
+++ b/server/tests/diagnostics_test.v
@@ -44,10 +44,10 @@ const diagnostics_results = {
 }
 
 fn test_diagnostics() {
-	mut io := &test_utils.Testio{}
+	mut io := &test_utils.Testio{ test_files_dir: test_utils.get_test_files_path(@FILE) }
 	mut ls := server.new(io)
 	ls.dispatch(io.request('initialize'))
-	files := test_utils.load_test_file_paths('diagnostics') or {
+	files := io.load_test_file_paths('diagnostics') or {
 		io.bench.fail()
 		eprintln(io.bench.step_message_fail(err.msg))
 		assert false

--- a/server/tests/document_symbols_test.v
+++ b/server/tests/document_symbols_test.v
@@ -82,10 +82,10 @@ const doc_symbols_result = {
 }
 
 fn test_document_symbols() {
-	mut io := &test_utils.Testio{}
+	mut io := &test_utils.Testio{ test_files_dir: test_utils.get_test_files_path(@FILE) }
 	mut ls := server.new(io)
 	ls.dispatch(io.request('initialize'))
-	test_files := test_utils.load_test_file_paths('document_symbols') or {
+	test_files := io.load_test_file_paths('document_symbols') or {
 		io.bench.fail()
 		eprintln(io.bench.step_message_fail(err.msg))
 		assert false

--- a/server/tests/document_symbols_test.v
+++ b/server/tests/document_symbols_test.v
@@ -1,5 +1,5 @@
 import server
-import server.testing
+import test_utils
 import json
 import lsp
 import os
@@ -82,10 +82,10 @@ const doc_symbols_result = {
 }
 
 fn test_document_symbols() {
-	mut io := &testing.Testio{}
+	mut io := &test_utils.Testio{}
 	mut ls := server.new(io)
 	ls.dispatch(io.request('initialize'))
-	test_files := testing.load_test_file_paths('document_symbols') or {
+	test_files := test_utils.load_test_file_paths('document_symbols') or {
 		io.bench.fail()
 		eprintln(io.bench.step_message_fail(err.msg))
 		assert false

--- a/server/tests/document_symbols_test.v
+++ b/server/tests/document_symbols_test.v
@@ -82,7 +82,9 @@ const doc_symbols_result = {
 }
 
 fn test_document_symbols() {
-	mut io := &test_utils.Testio{ test_files_dir: test_utils.get_test_files_path(@FILE) }
+	mut io := &test_utils.Testio{
+		test_files_dir: test_utils.get_test_files_path(@FILE)
+	}
 	mut ls := server.new(io)
 	ls.dispatch(io.request('initialize'))
 	test_files := io.load_test_file_paths('document_symbols') or {

--- a/server/tests/folding_range_test.v
+++ b/server/tests/folding_range_test.v
@@ -50,7 +50,9 @@ const folding_range_results = {
 }
 
 fn test_folding_range() {
-	mut io := test_utils.Testio{ test_files_dir: test_utils.get_test_files_path(@FILE) }
+	mut io := test_utils.Testio{
+		test_files_dir: test_utils.get_test_files_path(@FILE)
+	}
 	mut ls := server.new(io)
 	ls.dispatch(io.request_with_params('initialize', lsp.InitializeParams{
 		root_uri: lsp.document_uri_from_path(os.join_path(os.dir(@FILE), 'test_files',

--- a/server/tests/folding_range_test.v
+++ b/server/tests/folding_range_test.v
@@ -1,5 +1,5 @@
 import server
-import server.testing
+import test_utils
 import json
 import lsp
 import os
@@ -50,13 +50,13 @@ const folding_range_results = {
 }
 
 fn test_folding_range() {
-	mut io := testing.Testio{}
+	mut io := test_utils.Testio{}
 	mut ls := server.new(io)
 	ls.dispatch(io.request_with_params('initialize', lsp.InitializeParams{
 		root_uri: lsp.document_uri_from_path(os.join_path(os.dir(@FILE), 'test_files',
 			'folding_range'))
 	}))
-	test_files := testing.load_test_file_paths('folding_range') or {
+	test_files := test_utils.load_test_file_paths('folding_range') or {
 		io.bench.fail()
 		eprintln(io.bench.step_message_fail(err.msg))
 		// assert false

--- a/server/tests/folding_range_test.v
+++ b/server/tests/folding_range_test.v
@@ -50,13 +50,13 @@ const folding_range_results = {
 }
 
 fn test_folding_range() {
-	mut io := test_utils.Testio{}
+	mut io := test_utils.Testio{ test_files_dir: test_utils.get_test_files_path(@FILE) }
 	mut ls := server.new(io)
 	ls.dispatch(io.request_with_params('initialize', lsp.InitializeParams{
 		root_uri: lsp.document_uri_from_path(os.join_path(os.dir(@FILE), 'test_files',
 			'folding_range'))
 	}))
-	test_files := test_utils.load_test_file_paths('folding_range') or {
+	test_files := io.load_test_file_paths('folding_range') or {
 		io.bench.fail()
 		eprintln(io.bench.step_message_fail(err.msg))
 		// assert false

--- a/server/tests/formatting_test.v
+++ b/server/tests/formatting_test.v
@@ -5,10 +5,10 @@ import lsp
 import os
 
 fn test_formatting() {
-	mut io := &test_utils.Testio{}
+	mut io := &test_utils.Testio{ test_files_dir: test_utils.get_test_files_path(@FILE) }
 	mut ls := server.new(io)
 	ls.dispatch(io.request('initialize'))
-	test_files := test_utils.load_test_file_paths('formatting') or {
+	test_files := io.load_test_file_paths('formatting') or {
 		io.bench.fail()
 		eprintln(io.bench.step_message_fail(err.msg))
 		assert false

--- a/server/tests/formatting_test.v
+++ b/server/tests/formatting_test.v
@@ -5,7 +5,9 @@ import lsp
 import os
 
 fn test_formatting() {
-	mut io := &test_utils.Testio{ test_files_dir: test_utils.get_test_files_path(@FILE) }
+	mut io := &test_utils.Testio{
+		test_files_dir: test_utils.get_test_files_path(@FILE)
+	}
 	mut ls := server.new(io)
 	ls.dispatch(io.request('initialize'))
 	test_files := io.load_test_file_paths('formatting') or {

--- a/server/tests/formatting_test.v
+++ b/server/tests/formatting_test.v
@@ -1,14 +1,14 @@
 import server
-import server.testing
+import test_utils
 import json
 import lsp
 import os
 
 fn test_formatting() {
-	mut io := &testing.Testio{}
+	mut io := &test_utils.Testio{}
 	mut ls := server.new(io)
 	ls.dispatch(io.request('initialize'))
-	test_files := testing.load_test_file_paths('formatting') or {
+	test_files := test_utils.load_test_file_paths('formatting') or {
 		io.bench.fail()
 		eprintln(io.bench.step_message_fail(err.msg))
 		assert false

--- a/server/tests/hover_test.v
+++ b/server/tests/hover_test.v
@@ -217,7 +217,9 @@ const hover_results = {
 }
 
 fn test_hover() {
-	mut io := test_utils.Testio{ test_files_dir: test_utils.get_test_files_path(@FILE) }
+	mut io := test_utils.Testio{
+		test_files_dir: test_utils.get_test_files_path(@FILE)
+	}
 	mut ls := server.new(io)
 	ls.dispatch(io.request_with_params('initialize', lsp.InitializeParams{
 		root_uri: lsp.document_uri_from_path(os.join_path(os.dir(@FILE), 'test_files',

--- a/server/tests/hover_test.v
+++ b/server/tests/hover_test.v
@@ -1,5 +1,5 @@
 import server
-import server.testing
+import test_utils
 import json
 import lsp
 import os
@@ -217,13 +217,13 @@ const hover_results = {
 }
 
 fn test_hover() {
-	mut io := testing.Testio{}
+	mut io := test_utils.Testio{}
 	mut ls := server.new(io)
 	ls.dispatch(io.request_with_params('initialize', lsp.InitializeParams{
 		root_uri: lsp.document_uri_from_path(os.join_path(os.dir(@FILE), 'test_files',
 			'hover'))
 	}))
-	test_files := testing.load_test_file_paths('hover') or {
+	test_files := test_utils.load_test_file_paths('hover') or {
 		io.bench.fail()
 		eprintln(io.bench.step_message_fail(err.msg))
 		assert false

--- a/server/tests/hover_test.v
+++ b/server/tests/hover_test.v
@@ -217,13 +217,13 @@ const hover_results = {
 }
 
 fn test_hover() {
-	mut io := test_utils.Testio{}
+	mut io := test_utils.Testio{ test_files_dir: test_utils.get_test_files_path(@FILE) }
 	mut ls := server.new(io)
 	ls.dispatch(io.request_with_params('initialize', lsp.InitializeParams{
 		root_uri: lsp.document_uri_from_path(os.join_path(os.dir(@FILE), 'test_files',
 			'hover'))
 	}))
-	test_files := test_utils.load_test_file_paths('hover') or {
+	test_files := io.load_test_file_paths('hover') or {
 		io.bench.fail()
 		eprintln(io.bench.step_message_fail(err.msg))
 		assert false

--- a/server/tests/implementation_test.v
+++ b/server/tests/implementation_test.v
@@ -1,5 +1,5 @@
 import server
-import server.testing
+import test_utils
 import json
 import lsp
 import os
@@ -48,12 +48,12 @@ const implementation_results = {
 const implementation_should_return_null = []string{}
 
 fn test_implementation() {
-	mut io := testing.Testio{}
+	mut io := test_utils.Testio{}
 	mut ls := server.new(io)
 	ls.dispatch(io.request_with_params('initialize', lsp.InitializeParams{
 		root_uri: lsp.document_uri_from_path(base_dir)
 	}))
-	test_files := testing.load_test_file_paths('implementation') or {
+	test_files := test_utils.load_test_file_paths('implementation') or {
 		io.bench.fail()
 		eprintln(io.bench.step_message_fail(err.msg))
 		assert false

--- a/server/tests/implementation_test.v
+++ b/server/tests/implementation_test.v
@@ -48,12 +48,12 @@ const implementation_results = {
 const implementation_should_return_null = []string{}
 
 fn test_implementation() {
-	mut io := test_utils.Testio{}
+	mut io := test_utils.Testio{ test_files_dir: test_utils.get_test_files_path(@FILE) }
 	mut ls := server.new(io)
 	ls.dispatch(io.request_with_params('initialize', lsp.InitializeParams{
 		root_uri: lsp.document_uri_from_path(base_dir)
 	}))
-	test_files := test_utils.load_test_file_paths('implementation') or {
+	test_files := io.load_test_file_paths('implementation') or {
 		io.bench.fail()
 		eprintln(io.bench.step_message_fail(err.msg))
 		assert false

--- a/server/tests/implementation_test.v
+++ b/server/tests/implementation_test.v
@@ -48,7 +48,9 @@ const implementation_results = {
 const implementation_should_return_null = []string{}
 
 fn test_implementation() {
-	mut io := test_utils.Testio{ test_files_dir: test_utils.get_test_files_path(@FILE) }
+	mut io := test_utils.Testio{
+		test_files_dir: test_utils.get_test_files_path(@FILE)
+	}
 	mut ls := server.new(io)
 	ls.dispatch(io.request_with_params('initialize', lsp.InitializeParams{
 		root_uri: lsp.document_uri_from_path(base_dir)

--- a/server/tests/positions_test.v
+++ b/server/tests/positions_test.v
@@ -18,7 +18,8 @@ const compute_offset_results = {
 
 fn test_compute_offset() {
 	mut bench := benchmark.new_benchmark()
-	test_files := test_utils.load_test_file_paths(test_utils.get_test_files_path(@FILE), 'pos_compute_offset') or {
+	test_files := test_utils.load_test_file_paths(test_utils.get_test_files_path(@FILE),
+		'pos_compute_offset') or {
 		bench.fail()
 		eprintln(bench.step_message_fail(err.msg))
 		assert false
@@ -74,7 +75,8 @@ const compute_position_results = {
 fn test_compute_position() {
 	mut bench := benchmark.new_benchmark()
 	// TODO:
-	test_files := test_utils.load_test_file_paths(test_utils.get_test_files_path(@FILE), 'pos_compute_offset') or {
+	test_files := test_utils.load_test_file_paths(test_utils.get_test_files_path(@FILE),
+		'pos_compute_offset') or {
 		bench.fail()
 		eprintln(bench.step_message_fail(err.msg))
 		assert false
@@ -130,7 +132,8 @@ const tspoint_to_lsp_pos_results = {
 
 fn test_tspoint_to_lsp_pos() {
 	mut bench := benchmark.new_benchmark()
-	test_files := test_utils.load_test_file_paths(test_utils.get_test_files_path(@FILE), 'pos_to_lsp_pos') or {
+	test_files := test_utils.load_test_file_paths(test_utils.get_test_files_path(@FILE),
+		'pos_to_lsp_pos') or {
 		bench.fail()
 		eprintln(bench.step_message_fail(err.msg))
 		assert false
@@ -206,7 +209,8 @@ const tsrange_to_lsp_range_results = {
 
 fn test_tsrange_to_lsp_range() {
 	mut bench := benchmark.new_benchmark()
-	test_files := test_utils.load_test_file_paths(test_utils.get_test_files_path(@FILE), 'pos_to_lsp_range') or {
+	test_files := test_utils.load_test_file_paths(test_utils.get_test_files_path(@FILE),
+		'pos_to_lsp_range') or {
 		bench.fail()
 		eprintln(bench.step_message_fail(err.msg))
 		assert false

--- a/server/tests/positions_test.v
+++ b/server/tests/positions_test.v
@@ -1,6 +1,6 @@
 import os
 import server
-import server.testing
+import test_utils
 import benchmark
 import lsp
 
@@ -18,7 +18,7 @@ const compute_offset_results = {
 
 fn test_compute_offset() {
 	mut bench := benchmark.new_benchmark()
-	test_files := testing.load_test_file_paths('pos_compute_offset') or {
+	test_files := test_utils.load_test_file_paths('pos_compute_offset') or {
 		bench.fail()
 		eprintln(bench.step_message_fail(err.msg))
 		assert false
@@ -74,7 +74,7 @@ const compute_position_results = {
 fn test_compute_position() {
 	mut bench := benchmark.new_benchmark()
 	// TODO:
-	test_files := testing.load_test_file_paths('pos_compute_offset') or {
+	test_files := test_utils.load_test_file_paths('pos_compute_offset') or {
 		bench.fail()
 		eprintln(bench.step_message_fail(err.msg))
 		assert false
@@ -130,7 +130,7 @@ const tspoint_to_lsp_pos_results = {
 
 fn test_tspoint_to_lsp_pos() {
 	mut bench := benchmark.new_benchmark()
-	test_files := testing.load_test_file_paths('pos_to_lsp_pos') or {
+	test_files := test_utils.load_test_file_paths('pos_to_lsp_pos') or {
 		bench.fail()
 		eprintln(bench.step_message_fail(err.msg))
 		assert false
@@ -206,7 +206,7 @@ const tsrange_to_lsp_range_results = {
 
 fn test_tsrange_to_lsp_range() {
 	mut bench := benchmark.new_benchmark()
-	test_files := testing.load_test_file_paths('pos_to_lsp_range') or {
+	test_files := test_utils.load_test_file_paths('pos_to_lsp_range') or {
 		bench.fail()
 		eprintln(bench.step_message_fail(err.msg))
 		assert false

--- a/server/tests/positions_test.v
+++ b/server/tests/positions_test.v
@@ -18,7 +18,7 @@ const compute_offset_results = {
 
 fn test_compute_offset() {
 	mut bench := benchmark.new_benchmark()
-	test_files := test_utils.load_test_file_paths('pos_compute_offset') or {
+	test_files := test_utils.load_test_file_paths(test_utils.get_test_files_path(@FILE), 'pos_compute_offset') or {
 		bench.fail()
 		eprintln(bench.step_message_fail(err.msg))
 		assert false
@@ -74,7 +74,7 @@ const compute_position_results = {
 fn test_compute_position() {
 	mut bench := benchmark.new_benchmark()
 	// TODO:
-	test_files := test_utils.load_test_file_paths('pos_compute_offset') or {
+	test_files := test_utils.load_test_file_paths(test_utils.get_test_files_path(@FILE), 'pos_compute_offset') or {
 		bench.fail()
 		eprintln(bench.step_message_fail(err.msg))
 		assert false
@@ -130,7 +130,7 @@ const tspoint_to_lsp_pos_results = {
 
 fn test_tspoint_to_lsp_pos() {
 	mut bench := benchmark.new_benchmark()
-	test_files := test_utils.load_test_file_paths('pos_to_lsp_pos') or {
+	test_files := test_utils.load_test_file_paths(test_utils.get_test_files_path(@FILE), 'pos_to_lsp_pos') or {
 		bench.fail()
 		eprintln(bench.step_message_fail(err.msg))
 		assert false
@@ -206,7 +206,7 @@ const tsrange_to_lsp_range_results = {
 
 fn test_tsrange_to_lsp_range() {
 	mut bench := benchmark.new_benchmark()
-	test_files := test_utils.load_test_file_paths('pos_to_lsp_range') or {
+	test_files := test_utils.load_test_file_paths(test_utils.get_test_files_path(@FILE), 'pos_to_lsp_range') or {
 		bench.fail()
 		eprintln(bench.step_message_fail(err.msg))
 		assert false

--- a/server/tests/regression_test.v
+++ b/server/tests/regression_test.v
@@ -1,5 +1,5 @@
 import server
-import server.testing
+import test_utils
 import lsp
 import os
 
@@ -16,13 +16,13 @@ import os
 // applies to the V compiler, it is better to add it there instead.
 
 fn test_regression() {
-	mut io := &testing.Testio{}
+	mut io := &test_utils.Testio{}
 	mut ls := server.new(io)
 	ls.dispatch(io.request_with_params('initialize', lsp.InitializeParams{
 		root_uri: lsp.document_uri_from_path(os.join_path(os.dir(@FILE), 'test_files',
 			'regressions'))
 	}))
-	test_files := testing.load_test_file_paths('regressions') or {
+	test_files := test_utils.load_test_file_paths('regressions') or {
 		io.bench.fail()
 		eprintln(io.bench.step_message_fail(err.msg))
 		assert false

--- a/server/tests/regression_test.v
+++ b/server/tests/regression_test.v
@@ -16,13 +16,13 @@ import os
 // applies to the V compiler, it is better to add it there instead.
 
 fn test_regression() {
-	mut io := &test_utils.Testio{}
+	mut io := &test_utils.Testio{ test_files_dir: test_utils.get_test_files_path(@FILE) }
 	mut ls := server.new(io)
 	ls.dispatch(io.request_with_params('initialize', lsp.InitializeParams{
 		root_uri: lsp.document_uri_from_path(os.join_path(os.dir(@FILE), 'test_files',
 			'regressions'))
 	}))
-	test_files := test_utils.load_test_file_paths('regressions') or {
+	test_files := io.load_test_file_paths('regressions') or {
 		io.bench.fail()
 		eprintln(io.bench.step_message_fail(err.msg))
 		assert false

--- a/server/tests/regression_test.v
+++ b/server/tests/regression_test.v
@@ -16,7 +16,9 @@ import os
 // applies to the V compiler, it is better to add it there instead.
 
 fn test_regression() {
-	mut io := &test_utils.Testio{ test_files_dir: test_utils.get_test_files_path(@FILE) }
+	mut io := &test_utils.Testio{
+		test_files_dir: test_utils.get_test_files_path(@FILE)
+	}
 	mut ls := server.new(io)
 	ls.dispatch(io.request_with_params('initialize', lsp.InitializeParams{
 		root_uri: lsp.document_uri_from_path(os.join_path(os.dir(@FILE), 'test_files',

--- a/server/tests/signature_help_test.v
+++ b/server/tests/signature_help_test.v
@@ -29,7 +29,9 @@ const signature_help_results = {
 }
 
 fn test_signature_help() {
-	mut io := test_utils.Testio{ test_files_dir: test_utils.get_test_files_path(@FILE) }
+	mut io := test_utils.Testio{
+		test_files_dir: test_utils.get_test_files_path(@FILE)
+	}
 	mut ls := server.new(io)
 	ls.dispatch(io.request_with_params('initialize', lsp.InitializeParams{
 		root_uri: lsp.document_uri_from_path(os.join_path(os.dir(@FILE), 'test_files',

--- a/server/tests/signature_help_test.v
+++ b/server/tests/signature_help_test.v
@@ -29,13 +29,13 @@ const signature_help_results = {
 }
 
 fn test_signature_help() {
-	mut io := test_utils.Testio{}
+	mut io := test_utils.Testio{ test_files_dir: test_utils.get_test_files_path(@FILE) }
 	mut ls := server.new(io)
 	ls.dispatch(io.request_with_params('initialize', lsp.InitializeParams{
 		root_uri: lsp.document_uri_from_path(os.join_path(os.dir(@FILE), 'test_files',
 			'signature_help'))
 	}))
-	test_files := test_utils.load_test_file_paths('signature_help') or {
+	test_files := io.load_test_file_paths('signature_help') or {
 		io.bench.fail()
 		eprintln(io.bench.step_message_fail(err.msg))
 		assert false

--- a/server/tests/signature_help_test.v
+++ b/server/tests/signature_help_test.v
@@ -1,5 +1,5 @@
 import server
-import server.testing
+import test_utils
 import json
 import lsp
 import os
@@ -29,13 +29,13 @@ const signature_help_results = {
 }
 
 fn test_signature_help() {
-	mut io := testing.Testio{}
+	mut io := test_utils.Testio{}
 	mut ls := server.new(io)
 	ls.dispatch(io.request_with_params('initialize', lsp.InitializeParams{
 		root_uri: lsp.document_uri_from_path(os.join_path(os.dir(@FILE), 'test_files',
 			'signature_help'))
 	}))
-	test_files := testing.load_test_file_paths('signature_help') or {
+	test_files := test_utils.load_test_file_paths('signature_help') or {
 		io.bench.fail()
 		eprintln(io.bench.step_message_fail(err.msg))
 		assert false

--- a/server/tests/workspace_did_change_test.v
+++ b/server/tests/workspace_did_change_test.v
@@ -1,14 +1,14 @@
 import server
-import server.testing
+import test_utils
 import lsp
 import os
 
 fn test_workspace_did_change() ? {
-	mut io := &testing.Testio{}
+	mut io := &test_utils.Testio{}
 	mut ls := server.new(io)
 
 	// TODO: add a mock filesystem
-	files := testing.load_test_file_paths('workspace_did_change') or {
+	files := test_utils.load_test_file_paths('workspace_did_change') or {
 		io.bench.fail()
 		eprintln(io.bench.step_message_fail(err.msg))
 		return err

--- a/server/tests/workspace_did_change_test.v
+++ b/server/tests/workspace_did_change_test.v
@@ -4,7 +4,9 @@ import lsp
 import os
 
 fn test_workspace_did_change() ? {
-	mut io := &test_utils.Testio{ test_files_dir: test_utils.get_test_files_path(@FILE) }
+	mut io := &test_utils.Testio{
+		test_files_dir: test_utils.get_test_files_path(@FILE)
+	}
 	mut ls := server.new(io)
 
 	// TODO: add a mock filesystem

--- a/server/tests/workspace_did_change_test.v
+++ b/server/tests/workspace_did_change_test.v
@@ -4,11 +4,11 @@ import lsp
 import os
 
 fn test_workspace_did_change() ? {
-	mut io := &test_utils.Testio{}
+	mut io := &test_utils.Testio{ test_files_dir: test_utils.get_test_files_path(@FILE) }
 	mut ls := server.new(io)
 
 	// TODO: add a mock filesystem
-	files := test_utils.load_test_file_paths('workspace_did_change') or {
+	files := io.load_test_file_paths('workspace_did_change') or {
 		io.bench.fail()
 		eprintln(io.bench.step_message_fail(err.msg))
 		return err

--- a/server/tests/workspace_symbols_test.v
+++ b/server/tests/workspace_symbols_test.v
@@ -54,7 +54,9 @@ const workspace_symbols_result = [
 ]
 
 fn test_workspace_symbols() {
-	mut io := &test_utils.Testio{ test_files_dir: test_utils.get_test_files_path(@FILE) }
+	mut io := &test_utils.Testio{
+		test_files_dir: test_utils.get_test_files_path(@FILE)
+	}
 	mut ls := server.new(io)
 	ls.dispatch(io.request('initialize'))
 	files := io.load_test_file_paths('workspace_symbols') or {

--- a/server/tests/workspace_symbols_test.v
+++ b/server/tests/workspace_symbols_test.v
@@ -54,10 +54,10 @@ const workspace_symbols_result = [
 ]
 
 fn test_workspace_symbols() {
-	mut io := &test_utils.Testio{}
+	mut io := &test_utils.Testio{ test_files_dir: test_utils.get_test_files_path(@FILE) }
 	mut ls := server.new(io)
 	ls.dispatch(io.request('initialize'))
-	files := test_utils.load_test_file_paths('workspace_symbols') or {
+	files := io.load_test_file_paths('workspace_symbols') or {
 		io.bench.fail()
 		eprintln(io.bench.step_message_fail(err.msg))
 		assert false

--- a/server/tests/workspace_symbols_test.v
+++ b/server/tests/workspace_symbols_test.v
@@ -1,5 +1,5 @@
 import server
-import server.testing
+import test_utils
 import json
 import lsp
 import os
@@ -54,10 +54,10 @@ const workspace_symbols_result = [
 ]
 
 fn test_workspace_symbols() {
-	mut io := &testing.Testio{}
+	mut io := &test_utils.Testio{}
 	mut ls := server.new(io)
 	ls.dispatch(io.request('initialize'))
-	files := testing.load_test_file_paths('workspace_symbols') or {
+	files := test_utils.load_test_file_paths('workspace_symbols') or {
 		io.bench.fail()
 		eprintln(io.bench.step_message_fail(err.msg))
 		assert false

--- a/server/window_test.v
+++ b/server/window_test.v
@@ -1,6 +1,6 @@
 import server
 import lsp
-import server.testing
+import test_utils
 import json
 
 const (
@@ -9,7 +9,7 @@ const (
 )
 
 fn test_log_message_error() {
-	mut io := &testing.Testio{}
+	mut io := &test_utils.Testio{}
 	mut ls := server.new(io)
 	// error
 	ls.log_message('Error!', .error)
@@ -25,7 +25,7 @@ fn test_log_message_error() {
 }
 
 fn test_log_message_warning() {
-	mut io := &testing.Testio{}
+	mut io := &test_utils.Testio{}
 	mut ls := server.new(io)
 	// warning
 	ls.log_message('This is a warning!', .warning)
@@ -41,7 +41,7 @@ fn test_log_message_warning() {
 }
 
 fn test_log_message_info() {
-	mut io := &testing.Testio{}
+	mut io := &test_utils.Testio{}
 	mut ls := server.new(io)
 	// info
 	ls.log_message('Hello World!', .info)
@@ -57,7 +57,7 @@ fn test_log_message_info() {
 }
 
 fn test_log_message_log() {
-	mut io := &testing.Testio{}
+	mut io := &test_utils.Testio{}
 	mut ls := server.new(io)
 	// log
 	ls.log_message('Logged!', .log)
@@ -73,7 +73,7 @@ fn test_log_message_log() {
 }
 
 fn test_show_message_error() {
-	mut io := &testing.Testio{}
+	mut io := &test_utils.Testio{}
 	mut ls := server.new(io)
 	// error
 	ls.show_message('Error!', .error)
@@ -89,7 +89,7 @@ fn test_show_message_error() {
 }
 
 fn test_show_message_warning() {
-	mut io := &testing.Testio{}
+	mut io := &test_utils.Testio{}
 	mut ls := server.new(io)
 	// warning
 	ls.show_message('This is a warning!', .warning)
@@ -105,7 +105,7 @@ fn test_show_message_warning() {
 }
 
 fn test_show_message_info() {
-	mut io := &testing.Testio{}
+	mut io := &test_utils.Testio{}
 	mut ls := server.new(io)
 	// info
 	ls.show_message('Hello World!', .info)
@@ -121,7 +121,7 @@ fn test_show_message_info() {
 }
 
 fn test_show_message_log() {
-	mut io := &testing.Testio{}
+	mut io := &test_utils.Testio{}
 	mut ls := server.new(io)
 	// log
 	ls.show_message('Logged!', .log)
@@ -137,7 +137,7 @@ fn test_show_message_log() {
 }
 
 fn test_show_message_request() {
-	mut io := &testing.Testio{}
+	mut io := &test_utils.Testio{}
 	mut ls := server.new(io)
 	actions := [lsp.MessageActionItem{'Retry'}]
 	ls.show_message_request('Failed!', actions, .info)

--- a/test_utils/test_utils.v
+++ b/test_utils/test_utils.v
@@ -20,6 +20,8 @@ struct TestNotification {
 }
 
 pub struct Testio {
+pub:
+	test_files_dir string
 mut:
 	current_req_id int = 1
 	has_decoded    bool
@@ -79,15 +81,28 @@ fn (mut io Testio) decode_response() ? {
 	}
 }
 
-pub const test_files_dir = os.join_path(os.dir(os.dir(@FILE)), 'server', 'tests', 'test_files')
+// get_test_files_path returns the appended location of the test file dir and dir var.
+pub fn get_test_files_path(dir string) string {
+	if os.is_file(dir) {
+		return os.join_path(os.dir(dir), 'test_files')
+	}
+
+	return os.join_path(dir, 'tests', 'test_files')
+}
 
 // load_test_file_paths returns a list of input test file locations.
 [manualfree]
-pub fn load_test_file_paths(folder_name string) ?[]string {
+pub fn (io &Testio) load_test_file_paths(folder_name string) ?[]string {
+	return load_test_file_paths(io.test_files_dir, folder_name)
+}
+
+// load_test_file_paths returns a list of input test file locations.
+[manualfree]
+pub fn load_test_file_paths(test_files_dir string, folder_name string) ?[]string {
 	current_os := os.user_os()
-	target_path := os.join_path(test_utils.test_files_dir, folder_name)
+	target_path := os.join_path(test_files_dir, folder_name)
 	dir := os.ls(target_path) or { return error('error loading test files for "$folder_name"') }
-	mut filtered := []string{}
+	mut filtered := []string{cap: dir.len}
 	for path in dir {
 		if !path.ends_with('.vv') || path.ends_with('_skip.vv')
 			|| path.ends_with('_skip_${current_os}.vv') {

--- a/test_utils/test_utils.v
+++ b/test_utils/test_utils.v
@@ -1,4 +1,4 @@
-module testing
+module test_utils
 
 import json
 import jsonrpc
@@ -79,13 +79,13 @@ fn (mut io Testio) decode_response() ? {
 	}
 }
 
-pub const test_files_dir = os.join_path(os.dir(os.dir(@FILE)), 'tests', 'test_files')
+pub const test_files_dir = os.join_path(os.dir(os.dir(@FILE)), 'server', 'tests', 'test_files')
 
 // load_test_file_paths returns a list of input test file locations.
 [manualfree]
 pub fn load_test_file_paths(folder_name string) ?[]string {
 	current_os := os.user_os()
-	target_path := os.join_path(testing.test_files_dir, folder_name)
+	target_path := os.join_path(test_utils.test_files_dir, folder_name)
 	dir := os.ls(target_path) or { return error('error loading test files for "$folder_name"') }
 	mut filtered := []string{}
 	for path in dir {

--- a/test_utils/test_utils_test.v
+++ b/test_utils/test_utils_test.v
@@ -1,4 +1,4 @@
-module testing
+module test_utils
 
 import json
 import jsonrpc


### PR DESCRIPTION
As preparation for an upcoming PR, this change will allow other modules outside of server module to utilize the useful testing utilities. This also makes loading test file paths configurable and not hardcoded unlike before.