### PR TITLE
server: add feature toggle for v diagnostics and analyzer diagnostics

### DIFF
--- a/server/diagnostics.v
+++ b/server/diagnostics.v
@@ -59,6 +59,10 @@ fn (ls Vls) v_msg_to_diagnostic(from_file_path string, msg string) ?lsp.Diagnost
 
 // exec_v_diagnostics returns a list of errors/warnings taken from `v -check`
 fn (mut ls Vls) exec_v_diagnostics(uri lsp.DocumentUri) ?[]lsp.Diagnostic {
+	if Feature.v_diagnostics !in ls.enabled_features {
+		return none
+	}
+
 	dir_path := uri.dir_path()
 	file_path := uri.path()
 	input_path := if file_path.ends_with('.vv') { file_path } else { dir_path }

--- a/server/diagnostics.v
+++ b/server/diagnostics.v
@@ -110,7 +110,6 @@ fn (mut ls Vls) show_diagnostics(uri lsp.DocumentUri) {
 }
 
 // publish_diagnostics sends errors, warnings and other diagnostics to the editor
-[manualfree]
 fn (mut ls Vls) publish_diagnostics(uri lsp.DocumentUri, diagnostics []lsp.Diagnostic) {
 	if Feature.diagnostics !in ls.enabled_features {
 		return
@@ -123,5 +122,4 @@ fn (mut ls Vls) publish_diagnostics(uri lsp.DocumentUri, diagnostics []lsp.Diagn
 			diagnostics: diagnostics
 		}
 	})
-	unsafe { diagnostics.free() }
 }

--- a/server/general_test.v
+++ b/server/general_test.v
@@ -46,6 +46,7 @@ fn test_set_features() {
 	}
 	assert ls.features() == [
 		.diagnostics,
+		.v_diagnostics,
 		.document_symbol,
 		.workspace_symbol,
 		.signature_help,
@@ -61,6 +62,7 @@ fn test_set_features() {
 	}
 	assert ls.features() == [
 		.diagnostics,
+		.v_diagnostics,
 		.document_symbol,
 		.workspace_symbol,
 		.signature_help,

--- a/server/vls.v
+++ b/server/vls.v
@@ -32,6 +32,8 @@ fn meta_info() vmod.Manifest {
 // If the feature is experimental, the value name should have a `exp_` prefix
 pub enum Feature {
 	diagnostics
+	v_diagnostics
+	analyzer_diagnostics
 	formatting
 	document_symbol
 	workspace_symbol
@@ -48,6 +50,8 @@ pub enum Feature {
 fn feature_from_str(feature_name string) ?Feature {
 	match feature_name {
 		'diagnostics' { return Feature.diagnostics }
+		'v_diagnostics' { return Feature.v_diagnostics }
+		'analyzer_diagnostics' { return Feature.analyzer_diagnostics }
 		'formatting' { return Feature.formatting }
 		'document_symbol' { return Feature.document_symbol }
 		'workspace_symbol' { return Feature.workspace_symbol }
@@ -63,6 +67,7 @@ fn feature_from_str(feature_name string) ?Feature {
 pub const (
 	default_features_list = [
 		Feature.diagnostics,
+		.v_diagnostics,
 		.formatting,
 		.document_symbol,
 		.workspace_symbol,

--- a/server/vls.v
+++ b/server/vls.v
@@ -312,10 +312,9 @@ fn monitor_changes(mut ls Vls) {
 				}
 
 				uri := lsp.document_uri_from_path(ls.store.cur_file_path)
-				analyze(mut ls.store, ls.root_uri, ls.trees[uri], ls.sources[uri])
+				ls.analyze_file(ls.trees[uri], ls.sources[uri])
 				ls.is_typing = false
 				ls.show_diagnostics(uri)
-				unsafe { uri.free() }
 			}
 		}
 	}


### PR DESCRIPTION
In preparation for #159 .

This PR adds two new feature enum members: `v_diagnostics` and `analyzer_diagnostics`. These are used for toggling which source to be used for displaying diagnostics into the editor. It also updates the `analyze` function and made it as a `Vls` method.