### PR TITLE
server: better implementation of signature help feature; add additional tests

### DIFF
--- a/server/features.v
+++ b/server/features.v
@@ -204,9 +204,14 @@ fn (mut ls Vls) signature_help(id string, params string) {
 	off := compute_offset(source, pos.line, pos.character)
 	mut node := traverse_node(tree.root_node(), u32(off))
 	mut parent_node := node
+	closest_parent_node := closest_symbol_node_parent(node)
+
 	if node.type_name() == 'argument_list' {
 		parent_node = node.parent() or { node }
 		node = node.prev_named_sibling() or { node }
+	} else if parent_node.type_name() != 'call_expression' {
+		parent_node = closest_symbol_node_parent(node)
+		node = parent_node
 	}
 
 	// signature help supports function calls for now
@@ -226,20 +231,29 @@ fn (mut ls Vls) signature_help(id string, params string) {
 		ls.send_null(id)
 		return
 	}
+
+	// get the nearest parameter based on the position of the cursor
+	args_count := args_node.named_child_count()
+	mut active_parameter_idx := -1
+	for i in u32(0) .. args_count {
+		current_arg_node := args_node.named_child(i) or { continue }
+		if u32(off) >= current_arg_node.start_byte() && u32(off) <= current_arg_node.end_byte() {
+			active_parameter_idx = int(i)
+			break
+		}
+	}
+
+	// go to the first parameter or the last parameter if not found
+	if args_count == 0 {
+		active_parameter_idx = 0
+	} else if active_parameter_idx == -1 {
+		active_parameter_idx = int(args_count) - 1
+	}
+
 	// for retrigger, it utilizes the current signature help data
 	if ctx.is_retrigger {
 		mut active_sighelp := ctx.active_signature_help
-
-		if ctx.trigger_kind == .content_change {
-			// change the current active param value to the length of the current args.
-			active_sighelp.active_parameter = int(args_node.named_child_count()) - 1
-		} else if ctx.trigger_kind == .trigger_character && ctx.trigger_character == ','
-			&& active_sighelp.signatures.len > 0
-			&& active_sighelp.active_parameter < active_sighelp.signatures[0].parameters.len {
-			// when pressing comma, it must proceed to the next parameter
-			// by incrementing the active parameter.
-			active_sighelp.active_parameter++
-		}
+		active_sighelp.active_parameter = active_parameter_idx
 
 		ls.send(jsonrpc.Response<lsp.SignatureHelp>{
 			id: id
@@ -264,6 +278,7 @@ fn (mut ls Vls) signature_help(id string, params string) {
 	ls.send(jsonrpc.Response<lsp.SignatureHelp>{
 		id: id
 		result: lsp.SignatureHelp{
+			active_parameter: active_parameter_idx
 			signatures: [
 				lsp.SignatureInformation{
 					label: sym.gen_str()

--- a/server/features.v
+++ b/server/features.v
@@ -204,7 +204,6 @@ fn (mut ls Vls) signature_help(id string, params string) {
 	off := compute_offset(source, pos.line, pos.character)
 	mut node := traverse_node(tree.root_node(), u32(off))
 	mut parent_node := node
-	closest_parent_node := closest_symbol_node_parent(node)
 
 	if node.type_name() == 'argument_list' {
 		parent_node = node.parent() or { node }

--- a/server/tests/signature_help_test.v
+++ b/server/tests/signature_help_test.v
@@ -11,6 +11,18 @@ const signature_help_inputs = {
 			trigger_character: '('
 		}
 		position: lsp.Position{7, 8}
+	},
+	'with_content.vv': lsp.SignatureHelpParams{
+		context: lsp.SignatureHelpContext{
+			trigger_kind: .invoked
+		}
+		position: lsp.Position{7,16}
+	},
+	'with_content_b.vv': lsp.SignatureHelpParams{
+		context: lsp.SignatureHelpContext{
+			trigger_kind: .invoked
+		}
+		position: lsp.Position{7,11}
 	}
 }
 
@@ -21,6 +33,30 @@ const signature_help_results = {
 				label: 'fn greet(name string) bool'
 				parameters: [
 					lsp.ParameterInformation{'name string'},
+				]
+			},
+		]
+		active_parameter: 0
+	},
+	'with_content.vv': lsp.SignatureHelp{
+		signatures: [
+			lsp.SignatureInformation{
+				label: 'fn greet(name string, age int) bool'
+				parameters: [
+					lsp.ParameterInformation{'name string'},
+					lsp.ParameterInformation{'age int'}
+				]
+			},
+		]
+		active_parameter: 1
+	},
+	'with_content_b.vv': lsp.SignatureHelp{
+		signatures: [
+			lsp.SignatureInformation{
+				label: 'fn greet(name string, age int) bool'
+				parameters: [
+					lsp.ParameterInformation{'name string'},
+					lsp.ParameterInformation{'age int'}
 				]
 			},
 		]

--- a/server/tests/signature_help_test.v
+++ b/server/tests/signature_help_test.v
@@ -5,20 +5,32 @@ import lsp
 import os
 
 const signature_help_inputs = {
-	'simple.vv':         lsp.SignatureHelpParams{
+	'empty_middle_arg.vv': lsp.SignatureHelpParams{
+		context: lsp.SignatureHelpContext{
+			trigger_kind: .invoked
+		}
+		position: lsp.Position{2, 7}
+	}
+	'empty_second_arg.vv': lsp.SignatureHelpParams{
+		context: lsp.SignatureHelpContext{
+			trigger_kind: .invoked
+		}
+		position: lsp.Position{6, 18}
+	}
+	'simple.vv':           lsp.SignatureHelpParams{
 		context: lsp.SignatureHelpContext{
 			trigger_kind: .trigger_character
 			trigger_character: '('
 		}
 		position: lsp.Position{7, 8}
 	}
-	'with_content.vv':   lsp.SignatureHelpParams{
+	'with_content.vv':     lsp.SignatureHelpParams{
 		context: lsp.SignatureHelpContext{
 			trigger_kind: .invoked
 		}
 		position: lsp.Position{7, 16}
 	}
-	'with_content_b.vv': lsp.SignatureHelpParams{
+	'with_content_b.vv':   lsp.SignatureHelpParams{
 		context: lsp.SignatureHelpContext{
 			trigger_kind: .invoked
 		}
@@ -27,7 +39,32 @@ const signature_help_inputs = {
 }
 
 const signature_help_results = {
-	'simple.vv':         lsp.SignatureHelp{
+	'empty_middle_arg.vv': lsp.SignatureHelp{
+		signatures: [
+			lsp.SignatureInformation{
+				label: 'fn foo(a int, b f32, c i64)'
+				parameters: [
+					lsp.ParameterInformation{'a int'},
+					lsp.ParameterInformation{'b f32'},
+					lsp.ParameterInformation{'c i64'},
+				]
+			},
+		]
+		active_parameter: 1
+	}
+	'empty_second_arg.vv': lsp.SignatureHelp{
+		signatures: [
+			lsp.SignatureInformation{
+				label: 'fn return_number(a int, b int) int'
+				parameters: [
+					lsp.ParameterInformation{'a int'},
+					lsp.ParameterInformation{'b int'},
+				]
+			},
+		]
+		active_parameter: 1
+	}
+	'simple.vv':           lsp.SignatureHelp{
 		signatures: [
 			lsp.SignatureInformation{
 				label: 'fn greet(name string) bool'
@@ -38,7 +75,7 @@ const signature_help_results = {
 		]
 		active_parameter: 0
 	}
-	'with_content.vv':   lsp.SignatureHelp{
+	'with_content.vv':     lsp.SignatureHelp{
 		signatures: [
 			lsp.SignatureInformation{
 				label: 'fn greet(name string, age int) bool'
@@ -50,7 +87,7 @@ const signature_help_results = {
 		]
 		active_parameter: 1
 	}
-	'with_content_b.vv': lsp.SignatureHelp{
+	'with_content_b.vv':   lsp.SignatureHelp{
 		signatures: [
 			lsp.SignatureInformation{
 				label: 'fn greet(name string, age int) bool'

--- a/server/tests/signature_help_test.v
+++ b/server/tests/signature_help_test.v
@@ -5,29 +5,29 @@ import lsp
 import os
 
 const signature_help_inputs = {
-	'simple.vv': lsp.SignatureHelpParams{
+	'simple.vv':         lsp.SignatureHelpParams{
 		context: lsp.SignatureHelpContext{
 			trigger_kind: .trigger_character
 			trigger_character: '('
 		}
 		position: lsp.Position{7, 8}
-	},
-	'with_content.vv': lsp.SignatureHelpParams{
+	}
+	'with_content.vv':   lsp.SignatureHelpParams{
 		context: lsp.SignatureHelpContext{
 			trigger_kind: .invoked
 		}
-		position: lsp.Position{7,16}
-	},
+		position: lsp.Position{7, 16}
+	}
 	'with_content_b.vv': lsp.SignatureHelpParams{
 		context: lsp.SignatureHelpContext{
 			trigger_kind: .invoked
 		}
-		position: lsp.Position{7,11}
+		position: lsp.Position{7, 11}
 	}
 }
 
 const signature_help_results = {
-	'simple.vv': lsp.SignatureHelp{
+	'simple.vv':         lsp.SignatureHelp{
 		signatures: [
 			lsp.SignatureInformation{
 				label: 'fn greet(name string) bool'
@@ -37,26 +37,26 @@ const signature_help_results = {
 			},
 		]
 		active_parameter: 0
-	},
-	'with_content.vv': lsp.SignatureHelp{
+	}
+	'with_content.vv':   lsp.SignatureHelp{
 		signatures: [
 			lsp.SignatureInformation{
 				label: 'fn greet(name string, age int) bool'
 				parameters: [
 					lsp.ParameterInformation{'name string'},
-					lsp.ParameterInformation{'age int'}
+					lsp.ParameterInformation{'age int'},
 				]
 			},
 		]
 		active_parameter: 1
-	},
+	}
 	'with_content_b.vv': lsp.SignatureHelp{
 		signatures: [
 			lsp.SignatureInformation{
 				label: 'fn greet(name string, age int) bool'
 				parameters: [
 					lsp.ParameterInformation{'name string'},
-					lsp.ParameterInformation{'age int'}
+					lsp.ParameterInformation{'age int'},
 				]
 			},
 		]

--- a/server/tests/test_files/signature_help/empty_middle_arg.vv
+++ b/server/tests/test_files/signature_help/empty_middle_arg.vv
@@ -1,0 +1,3 @@
+fn foo(a int, b f32, c i64) {}
+
+foo(10,, i64(100))

--- a/server/tests/test_files/signature_help/empty_second_arg.vv
+++ b/server/tests/test_files/signature_help/empty_second_arg.vv
@@ -1,0 +1,7 @@
+module main
+
+fn return_number(a int, b int) int {
+	return a
+}
+
+return_number(10, )

--- a/server/tests/test_files/signature_help/with_content.vv
+++ b/server/tests/test_files/signature_help/with_content.vv
@@ -1,0 +1,9 @@
+module main
+
+fn greet(name string, age int) bool {
+  println(name)
+}
+
+fn main() {
+  greet('Bob', 12)
+}

--- a/server/tests/test_files/signature_help/with_content_b.vv
+++ b/server/tests/test_files/signature_help/with_content_b.vv
@@ -1,0 +1,9 @@
+module main
+
+fn greet(name string, age int) bool {
+  println(name)
+}
+
+fn main() {
+  greet('Bob', 12)
+}


### PR DESCRIPTION
This PR updates the signature help feature in which it is only activated before on empty arguments or after pressing comma and only points to the last index of the argument list. Now it points to the argument according to the position of the cursor. 

Closes #282.