### PR TITLE
analyzer: improve function type analysis, add tests

### DIFF
--- a/analyzer/store.v
+++ b/analyzer/store.v
@@ -546,7 +546,7 @@ pub fn (mut store Store) find_symbol_by_type_node(node C.TSNode, src_text []byte
 		}
 
 		return store.find_fn_symbol(module_name, return_sym, parameters) or {
-			mut new_sym := Symbol{
+			mut new_sym := &Symbol{
 				name: analyzer.anon_fn_prefix + store.anon_fn_counter.str()
 				file_path: store.cur_file_path
 				file_version: store.cur_version
@@ -560,7 +560,7 @@ pub fn (mut store Store) find_symbol_by_type_node(node C.TSNode, src_text []byte
 			}
 
 			store.anon_fn_counter++
-			store.register_symbol(mut new_sym) or { void_sym }
+			return new_sym
 		}
 	}
 

--- a/analyzer/store.v
+++ b/analyzer/store.v
@@ -169,11 +169,18 @@ const anon_fn_prefix = '#anon_'
 pub fn (ss &Store) find_fn_symbol(module_name string, return_sym &Symbol, params []&Symbol) ?&Symbol {
 	module_path := ss.get_module_path(module_name)
 	for sym in ss.symbols[module_path] ? {
-		if sym.kind == .function_type && sym.name.starts_with(analyzer.anon_fn_prefix)
+		mut final_sym := sym
+		if sym.kind == .typedef && sym.parent_sym.kind == .function_type {
+			final_sym = sym.parent_sym
+		}
+
+		if final_sym.kind == .function_type && final_sym.name.starts_with(analyzer.anon_fn_prefix)
 			&& sym.generic_placeholder_len == 0 {
-			if !compare_params_and_ret_type(params, return_sym, sym, true) {
+			if !compare_params_and_ret_type(params, return_sym, final_sym, true) {
 				continue
 			}
+
+			// return the typedef'd function type or the anon fn type itself
 			return sym
 		}
 	}

--- a/analyzer/symbol.v
+++ b/analyzer/symbol.v
@@ -313,7 +313,11 @@ fn (sym &Symbol) sexpr_str_write(mut writer strings.Builder) {
 	if sym.kind in analyzer.sym_kinds_allowed_to_print_parent && !sym.parent_sym.is_void() {
 		writer.write_string('(parent ')
 		writer.write_string(sym.parent_sym.kind.str() + ' ')
-		writer.write_string(sym.parent_sym.name)
+		if sym.parent_sym.kind == .function_type {
+			writer.write_string(sym.parent_sym.gen_str())
+		} else {
+			writer.write_string(sym.parent_sym.name)
+		}
 		writer.write_string(') ')
 	}
 	write_ctspoint_sexpr_str(sym.range.start_point, mut writer)

--- a/analyzer/symbol_registration_test.v
+++ b/analyzer/symbol_registration_test.v
@@ -66,7 +66,7 @@ fn test_symbol_registration() ? {
 		sym_analyzer.cursor = new_tree_cursor(tree.root_node())
 		symbols, _ := sym_analyzer.analyze()
 		result := symbols.sexpr_str()
-		assert result == expected
+		assert expected == result
 		println(bench.step_message_ok(test_name))
 
 		unsafe {

--- a/analyzer/test_files/symbol_registration/fn_decl.test.txt
+++ b/analyzer/test_files/symbol_registration/fn_decl.test.txt
@@ -31,6 +31,10 @@ fn inside_if() {
 
 fn mutate_arr(mut s []string) {}
 
+fn fn__arr(handler fn (s int) int) {
+    handler(1)
+}
+
 ---
 
 (function main [0,3]-[0,7])
@@ -55,3 +59,5 @@ fn mutate_arr(mut s []string) {}
         (mut variable unsafe_var int [27,12]-[27,22])))
 (function mutate_arr [31,3]-[31,13]
     (mut variable s []string [31,18]-[31,19]))
+(function fn__arr [33,3]-[33,10]
+    (variable handler fn (s int) int [33,11]-[33,18]))

--- a/analyzer/test_files/symbol_registration/type_decl.test.txt
+++ b/analyzer/test_files/symbol_registration/type_decl.test.txt
@@ -1,5 +1,6 @@
 pub type Text = string
 type Any = string | int | []string
+pub type Handler = fn (a int) int
 
 ---
 
@@ -8,3 +9,4 @@ type Any = string | int | []string
     (struct string)
     (typedef int)
     (array []string))
+(pub typedef Handler (parent function_type fn (a int) int) [2,9]-[2,16])


### PR DESCRIPTION
This PR improves analysis of function type symbols and add tests related to it. Anonymous function types are not also registered immediately anymore inside the analyzer store but is instead stored into their respective parent symbols like typedefs or variables.