### PR TITLE
analyzer: support for match expr analysis

### DIFF
--- a/analyzer/store.v
+++ b/analyzer/store.v
@@ -668,7 +668,6 @@ pub fn (mut ss Store) infer_symbol_from_node(node C.TSNode, src_text []byte) ?&S
 			if type_node := node.child_by_field_name('type') {
 				parent_sym := ss.infer_symbol_from_node(type_node, src_text) ?
 				child_sym := parent_sym.children_syms.get(field_node.code(src_text)) ?
-
 				return child_sym
 			} else {
 				// for shorhand enum
@@ -894,6 +893,14 @@ pub fn (mut ss Store) infer_value_type_from_node(node C.TSNode, src_text []byte)
 				return got_sym.return_sym
 			}
 			return got_sym
+		}
+		'type_selector_expression' {
+			if type_node := node.child_by_field_name('type') {
+				if parent_sym := ss.infer_symbol_from_node(type_node, src_text) {
+					return parent_sym
+				}
+			}
+			return void_sym
 		}
 		// 'argument_list' {
 		// 	return ss.infer_value_type_from_node(node.parent(), src_text)

--- a/analyzer/symbol_registration.v
+++ b/analyzer/symbol_registration.v
@@ -581,20 +581,20 @@ fn (mut sr SymbolAnalyzer) match_expression(match_node C.TSNode) ?[]&Symbol {
 	for i in u32(1) .. named_child_count {
 		case_node := match_node.named_child(i) or { continue }
 		if case_node.type_name() == 'expression_case' {
-			case_list_node := case_node.child_by_field_name('value') or {
-				return void_sym_arr
-			}
+			case_list_node := case_node.child_by_field_name('value') or { return void_sym_arr }
 
 			case_list_count := case_list_node.named_child_count()
 			for j in u32(0) .. case_list_count {
 				value_node := case_list_node.named_child(j) or { continue }
-				if cond_value_type.kind == .enum_ && value_node.type_name() == 'type_selector_expression' {
+				if cond_value_type.kind == .enum_
+					&& value_node.type_name() == 'type_selector_expression' {
 					field_node := value_node.child_by_field_name('field_name') or { continue }
 					if !cond_value_type.children_syms.exists(field_node.code(sr.src_text)) {
 						return void_sym_arr
 					}
 				} else {
-					value_node_type := sr.store.infer_value_type_from_node(value_node, sr.src_text)
+					value_node_type := sr.store.infer_value_type_from_node(value_node,
+						sr.src_text)
 					if value_node_type.is_void() || value_node_type != cond_value_type {
 						// return void if no type matches
 						return void_sym_arr

--- a/analyzer/test_files/symbol_registration/match_expr.test.txt
+++ b/analyzer/test_files/symbol_registration/match_expr.test.txt
@@ -1,0 +1,32 @@
+enum Color {
+    red
+    yellow
+    blue
+}
+
+fn main() {
+    color := Color.red
+    cstr := match color {
+        .red { 'red' }
+        .yellow { 'yellow' }
+        .blue { 'blue' }
+    }
+
+    cstr2 := match color {
+        .red { 2 }
+        .yellow { 'hey' }
+        else { 'what' }
+    }
+}
+
+---
+
+(enum Color [0,5]-[0,10]
+    (field red int [1,4]-[1,7])
+    (field yellow int [2,4]-[2,10])
+    (field blue int [3,4]-[3,8]))
+
+(function main [6,3]-[6,7]
+    (variable color Color [7,4]-[7,9])
+    (variable cstr string [8,4]-[8,8])
+    (variable cstr2 [14,4]-[14,9]))


### PR DESCRIPTION
This PR adds support for analyzing match expressions when used inside a variable or a constant. This also includes adding `type_selector_expression` node to the `infer_value_type_from_node`