### PR TITLE
server, analyzer, tree-sitter: improve didOpen/didUpdate; implement get_changed_ranges and parse_bytes

### DIFF
--- a/analyzer/store.v
+++ b/analyzer/store.v
@@ -272,6 +272,7 @@ pub fn (mut ss Store) register_symbol(mut info Symbol) ?&Symbol {
 			existing_sym.generic_placeholder_len = info.generic_placeholder_len
 			existing_sym.file_path = info.file_path
 			existing_sym.file_version = info.file_version
+			existing_sym.scope = info.scope
 		}
 
 		return existing_sym

--- a/analyzer/store.v
+++ b/analyzer/store.v
@@ -1235,10 +1235,10 @@ pub fn (mut store Store) import_modules(mut imports []&Import) {
 
 			full_path := os.join_path(new_import.path, file_name)
 			content := os.read_bytes(full_path) or { continue }
-			tree_from_import := parser.parse_string(content.bytestr())
+			tree_from_import := parser.parse_bytes(content)
 
-			// Set version to zero so that modules who are already opened
-			// in the editors can register symbols with scopes without
+			// Set version to zero so that modules that are already opened
+			// in the editor can register symbols with scopes without
 			// getting "symbol exists" errors
 			store.set_active_file_path(full_path, 0)
 

--- a/server/positions.v
+++ b/server/positions.v
@@ -3,12 +3,7 @@ module server
 // commenting it here so that it recognizes that
 // TSPoint and TSRange is used from the "tree_sitter" module
 // import tree_sitter
-import v.token
 import lsp
-
-pub fn is_within_pos(offset int, pos token.Position) bool {
-	return offset >= pos.pos && offset <= pos.pos + pos.len
-}
 
 // compute_offset returns a byte offset from the given position
 pub fn compute_offset(src []byte, line int, col int) int {

--- a/server/text_synchronization.v
+++ b/server/text_synchronization.v
@@ -24,62 +24,72 @@ fn (mut ls Vls) did_open(_ string, params string) {
 		ls.panic(err.msg)
 		return
 	}
+
 	ls.parser.reset()
 	src := did_open_params.text_document.text
 	uri := did_open_params.text_document.uri
-	// ls.log_message('opening $uri ...', .info)
-	// if project is not opened, analyze all the files available
 	project_dir := uri.dir_path()
+	mut should_scan_whole_dir := false
+
+	// should_scan_whole_dir is toggled if
+	// - it's V file ending with .v format
+	// - the project directory does not end with a dot (.)
+	// - and has not been present in the dependency tree
 	if uri.ends_with('.v') && project_dir != '.' && !ls.store.dependency_tree.has(project_dir) {
-		mut files := os.ls(project_dir) or { [] }
-		for file_name in files {
-			if !analyzer.should_analyze_file(file_name) {
-				continue
-			}
-
-			full_path := os.join_path(project_dir, file_name)
-			file_uri := lsp.document_uri_from_path(full_path)
-
-			if file_uri != uri {
-				ls.sources[file_uri] = File{
-					uri: file_uri
-					source: os.read_bytes(full_path) or { [] }
-				}
-				source_str := ls.sources[file_uri].source.bytestr()
-				ls.trees[file_uri] = ls.parser.parse_string(source_str)
-				unsafe { source_str.free() }
-			} else {
-				ls.sources[uri] = File{
-					source: src.bytes()
-					uri: uri
-				}
-				ls.trees[uri] = ls.parser.parse_string(src)
-			}
-
-			ls.analyze_file(ls.trees[file_uri], ls.sources[file_uri])
-			ls.show_diagnostics(file_uri)
-
-			// unsafe {
-			// 	full_path.free()
-			// 	file_uri.free()
-			// }
-		}
-		ls.store.set_active_file_path(uri.path(), ls.sources[uri].version)
-		unsafe { files.free() }
-	} else if uri !in ls.sources && uri !in ls.trees {
-		ls.sources[uri] = File{
-			source: src.bytes()
-			uri: uri
-		}
-		ls.trees[uri] = ls.parser.parse_string(src)
-
-		if !ls.store.has_file_path(uri.path()) || uri.path() !in ls.store.opened_scopes {
-			ls.analyze_file(ls.trees[uri], ls.sources[uri])
-		}
-
-		ls.show_diagnostics(uri)
+		should_scan_whole_dir = true
 	}
 
+	mut files_to_analyze := if should_scan_whole_dir {
+		os.ls(project_dir) or { [uri.path()] }
+	} else {
+		[uri.path()]
+	}
+
+	for file_name in files_to_analyze {
+		if should_scan_whole_dir && !analyzer.should_analyze_file(file_name) {
+			continue
+		}
+
+		file_uri := lsp.document_uri_from_path(file_name)
+		mut has_source := file_uri in ls.sources
+		mut has_tree := file_uri in ls.trees
+		mut should_be_analyzed := has_source && has_tree
+
+		// Create file only if source does not exist
+		if !has_source {
+			ls.sources[file_uri] = File{
+				uri: file_uri
+				source: if file_uri != uri {
+					os.read_bytes(file_name) or { [] }
+				} else {
+					src.bytes()
+				},
+				version: 1
+			}
+
+			has_source = true
+		}
+
+		// Parse only if tree does not exist
+		if !has_tree {
+			ls.trees[file_uri] = ls.parser.parse_bytes(ls.sources[file_uri].source)
+			has_tree = true
+		}
+
+		// If data about the document/file has recently been created,
+		// mark it as "should_be_analyzed" (hence the variable name).
+		if !should_be_analyzed && (has_source && has_tree) {
+			should_be_analyzed = true
+		}
+
+		// Analyze only if both source and tree exists
+		if should_be_analyzed {
+			ls.analyze_file(ls.trees[file_uri], ls.sources[file_uri])
+			ls.show_diagnostics(file_uri)
+		}
+	}
+
+	ls.store.set_active_file_path(uri.path(), ls.sources[uri].version)
 	if v_check_results := ls.exec_v_diagnostics(uri) {
 		ls.publish_diagnostics(uri, v_check_results)
 	}
@@ -153,7 +163,7 @@ fn (mut ls Vls) did_change(_ string, params string) {
 		)
 	}
 
-	mut new_tree := ls.parser.parse_string_with_old_tree(new_src.bytestr(), ls.trees[uri])
+	mut new_tree := ls.parser.parse_bytes_with_old_tree(new_src, ls.trees[uri])
 	// ls.log_message('${ls.trees[uri].get_changed_ranges(new_tree)}', .info)
 
 	// ls.log_message('new tree: ${new_tree.root_node().sexpr_str()}', .info)

--- a/server/text_synchronization.v
+++ b/server/text_synchronization.v
@@ -154,6 +154,7 @@ fn (mut ls Vls) did_change(_ string, params string) {
 	}
 
 	mut new_tree := ls.parser.parse_string_with_old_tree(new_src.bytestr(), ls.trees[uri])
+	// ls.log_message('${ls.trees[uri].get_changed_ranges(new_tree)}', .info)
 
 	// ls.log_message('new tree: ${new_tree.root_node().sexpr_str()}', .info)
 	ls.trees[uri] = new_tree

--- a/server/text_synchronization.v
+++ b/server/text_synchronization.v
@@ -128,18 +128,17 @@ fn (mut ls Vls) did_change(_ string, params string) {
 		unsafe { new_src.grow_len(diff) }
 
 		// copy(new_src[new_end_idx ..], old_src[old_end_idx ..])
-		mut new_idx, mut right_idx := new_end_idx, 0
-		for new_idx < new_src.len && right_idx < right_text.len {
+		mut new_idx := new_end_idx
+		for right_idx := 0; new_idx < new_src.len && right_idx < right_text.len; right_idx++ {
 			new_src[new_idx] = right_text[right_idx]
 			new_idx++
 			right_idx++
 		}
 
 		// add the remaining characters to the remaining items
-		mut insert_idx, mut change_idx := start_idx, 0
-		for insert_idx < new_src.len && change_idx < content_change.text.len {
+		mut insert_idx := start_idx
+		for change_idx := 0; insert_idx < new_src.len && change_idx < content_change.text.len; change_idx++ {
 			new_src[insert_idx] = content_change.text[change_idx]
-			change_idx++
 			insert_idx++
 		}
 

--- a/server/text_synchronization.v
+++ b/server/text_synchronization.v
@@ -94,7 +94,6 @@ fn (mut ls Vls) did_open(_ string, params string) {
 	}
 }
 
-[manualfree]
 fn (mut ls Vls) did_change(_ string, params string) {
 	did_change_params := json.decode(lsp.DidChangeTextDocumentParams, params) or {
 		ls.panic(err.msg)

--- a/server/text_synchronization.v
+++ b/server/text_synchronization.v
@@ -39,11 +39,10 @@ fn (mut ls Vls) did_open(_ string, params string) {
 		should_scan_whole_dir = true
 	}
 
-	mut files_to_analyze := if should_scan_whole_dir {
-		os.ls(project_dir) or { [uri.path()] }
-	} else {
-		[uri.path()]
-	}
+	mut files_to_analyze := if should_scan_whole_dir { os.ls(project_dir) or { [
+			uri.path()] } } else { [
+			uri.path(),
+		] }
 
 	for file_name in files_to_analyze {
 		if should_scan_whole_dir && !analyzer.should_analyze_file(file_name) {
@@ -63,7 +62,7 @@ fn (mut ls Vls) did_open(_ string, params string) {
 					os.read_bytes(file_name) or { [] }
 				} else {
 					src.bytes()
-				},
+				}
 				version: 1
 			}
 
@@ -122,7 +121,7 @@ fn (mut ls Vls) did_change(_ string, params string) {
 		old_len := new_src.len
 		new_len := old_len - (old_end_idx - start_idx) + content_change.text.len
 		diff := new_len - old_len
-		right_text := new_src[old_end_idx ..].clone()
+		right_text := new_src[old_end_idx..].clone()
 
 		// remove immediately the symbol
 		if content_change.text.len == 0 && diff < 0 {

--- a/server/text_synchronization_test.v
+++ b/server/text_synchronization_test.v
@@ -1,0 +1,7 @@
+module server
+
+import test_utils
+
+fn test_did_update() {
+	
+}

--- a/server/text_synchronization_test.v
+++ b/server/text_synchronization_test.v
@@ -1,7 +1,0 @@
-module server
-
-import test_utils
-
-fn test_did_update() {
-	
-}

--- a/tree_sitter/tree_sitter.v
+++ b/tree_sitter/tree_sitter.v
@@ -74,10 +74,19 @@ pub fn (tree &C.TSTree) edit(input_edit &C.TSInputEdit) {
 	C.ts_tree_edit(tree, input_edit)
 }
 
-[inline]
-pub fn (old_tree &C.TSTree) get_changed_ranges(new_tree &C.TSTree) &C.TSRange {
-	mut count := u32(0)
-	return C.ts_tree_get_changed_ranges(old_tree, new_tree, &count)
+pub fn (old_tree &C.TSTree) get_changed_ranges(new_tree &C.TSTree) []C.TSRange {
+    mut len := u32(0)
+    buf := C.ts_tree_get_changed_ranges(old_tree, new_tree, &len)
+    e_size := int(sizeof(C.TSRange))
+
+    return unsafe {
+        array{
+            element_size: e_size
+            len: int(len)
+            cap: int(len)
+            data: buf
+        }
+    }
 }
 
 [unsafe]

--- a/tree_sitter/tree_sitter.v
+++ b/tree_sitter/tree_sitter.v
@@ -6,15 +6,15 @@ module tree_sitter
 
 // Input
 enum TSVInputEncoding {
-  utf8
-  utf16
+	utf8
+	utf16
 }
 
 [typedef]
 struct C.TSInput {
 mut:
-	payload voidptr
-	read fn (payload voidptr, byte_index u32, position C.TSPoint, bytes_read &u32) &char
+	payload  voidptr
+	read     fn (payload voidptr, byte_index u32, position C.TSPoint, bytes_read &u32) &char
 	encoding TSVInputEncoding
 }
 
@@ -72,18 +72,22 @@ pub fn (mut parser C.TSParser) parse_bytes(content []byte) &C.TSTree {
 fn v_byte_array_input_read(pl voidptr, byte_index u32, position C.TSPoint, bytes_read &u32) &char {
 	payload := *(&[]byte(pl))
 	if byte_index >= u32(payload.len) {
-		unsafe { *bytes_read = 0 }
+		unsafe {
+			*bytes_read = 0
+		}
 		return c''
 	} else {
-		unsafe { *bytes_read = u32(payload.len) - byte_index }
+		unsafe {
+			*bytes_read = u32(payload.len) - byte_index
+		}
 		return unsafe { &char(payload.data) + byte_index }
 	}
 }
 
 pub fn (mut parser C.TSParser) parse_bytes_with_old_tree(content []byte, old_tree &C.TSTree) &C.TSTree {
 	return parser.parse(old_tree,
-		payload: &content,
-		read: v_byte_array_input_read,
+		payload: &content
+		read: v_byte_array_input_read
 		encoding: .utf8
 	)
 }
@@ -118,18 +122,18 @@ pub fn (tree &C.TSTree) edit(input_edit &C.TSInputEdit) {
 }
 
 pub fn (old_tree &C.TSTree) get_changed_ranges(new_tree &C.TSTree) []C.TSRange {
-    mut len := u32(0)
-    buf := C.ts_tree_get_changed_ranges(old_tree, new_tree, &len)
-    e_size := int(sizeof(C.TSRange))
+	mut len := u32(0)
+	buf := C.ts_tree_get_changed_ranges(old_tree, new_tree, &len)
+	e_size := int(sizeof(C.TSRange))
 
-    return unsafe {
-        array{
-            element_size: e_size
-            len: int(len)
-            cap: int(len)
-            data: buf
-        }
-    }
+	return unsafe {
+		array{
+			element_size: e_size
+			len: int(len)
+			cap: int(len)
+			data: buf
+		}
+	}
 }
 
 [unsafe]

--- a/tree_sitter/tree_sitter.v
+++ b/tree_sitter/tree_sitter.v
@@ -4,6 +4,20 @@ module tree_sitter
 #flag -I@VMODROOT/tree_sitter/lib
 #flag @VMODROOT/tree_sitter/lib/lib.o
 
+// Input
+enum TSVInputEncoding {
+  utf8
+  utf16
+}
+
+[typedef]
+struct C.TSInput {
+mut:
+	payload voidptr
+	read fn (payload voidptr, byte_index u32, position C.TSPoint, bytes_read &u32) &char
+	encoding TSVInputEncoding
+}
+
 [typedef]
 struct C.TSParser {}
 
@@ -18,6 +32,11 @@ fn C.ts_parser_reset(parser &C.TSParser)
 [inline]
 pub fn new_parser() &C.TSParser {
 	return C.ts_parser_new()
+}
+
+[inline]
+pub fn (mut parser C.TSParser) parse(old_tree &C.TSTree, input C.TSInput) &C.TSTree {
+	return C.ts_parser_parse(parser, old_tree, input)
 }
 
 [inline]
@@ -43,6 +62,30 @@ pub fn (mut parser C.TSParser) parse_string_with_old_tree(content string, old_tr
 [inline]
 pub fn (mut parser C.TSParser) parse_string_with_old_tree_and_len(content string, old_tree &C.TSTree, len u32) &C.TSTree {
 	return C.ts_parser_parse_string(parser, old_tree, &char(content.str), len)
+}
+
+[inline]
+pub fn (mut parser C.TSParser) parse_bytes(content []byte) &C.TSTree {
+	return parser.parse_bytes_with_old_tree(content, &C.TSTree(0))
+}
+
+fn v_byte_array_input_read(pl voidptr, byte_index u32, position C.TSPoint, bytes_read &u32) &char {
+	payload := *(&[]byte(pl))
+	if byte_index >= u32(payload.len) {
+		unsafe { *bytes_read = 0 }
+		return c''
+	} else {
+		unsafe { *bytes_read = u32(payload.len) - byte_index }
+		return unsafe { &char(payload.data) + byte_index }
+	}
+}
+
+pub fn (mut parser C.TSParser) parse_bytes_with_old_tree(content []byte, old_tree &C.TSTree) &C.TSTree {
+	return parser.parse(old_tree,
+		payload: &content,
+		read: v_byte_array_input_read,
+		encoding: .utf8
+	)
 }
 
 [inline; unsafe]


### PR DESCRIPTION
This PR implements numerous changes across the codebase:
- In tree-sitter, get_changed_ranges has been implemented for future use.
- Adding a new method for parsing source code with byte arrays.
- Refactor didOpen. Add comments
- Refactor didUpdate and add comments to avoid confusion.
- Update symbol scope on register_symbol