### PR TITLE
Correct types in capabilities to match specs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 # Other
 cmd/vls/vls
 .vscode
+vls.log
 
 bin/*
 

--- a/cmd/vls/host.v
+++ b/cmd/vls/host.v
@@ -221,7 +221,7 @@ fn (mut host VlsHost) generate_report() ?string {
 	report_file.writeln('<!-- Copy and paste the contents of this file to https://github.com/vlang/vls/issues/new -->') ?
 	report_file.writeln('## System Information') ?
 	report_file.writeln('### V doctor\n```\n$vdoctor_info\n```\n') ?
-	report_file.writeln('### VLS info \n```\nvls version: ${server.meta.version}\n```\n') ?
+	report_file.writeln('### VLS info \n```\nvls version: $server.meta.version\n```\n') ?
 
 	// Problem Description
 	report_file.writeln('## Problem Description') ?

--- a/lsp/capabilities.v
+++ b/lsp/capabilities.v
@@ -183,7 +183,7 @@ pub mut:
 	type_definition_provider             bool                            [json: typeDefinitionProvider]
 	implementation_provider              bool                            [json: implementationProvider]
 	references_provider                  bool                            [json: referencesProvider]
-	document_highlight_provider          bool                            [json: documentHightlightProvider]
+	document_highlight_provider          bool                            [json: documentHighlightProvider]
 	document_symbol_provider             bool                            [json: documentSymbolProvider]
 	workspace_symbol_provider            bool                            [json: workspaceSymbolProvider]
 	code_action_provider                 bool                            [json: codeActionProvider]

--- a/lsp/capabilities.v
+++ b/lsp/capabilities.v
@@ -191,10 +191,10 @@ pub mut:
 	document_formatting_provider         bool                            [json: documentFormattingProvider]
 	document_on_type_formatting_provider DocumentOnTypeFormattingOptions [json: documentOnTypeFormattingProvider]
 	rename_provider                      bool                            [json: renameProvider]
-	document_link_provider               bool                            [json: documentLinkProvider]
+	document_link_provider               DocumentLinkOptions             [json: documentLinkProvider]
 	color_provider                       bool                            [json: colorProvider]
 	declaration_provider                 bool                            [json: declarationProvider]
-	execute_command_provder              string                          [json: executeCommandProvider; raw]
+	execute_command_provider             ExecuteCommandOptions           [json: executeCommandProvider]
 	folding_range_provider               bool                            [json: foldingRangeProvider]
 	experimental                         map[string]bool
 }

--- a/lsp/initialize.v
+++ b/lsp/initialize.v
@@ -54,7 +54,7 @@ pub enum FailureHandlingKind {
 }
 
 pub struct ExecuteCommandOptions {
-	commands []string
+	commands []string [json: commands]
 }
 
 pub struct StaticRegistrationOptions {


### PR DESCRIPTION
The documentLinkProvider(had bool now DocumentLinkOptions) and executeCommandProvider(had string now ExecuteCommandOptions) had the wrong types.