### PR TITLE
Add dummy code lens support

### DIFF
--- a/build.vsh
+++ b/build.vsh
@@ -1,4 +1,4 @@
-#!/usr/local/bin/v run
+#!/usr/bin/env -S v run
 
 import os
 
@@ -34,7 +34,7 @@ if vls_git_hash.exit_code != 0 {
 }
 os.setenv('VLS_BUILD_COMMIT', vls_git_hash.output.trim_space(), true)
 
-cmd := 'v -gc boehm -keepc -cg -cc $cc cmd/vls -o $full_vls_exec_path'
+cmd := 'v -gc boehm -keepc -cg -showcc -cc $cc cmd/vls -o $full_vls_exec_path'
 println(cmd)
 ret := system(cmd)
 if ret != 0 {

--- a/server/code_lens.v
+++ b/server/code_lens.v
@@ -1,0 +1,19 @@
+module server
+
+import lsp
+import json
+
+fn (mut ls Vls) code_lens(id string, params string) {
+	if Feature.code_lens !in ls.enabled_features {
+		return
+	}
+
+	// code_lens_params :=
+	json.decode(lsp.CodeLensParams, params) or {
+		ls.panic(err.msg())
+		return
+	}
+
+	// TODO: compute codelenses, for now return empty result
+	ls.send_null(id)
+}

--- a/server/code_lens.v
+++ b/server/code_lens.v
@@ -8,11 +8,10 @@ fn (mut ls Vls) code_lens(id string, params string) {
 		return
 	}
 
-	// code_lens_params :=
-	json.decode(lsp.CodeLensParams, params) or {
-		ls.panic(err.msg())
-		return
-	}
+	// json.decode(lsp.CodeLensParams, params) or {
+	// 	ls.panic(err.msg())
+	// 	return
+	// }
 
 	// TODO: compute codelenses, for now return empty result
 	ls.send_null(id)

--- a/server/vls.v
+++ b/server/vls.v
@@ -43,6 +43,7 @@ pub enum Feature {
 	folding_range
 	definition
 	implementation
+	code_lens
 }
 
 // feature_from_str returns the Feature-enum value equivalent of the given string.
@@ -60,6 +61,7 @@ fn feature_from_str(feature_name string) ?Feature {
 		'hover' { return Feature.hover }
 		'folding_range' { return Feature.folding_range }
 		'definition' { return Feature.definition }
+		'code_lens' { return Feature.code_lens }
 		else { return error('feature "$feature_name" not found') }
 	}
 }
@@ -77,6 +79,7 @@ pub const (
 		.folding_range,
 		.definition,
 		.implementation,
+		.code_lens,
 	]
 )
 
@@ -205,6 +208,9 @@ pub fn (mut ls Vls) dispatch(payload string) {
 			}
 			'workspace/didChangeWatchedFiles' {
 				ls.did_change_watched_files(request.params)
+			}
+			'textDocument/codeLens' {
+				ls.code_lens(request.id, request.params)
 			}
 			else {}
 		}


### PR DESCRIPTION
Currently every time we switch document, vscode cancels previous request and requests new code lenses for newly focused document. I thought it would be nice to either:
1. reply with empty response 
OR
2. do not report code lenses capability to vs code
 
Since we probably want to have this capability in the future I thought I will go with option nr 1.

Let me know WDYT.

This functionality is currently implemented in separate file (code_lens.v) and I'm not sure if it is good practice or it should be in features.v file. Personally I think features.v file should be split into several smaller ones, but this is only my take on it.