### PR TITLE
server: move json param decoding to handle_jsonrpc, simplify tests

### DIFF
--- a/jsonrpc/server.v
+++ b/jsonrpc/server.v
@@ -156,10 +156,10 @@ mut:
 
 // ResponseWriter constructs and sends a JSONRPC response to the stream.
 pub struct ResponseWriter {
-	req_id string = 'null' // raw JSON
 mut:
 	sb     strings.Builder
 pub mut:
+	req_id string = 'null' // raw JSON
 	server  &Server
 	writer io.Writer
 }

--- a/jsonrpc/server.v
+++ b/jsonrpc/server.v
@@ -93,7 +93,9 @@ fn (mut s Server) internal_respond(mut base_rw ResponseWriter) ? {
 	}
 
 	s.handler.handle_jsonrpc(&req, mut rw) or {
-		if err is ResponseError {
+		if err is none {
+			rw.write(null)
+		} else if err is ResponseError {
 			rw.write_error(err)
 		} else {
 			rw.write_error(response_error(unknown_error))

--- a/server/code_lens.v
+++ b/server/code_lens.v
@@ -1,19 +1,12 @@
 module server
 
-// import lsp
-// import json
-import jsonrpc
+import lsp
 
-fn (mut ls Vls) code_lens(id string, params string, mut wr ResponseWriter) {
+pub fn (mut ls Vls) code_lens(params lsp.CodeLensParams, mut wr ResponseWriter) ?[]lsp.CodeLens {
 	if Feature.code_lens !in ls.enabled_features {
-		return
+		return none
 	}
 
-	// json.decode(lsp.CodeLensParams, params) or {
-	// 	ls.panic(err.msg())
-	// 	return
-	// }
-
 	// TODO: compute codelenses, for now return empty result
-	wr.write(jsonrpc.null)
+	return none
 }

--- a/server/tests/completion_test.v
+++ b/server/tests/completion_test.v
@@ -424,12 +424,14 @@ const completion_results = {
 }
 
 fn test_completion() ? {
+	mut ls := server.new()
 	mut t := &test_utils.Tester{
 		test_files_dir: test_utils.get_test_files_path(@FILE)
 		folder_name: 'completion'
-		client: new_test_client(server.new())
+		client: new_test_client(ls)
 	}
 
+	mut writer := t.client.server.writer()
 	test_files := t.initialize() ?
 	for file in test_files {
 		test_name := file.file_name
@@ -449,11 +451,13 @@ fn test_completion() ? {
 			t.fail(file, err.msg())
 			continue
 		}
+
 		// initiate completion request
-		actual := t.client.send<lsp.CompletionParams, []lsp.CompletionItem>('textDocument/completion', lsp.CompletionParams{
+		actual := ls.completion(lsp.CompletionParams{
 			...completion_inputs[test_name]
 			text_document: doc_id
-		}) ?
+		}, mut writer) ?
+
 		// compare content
 		expected := completion_results[test_name]
 		assert actual == expected

--- a/server/tests/definition_test.v
+++ b/server/tests/definition_test.v
@@ -380,12 +380,14 @@ const definition_results = {
 }
 
 fn test_definition() ? {
+	mut ls := server.new()
 	mut t := &test_utils.Tester{
 		test_files_dir: test_utils.get_test_files_path(@FILE)
 		folder_name: 'definition'
-		client: new_test_client(server.new())
+		client: new_test_client(ls)
 	}
 
+	mut writer := t.client.server.writer()
 	test_files := t.initialize() ?
 	for file in test_files {
 		test_name := file.file_name
@@ -407,10 +409,10 @@ fn test_definition() ? {
 			continue
 		}
 		// initiate definition request
-		actual := t.client.send<lsp.TextDocumentPositionParams, []lsp.LocationLink>('textDocument/definition', lsp.TextDocumentPositionParams{
+		actual := ls.definition(lsp.TextDocumentPositionParams{
 			text_document: doc_id
 			position: definition_inputs[test_name]
-		}) ?
+		}, mut writer) ?
 
 		// compare content
 		if test_name in definition_should_return_null {

--- a/server/tests/document_symbols_test.v
+++ b/server/tests/document_symbols_test.v
@@ -81,12 +81,13 @@ const doc_symbols_result = {
 }
 
 fn test_document_symbols() ? {
+	mut ls := server.new()
 	mut t := &test_utils.Tester{
 		test_files_dir: test_utils.get_test_files_path(@FILE)
 		folder_name: 'document_symbols'
-		client: new_test_client(server.new())
+		client: new_test_client(ls)
 	}
-
+	mut writer := t.client.server.writer()
 	test_files := t.initialize() ?
 	for file in test_files {
 		// open document
@@ -96,9 +97,9 @@ fn test_document_symbols() ? {
 		}
 
 		// initiate formatting request
-		actual := t.client.send<lsp.DocumentSymbolParams, []lsp.SymbolInformation>('textDocument/documentSymbol', lsp.DocumentSymbolParams{
+		actual := ls.document_symbol(lsp.DocumentSymbolParams{
 			text_document: doc_id
-		}) ?
+		}, mut writer) ?
 
 		// compare content
 		expected := doc_symbols_result[file.file_name].map(lsp.SymbolInformation{

--- a/server/tests/folding_range_test.v
+++ b/server/tests/folding_range_test.v
@@ -49,12 +49,13 @@ const folding_range_results = {
 }
 
 fn test_folding_range() ? {
+	mut ls := server.new()
 	mut t := &test_utils.Tester{
 		test_files_dir: test_utils.get_test_files_path(@FILE)
 		folder_name: 'folding_range'
-		client: new_test_client(server.new())
+		client: new_test_client(ls)
 	}
-
+	mut writer := t.client.server.writer()
 	test_files := t.initialize() or {
 		// TODO: skip for now
 		if err.msg() == 'no test files found for "folding_range"' {
@@ -81,9 +82,9 @@ fn test_folding_range() ? {
 		}
 
 		// initiate folding range request
-		actual := t.client.send<lsp.FoldingRangeParams, []lsp.FoldingRange>('textDocument/foldingRange', lsp.FoldingRangeParams{
+		actual := ls.folding_range(lsp.FoldingRangeParams{
 			text_document: doc_id
-		}) ?
+		}, mut writer) ?
 
 		// compare content
 		assert actual == folding_range_results[test_name]

--- a/server/tests/workspace_did_change_test.v
+++ b/server/tests/workspace_did_change_test.v
@@ -5,13 +5,15 @@ import lsp
 import os
 
 fn test_workspace_did_change() ? {
+	mut ls := server.new()
 	mut t := &test_utils.Tester{
 		test_files_dir: test_utils.get_test_files_path(@FILE)
 		folder_name: 'workspace_did_change'
-		client: new_test_client(server.new())
+		client: new_test_client(ls)
 	}
 
 	// TODO: add a mock filesystem
+	mut writer := t.client.server.writer()
 	test_files := t.initialize() ?
 	for file in test_files {
 		// open document
@@ -21,40 +23,48 @@ fn test_workspace_did_change() ? {
 		}
 	}
 
-	method_name := 'workspace/didChangeWatchedFiles'
-	assert t.is_ok()
-
 	// delete
-	t.client.notify(method_name, lsp.DidChangeWatchedFilesParams{
+	first_file_uri := lsp.document_uri_from_path(test_files.get(1)?.file_path)
+	ls.did_change_watched_files(lsp.DidChangeWatchedFilesParams{
 		changes: [
 			lsp.FileEvent{
-				uri: lsp.document_uri_from_path(test_files.get(1)?.file_path)
+				uri: first_file_uri
 				typ: .deleted
 			},
 		]
-	}) ?
+	}, mut writer)
+	assert ls.files.keys().index(first_file_uri) == -1
+	t.ok(test_files.get(1) ?)
 
 	// rename
-	t.client.notify(method_name, lsp.DidChangeWatchedFilesParams{
+	second_file_uri_old := lsp.document_uri_from_path(test_files.get(2)?.file_path)
+	second_file_uri_new := lsp.document_uri_from_path(os.join_path(os.dir(test_files.get(2)?.file_path), 'renamed.vv'))
+	ls.did_change_watched_files(lsp.DidChangeWatchedFilesParams{
 		changes: [
 			lsp.FileEvent{
-				uri: lsp.document_uri_from_path(test_files.get(2)?.file_path)
+				uri: second_file_uri_old
 				typ: .deleted
 			},
 			lsp.FileEvent{
-				uri: lsp.document_uri_from_path(os.join_path(os.dir(test_files.get(2)?.file_path), 'renamed.vv'))
+				uri: second_file_uri_new
 				typ: .created
 			},
 		]
-	}) ?
+	}, mut writer)
+	assert ls.files.keys().index(second_file_uri_old) == -1
+	assert ls.files.keys().index(second_file_uri_new) != -1
+	t.ok(test_files.get(2) ?)
 
 	// on save
-	t.client.notify(method_name, lsp.DidChangeWatchedFilesParams{
+	ls.did_change_watched_files(lsp.DidChangeWatchedFilesParams{
 		changes: [
 			lsp.FileEvent{
 				uri: lsp.document_uri_from_path(test_files.get(0)?.file_path)
 				typ: .changed
 			},
 		]
-	}) ?
+	}, mut writer)
+	t.ok(test_files.get(2) ?)
+
+	assert t.is_ok()
 }

--- a/server/tests/workspace_symbols_test.v
+++ b/server/tests/workspace_symbols_test.v
@@ -54,12 +54,13 @@ const workspace_symbols_result = [
 ]
 
 fn test_workspace_symbols() ? {
+	mut ls := server.new()
 	mut t := &test_utils.Tester{
 		test_files_dir: test_utils.get_test_files_path(@FILE)
 		folder_name: 'workspace_symbols'
-		client: new_test_client(server.new())
+		client: new_test_client(ls)
 	}
-
+	mut writer := t.client.server.writer()
 	test_files := t.initialize() ?
 	for file in test_files {
 		// open document
@@ -70,6 +71,6 @@ fn test_workspace_symbols() ? {
 	}
 
 	assert t.is_ok()
-	symbols := t.client.send<lsp.WorkspaceSymbolParams, []lsp.SymbolInformation>('workspace/symbol', lsp.WorkspaceSymbolParams{}) ?
+	symbols := ls.workspace_symbol(lsp.WorkspaceSymbolParams{}, mut writer)
 	assert symbols == workspace_symbols_result
 }

--- a/server/vls.v
+++ b/server/vls.v
@@ -97,7 +97,6 @@ mut:
 	parser           &C.TSParser
 	store            analyzer.Store
 	status           ServerStatus = .off
-	files            map[string]File
 	root_uri         lsp.DocumentUri
 	is_typing        bool
 	typing_ch        chan int
@@ -107,6 +106,8 @@ mut:
 	shutdown_timeout time.Duration = 5 * time.minute
 	client_pid       int
 	// client_capabilities lsp.ClientCapabilities
+pub mut:
+	files            map[string]File
 }
 
 pub fn new() &Vls {

--- a/server/vls.v
+++ b/server/vls.v
@@ -250,10 +250,10 @@ pub fn (mut ls Vls) handle_jsonrpc(request &jsonrpc.Request, mut rw jsonrpc.Resp
 				ls.did_change_watched_files(params, mut rw)
 			}
 			'textDocument/codeLens' {
-				params := json.decode(lsp.CodeLensParams, request.params) or {
-					return w.wrap_error(err)
-				}
-				w.write(ls.code_lens(params, mut rw) or {
+				// params := json.decode(lsp.CodeLensParams, request.params) or {
+				// 	return w.wrap_error(err)
+				// }
+				w.write(ls.code_lens(lsp.CodeLensParams{}, mut rw) or {
 					return w.wrap_error(err)
 				})
 			}

--- a/server/vls.v
+++ b/server/vls.v
@@ -1,5 +1,6 @@
 module server
 
+import json
 import jsonrpc
 import lsp
 import lsp.log
@@ -124,7 +125,17 @@ pub fn new() &Vls {
 	return inst
 }
 
-pub fn (mut ls Vls) handle_jsonrpc(request &jsonrpc.Request, mut wr jsonrpc.ResponseWriter) ? {
+fn (mut wr ResponseWriter) wrap_error(err IError) IError {
+	if err is none {
+		return err
+	}
+	wr.log_message(err.msg(), .error)
+	return none
+}
+
+pub fn (mut ls Vls) handle_jsonrpc(request &jsonrpc.Request, mut rw jsonrpc.ResponseWriter) ? {
+	mut w := unsafe { &ResponseWriter(rw) }
+
 	// The server will log a send request/notification
 	// log based on the the received payload since the spec
 	// doesn't indicate a way to log on the client side and
@@ -138,7 +149,7 @@ pub fn (mut ls Vls) handle_jsonrpc(request &jsonrpc.Request, mut wr jsonrpc.Resp
 		// a shutdown request is allowed before server init
 		// but we'll just put it here since we want to formally
 		// shutdown the server after a certain timeout period.
-		ls.shutdown(request.id, mut wr)
+		ls.shutdown(mut rw)
 	} else if ls.status == .initialized {
 		match request.method {
 			// not only requests but also notifications
@@ -148,70 +159,123 @@ pub fn (mut ls Vls) handle_jsonrpc(request &jsonrpc.Request, mut wr jsonrpc.Resp
 				// ls.exit()
 			}
 			'textDocument/didOpen' {
-				ls.did_open(request.id, request.params, mut wr)
+				params := json.decode(lsp.DidOpenTextDocumentParams, request.params) ?
+				ls.did_open(params, mut rw)
 			}
 			'textDocument/didSave' {
-				ls.did_save(request.id, request.params, mut wr)
+				params := json.decode(lsp.DidSaveTextDocumentParams, request.params) ?
+				ls.did_save(params, mut rw)
 			}
 			'textDocument/didChange' {
+				params := json.decode(lsp.DidChangeTextDocumentParams, request.params) ?
 				ls.typing_ch <- 1
-				ls.did_change(request.id, request.params, mut wr)
+				ls.did_change(params, mut rw)
 			}
 			'textDocument/didClose' {
-				ls.did_close(request.id, request.params, mut wr)
+				params := json.decode(lsp.DidCloseTextDocumentParams, request.params) ?
+				ls.did_close(params, mut rw)
 			}
 			'textDocument/formatting' {
-				ls.formatting(request.id, request.params, mut wr)
+				params := json.decode(lsp.DocumentFormattingParams, request.params) or {
+					return w.wrap_error(err)
+				}
+				w.write(ls.formatting(params, mut rw) or {
+					return w.wrap_error(err)
+				})
 			}
 			'textDocument/documentSymbol' {
-				ls.document_symbol(request.id, request.params, mut wr)
+				params := json.decode(lsp.DocumentSymbolParams, request.params) or {
+					return w.wrap_error(err)
+				}
+				w.write(ls.document_symbol(params, mut rw) or {
+					return w.wrap_error(err)
+				})
 			}
 			'workspace/symbol' {
-				ls.workspace_symbol(request.id, request.params, mut wr)
+				// params := json.decode(lsp.WorkspaceSymbolParams, request.params) or {
+				// 	return w.wrap_error(err)
+				// }
+				ls.workspace_symbol(lsp.WorkspaceSymbolParams{}, mut rw)
 			}
 			'textDocument/signatureHelp' {
-				ls.signature_help(request.id, request.params, mut wr)
+				params := json.decode(lsp.SignatureHelpParams, request.params) or {
+					return w.wrap_error(err)
+				}
+				w.write(ls.signature_help(params, mut rw) or {
+					return w.wrap_error(err)
+				})
 			}
 			'textDocument/completion' {
-				ls.completion(request.id, request.params, mut wr)
+				params := json.decode(lsp.CompletionParams, request.params) or {
+					return w.wrap_error(err)
+				}
+				w.write(ls.completion(params, mut rw) or {
+					return w.wrap_error(err)
+				})
 			}
 			'textDocument/hover' {
-				ls.hover(request.id, request.params, mut wr)
+				params := json.decode(lsp.HoverParams, request.params) or {
+					return w.wrap_error(err)
+				}
+				w.write(ls.hover(params, mut rw) or {
+					return w.wrap_error(err)
+				})
 			}
 			'textDocument/foldingRange' {
-				ls.folding_range(request.id, request.params, mut wr)
+				params := json.decode(lsp.FoldingRangeParams, request.params) or {
+					return w.wrap_error(err)
+				}
+				w.write(ls.folding_range(params, mut rw) or {
+					return w.wrap_error(err)
+				})
 			}
 			'textDocument/definition' {
-				ls.definition(request.id, request.params, mut wr)
+				params := json.decode(lsp.TextDocumentPositionParams, request.params) or {
+					return w.wrap_error(err)
+				}
+				w.write(ls.definition(params, mut rw) or {
+					return w.wrap_error(err)
+				})
 			}
 			'textDocument/implementation' {
-				ls.implementation(request.id, request.params, mut wr)
+				params := json.decode(lsp.TextDocumentPositionParams, request.params) or {
+					return w.wrap_error(err)
+				}
+				w.write(ls.implementation(params, mut rw) or {
+					return w.wrap_error(err)
+				})
 			}
 			'workspace/didChangeWatchedFiles' {
-				ls.did_change_watched_files(request.params, mut wr)
+				params := json.decode(lsp.DidChangeWatchedFilesParams, request.params) ?
+				ls.did_change_watched_files(params, mut rw)
 			}
 			'textDocument/codeLens' {
-				ls.code_lens(request.id, request.params, mut wr)
+				params := json.decode(lsp.CodeLensParams, request.params) or {
+					return w.wrap_error(err)
+				}
+				w.write(ls.code_lens(params, mut rw) or {
+					return w.wrap_error(err)
+				})
 			}
 			else {
-				return jsonrpc.response_error(jsonrpc.method_not_found).err()
+				return jsonrpc.method_not_found
 			}
 		}
 	} else {
 		match request.method {
 			'exit' {
-				ls.exit(mut wr)
+				ls.exit(mut rw)
 			}
 			'initialize' {
-				ls.initialize(request.id, request.params, mut wr)
+				params := json.decode(lsp.InitializeParams, request.params) ?
+				w.write(ls.initialize(params, mut rw))
 			}
 			else {
-				err_type := if ls.status == .shutdown {
-					jsonrpc.invalid_request
+				if ls.status == .shutdown {
+					return jsonrpc.invalid_request
 				} else {
-					jsonrpc.server_not_initialized
+					return jsonrpc.server_not_initialized
 				}
-				return jsonrpc.response_error(err_type).err()
 			}
 		}
 	}
@@ -281,11 +345,11 @@ pub fn monitor_changes(mut ls Vls, mut resp_wr ResponseWriter) {
 					timeout_sw.stop()
 				} else if ls.status == .off && ls.shutdown_timeout != 0
 					&& timeout_sw.elapsed() >= ls.shutdown_timeout {
-					ls.shutdown('', mut resp_wr)
+					ls.shutdown(mut resp_wr)
 				}
 
 				if ls.client_pid != 0 && !is_proc_exists(ls.client_pid) {
-					ls.shutdown('', mut resp_wr)
+					ls.shutdown(mut resp_wr)
 				} else if !ls.is_typing {
 					continue
 				}

--- a/server/workspace.v
+++ b/server/workspace.v
@@ -73,7 +73,7 @@ pub fn (mut ls Vls) did_change_watched_files(params lsp.DidChangeWatchedFilesPar
 				if next_change := changes[i + 1] {
 					// is_rename is set to true if next change event is created
 					// and the same as the current uri
-					is_rename = next_change.typ == .created && next_change.uri == change.uri
+					is_rename = next_change.typ == .created
 					continue
 				}
 

--- a/server/workspace.v
+++ b/server/workspace.v
@@ -1,16 +1,10 @@
 module server
 
 import lsp
-import json
 import os
 
-fn (mut ls Vls) did_change_watched_files(params string, mut wr ResponseWriter) {
-	did_change_watched_params := json.decode(lsp.DidChangeWatchedFilesParams, params) or {
-		ls.panic(err.msg(), mut wr)
-		return
-	}
-
-	changes := did_change_watched_params.changes
+pub fn (mut ls Vls) did_change_watched_files(params lsp.DidChangeWatchedFilesParams, mut wr ResponseWriter) {
+	changes := params.changes
 	mut is_rename := false
 
 	// NOTE:


### PR DESCRIPTION
This PR moves all of the JSON parameter decoding from methods to `handle_jsonrpc`. No obvious advantages other than almost-simplified unit testing (more PRs to be done later to tackle this)