### PR TITLE
analyzer/semantic_analyzer: add support for `type_declaration`

### DIFF
--- a/analyzer/test_files/semantic_analyzer/type_expression.test.txt
+++ b/analyzer/test_files/semantic_analyzer/type_expression.test.txt
@@ -1,0 +1,7 @@
+type Foo = Bar
+type Text = string | Baz
+
+---
+
+(error "unknown type `Bar`" [0,11]-[0,14])
+(error "unknown type `Baz`" [1,21]-[1,24])


### PR DESCRIPTION
This PR is a cherry-picked portion of https://github.com/vlang/vls/pull/159.

Adds support for analyzing `type_declaration`. 