### PR TITLE
analyzer/semantic_analyzer: add support for `assert_statement`, `send_statement`, and `assignment_statement`

### DIFF
--- a/analyzer/semantic_analyzer.v
+++ b/analyzer/semantic_analyzer.v
@@ -143,6 +143,45 @@ pub fn (mut an SemanticAnalyzer) top_level_statement(current_node ts.Node<v.Node
 	}
 }
 
+pub fn (mut an SemanticAnalyzer) assignment_statement(node ts.Node<v.NodeType>) ? {
+	op_node := node.child_by_field_name('operator')?
+	op := op_node.raw_node.type_name()[0].ascii_str()
+	is_multiplicative := op in multiplicative_operators
+	is_additive := op in additive_operators
+
+	left_node := node.child_by_field_name('left')?
+	right_node := node.child_by_field_name('right')?
+	left_sym_count := left_node.named_child_count()
+	right_sym_count := right_node.named_child_count()
+
+	if left_sym_count == right_sym_count {
+		for i in u32(0) .. u32(left_sym_count) {
+			left_child := left_node.named_child(i) or { continue }
+			right_child := right_node.named_child(i) or { continue }
+
+			left_sym := an.expression(left_child, as_value: true) or { analyzer.void_sym }
+			mut right_sym := an.expression(right_child, as_value: true) or { analyzer.void_sym }
+
+			if is_multiplicative || is_additive {
+				if left_sym.name in analyzer.numeric_types_with_any_type || right_sym.name in analyzer.numeric_types_with_any_type {
+					an.report(node, errors.mismatched_type_error, left_sym, right_sym)
+				} else {
+					an.report(node, errors.undefined_operation_error, left_sym, op, right_sym)
+				}
+			} else if right_child.type_name == .unary_expression && left_sym != right_sym {
+				unary_op_node := right_child.child_by_field_name('operator') or { continue }
+				if right_sym.kind == .chan_ {
+					right_sym = right_sym.parent_sym
+				}
+
+				an.report(unary_op_node, errors.invalid_assignment_error, left_child.code(an.src_text), left_sym, right_sym)
+			} else if left_sym != right_sym {
+				an.report(node, errors.invalid_assignment_error, left_child.code(an.src_text), left_sym, right_sym)
+			}
+		}
+	}
+}
+
 pub fn (mut an SemanticAnalyzer) block(node ts.Node<v.NodeType>) {
 	mut cursor := new_tree_cursor(node)
 	for got_node in cursor {
@@ -181,6 +220,9 @@ pub fn (mut an SemanticAnalyzer) send_statement(node ts.Node<v.NodeType>) ? {
 
 pub fn (mut an SemanticAnalyzer) statement(node ts.Node<v.NodeType>) {
 	match node.type_name {
+		.assignment_statement {
+			an.assignment_statement(node) or {}
+		}
 		.assert_statement {
 			an.assert_statement(node) or {}
 		}
@@ -262,6 +304,9 @@ pub fn (mut an SemanticAnalyzer) expression(node ts.Node<v.NodeType>, cfg Semant
 	match node.type_name {
 		.binary_expression {
 			return an.binary_expression(node, cfg)
+		}
+		.int_literal, .float_literal {
+			return an.store.infer_value_type_from_node(node, an.src_text)
 		}
 		else {
 			sym := an.store.infer_symbol_from_node(node, an.src_text) or { void_sym }

--- a/analyzer/semantic_analyzer.v
+++ b/analyzer/semantic_analyzer.v
@@ -167,10 +167,25 @@ pub fn (mut an SemanticAnalyzer) assert_statement(node ts.Node<v.NodeType>) ? {
 	}
 }
 
+pub fn (mut an SemanticAnalyzer) send_statement(node ts.Node<v.NodeType>) ? {
+	chan_node := node.child_by_field_name('channel')?
+	val_node := node.child_by_field_name('value')?
+	chan_typ_sym := an.expression(chan_node) or { analyzer.void_sym }
+	val_typ_sym := an.expression(val_node) or { analyzer.void_sym }
+	if chan_typ_sym.kind != .chan_ {
+		an.report(chan_node, errors.send_channel_invalid_chan_type_error, chan_typ_sym)
+	} else if val_typ_sym != chan_typ_sym.parent_sym {
+		an.report(chan_node, errors.send_channel_invalid_value_type_error, val_typ_sym, chan_typ_sym)
+	}
+}
+
 pub fn (mut an SemanticAnalyzer) statement(node ts.Node<v.NodeType>) {
 	match node.type_name {
 		.assert_statement {
 			an.assert_statement(node) or {}
+		}
+		.send_statement {
+			an.send_statement(node) or {}
 		}
 		.short_var_declaration {
 			an.short_var_declaration(node) or {}

--- a/analyzer/semantic_analyzer.v
+++ b/analyzer/semantic_analyzer.v
@@ -159,8 +159,19 @@ pub fn (mut an SemanticAnalyzer) short_var_declaration(node ts.Node<v.NodeType>)
 	}
 }
 
+pub fn (mut an SemanticAnalyzer) assert_statement(node ts.Node<v.NodeType>) ? {
+	expr_node := node.named_child(0)?
+	expr_typ_sym := an.expression(expr_node, as_value: true) or { analyzer.void_sym }
+	if expr_typ_sym.name != 'bool' {
+		an.report(expr_node, errors.invalid_assert_type_error, expr_typ_sym)
+	}
+}
+
 pub fn (mut an SemanticAnalyzer) statement(node ts.Node<v.NodeType>) {
 	match node.type_name {
+		.assert_statement {
+			an.assert_statement(node) or {}
+		}
 		.short_var_declaration {
 			an.short_var_declaration(node) or {}
 		}

--- a/analyzer/test_files/semantic_analyzer/assert_statement.test.txt
+++ b/analyzer/test_files/semantic_analyzer/assert_statement.test.txt
@@ -1,0 +1,11 @@
+fn test_assert() {
+    expected := 1
+    assert expected == 'test'
+    assert 1 + 1
+}
+
+---
+
+(error "mismatched types `int` and `string`" [2,11]-[2,29])
+(error "assert can be used only with `bool` expressions, but found `void` instead" [2,11]-[2,29])
+(error "assert can be used only with `bool` expressions, but found `int` instead" [3,11]-[3,16])

--- a/analyzer/test_files/semantic_analyzer/assignment_statement.test.txt
+++ b/analyzer/test_files/semantic_analyzer/assignment_statement.test.txt
@@ -1,0 +1,16 @@
+fn main() {
+    mut str := 'test'
+    str = 1
+    str *= 'world'
+
+    mut num := 1
+    num /= 'wrong'
+    num = -'welp'
+}
+
+---
+
+(error "cannot assign to `str`: expected `string`, not `int`" [2,4]-[2,11])
+(error "undefined operation `string` * `string`" [3,4]-[3,18])
+(error "mismatched types `int` and `string`" [6,4]-[6,18])
+(error "cannot assign to `num`: expected `int`, not `void`" [7,10]-[7,11])

--- a/analyzer/test_files/semantic_analyzer/send_statement.test.txt
+++ b/analyzer/test_files/semantic_analyzer/send_statement.test.txt
@@ -1,0 +1,12 @@
+fn main() {
+    not_chan := 2
+    not_chan <- 3
+
+    num_chan := chan int{}
+    num_chan <- 'test'
+}
+
+---
+
+(error "cannot push on non-channel `int`" [2,4]-[2,12])
+(error "cannot push `string` on `chan int`" [5,4]-[5,12])


### PR DESCRIPTION
This PR is a cherry-picked portion of https://github.com/vlang/vls/pull/159.

Adds support for analyzing `assert_statement`, `send_statement`, and `assignment_statement` nodes. 