### PR TITLE
cmd/vls, server: change output directory for logs, reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ For other editors, please refer to the plugin's/editor's documentation for instr
 - [x] `foldingRange`
 
 ## Crash Reporting
-When reporting a crash in the language server, you just need to copy the contents of the latest auto-generated error which can be found in the home directory (`C:\Users\<user_name>` for Windows, `/home/<user_name>` for Linux, and `/Users/<user_name>` for MacOS). The contents of the file can be then pasted into the [issue tracker form](https://github.com/vlang/vls/issues/new).
+When reporting a crash in the language server, you just need to copy the contents of the latest auto-generated error which can be found in the home directory (`C:\Users\<user_name>\.vls\reports` for Windows, `/home/<user_name>/.vls/reports` for Linux, and `/Users/<user_name>/.vls/reports` for MacOS). The contents of the file can be then pasted into the [issue tracker form](https://github.com/vlang/vls/issues/new).
 
 Bugs that are not crashes however can still generate report by passing the `--generate-report` flag to the language server CLI.
 

--- a/cmd/vls/host.v
+++ b/cmd/vls/host.v
@@ -177,8 +177,13 @@ fn (mut host VlsHost) handle_exit() {
 }
 
 fn (mut host VlsHost) generate_report() ?string {
+	reports_dir_path := os.join_path(server.get_folder_path(), 'reports')
+	if !os.exists(reports_dir_path) {
+		os.mkdir(reports_dir_path)?
+	}
+
 	report_file_name := 'vls_report_' + time.utc().unix.str() + '.md'
-	report_file_path := os.join_path(os.home_dir(), report_file_name)
+	report_file_path := os.join_path(reports_dir_path, report_file_name)
 	mut report_file := os.create(report_file_path) ?
 	defer {
 		report_file.close()

--- a/server/general.v
+++ b/server/general.v
@@ -102,7 +102,12 @@ fn (mut ls Vls) setup_logger(mut rw ResponseWriter) ?string {
 
 	rw.server.dispatch_event(log.set_logpath_event, log_path) or {
 		sanitized_root_uri := ls.root_uri.path().replace_each(['/', '_', ':', '_', '\\', '_'])
-		alt_log_path := os.join_path(os.home_dir(), 'vls__${sanitized_root_uri}.log')
+		logs_dir_path := os.join_path(get_folder_path(), 'logs')
+		if !os.exists(logs_dir_path) {
+			os.mkdir(logs_dir_path)?
+		}
+
+		alt_log_path := os.join_path(logs_dir_path, 'vls__${sanitized_root_uri}.log')
 		rw.show_message('Cannot save log to ${log_path}. Saving log to $alt_log_path',
 			.error)
 

--- a/server/general_test.v
+++ b/server/general_test.v
@@ -91,7 +91,7 @@ fn test_setup_logger() ? {
 	assert notif.method == 'window/showMessage'
 
 	expected_err_path := os.join_path('non_existent', 'path', 'vls.log')
-	expected_alt_log_path := os.join_path(os.home_dir(), 'vls__non_existent_path.log')
+	expected_alt_log_path := os.join_path(server.get_folder_path(), 'logs', 'vls__non_existent_path.log')
 	assert notif.params == lsp.ShowMessageParams{
 		@type: .error
 		message: 'Cannot save log to ${expected_err_path}. Saving log to $expected_alt_log_path'

--- a/server/vls.v
+++ b/server/vls.v
@@ -12,6 +12,20 @@ import analyzer
 import time
 import v.vmod
 
+const vls_folder_path = os.join_path(os.home_dir(), '.vls')
+
+pub fn get_folder_path() string {
+	if os.is_file(vls_folder_path) {
+		os.rm(vls_folder_path) or {}
+	}
+	
+	if !os.exists(vls_folder_path) {
+		os.mkdir(vls_folder_path) or {}
+	}
+
+	return vls_folder_path
+}
+
 pub const vls_build_commit = meta_vls_build_commit()
 
 pub const meta = meta_info()


### PR DESCRIPTION
This PR changes the output directory for report files and log files from the user's home directory to `<home dir>/.vls` with reports and logs have their own separate subdirectories respectively.

Closes #340.