### PR TITLE
ast: rename `parser` module to `ast`, alias some tree sitter symbols

### DIFF
--- a/analyzer/ast.v
+++ b/analyzer/ast.v
@@ -1,6 +1,6 @@
 module analyzer
 
-import tree_sitter
+import ast
 import tree_sitter_v as v
 
 fn within_range(node_range C.TSRange, range C.TSRange) bool {
@@ -12,9 +12,9 @@ const excluded_nodes = [v.NodeType.const_declaration, .global_var_declaration]
 
 const included_nodes = [v.NodeType.const_spec, .global_var_spec, .global_var_type_initializer, .block]
 
-fn get_nodes_within_range(node tree_sitter.Node<v.NodeType>, range C.TSRange) ?[]tree_sitter.Node<v.NodeType> {
+fn get_nodes_within_range(node ast.Node, range C.TSRange) ?[]ast.Node {
 	child_count := node.named_child_count()
-	mut nodes := []tree_sitter.Node<v.NodeType>{cap: int(child_count)}
+	mut nodes := []ast.Node{cap: int(child_count)}
 
 	for i in u32(0) .. child_count {
 		child := node.named_child(i) or { continue }

--- a/analyzer/imports.v
+++ b/analyzer/imports.v
@@ -3,7 +3,7 @@ module analyzer
 import os
 import tree_sitter
 import tree_sitter_v as v
-import parser
+import ast
 
 pub type ImportsMap = map[string][]Import
 
@@ -157,7 +157,7 @@ pub fn (mut imp Importer) inject_paths_of_new_imports(mut new_imports []&Import,
 // import_modules imports the given Import array to the current directory.
 // It also registers the symbols to the store.
 pub fn (mut imp Importer) import_modules(mut imports []&Import) {
-	mut parser := parser.new()
+	mut parser := ast.new_parser()
 	old_version := imp.store.cur_version
 	old_active_path := imp.store.cur_file_path
 	old_active_dir := imp.store.cur_dir

--- a/analyzer/imports.v
+++ b/analyzer/imports.v
@@ -1,8 +1,6 @@
 module analyzer
 
 import os
-import tree_sitter
-import tree_sitter_v as v
 import ast
 
 pub type ImportsMap = map[string][]Import
@@ -16,7 +14,7 @@ pub fn (mut imp Importer) imports() ImportsMap {
 	return imp.store.imports
 }
 
-pub fn (mut imp Importer) scan_imports(tree &tree_sitter.Tree<v.NodeType>, src_text []rune) []&Import {
+pub fn (mut imp Importer) scan_imports(tree &ast.Tree, src_text []rune) []&Import {
 	root_node := tree.root_node()
 	named_child_len := root_node.named_child_count()
 	mut newly_imported_modules := []&Import{}
@@ -237,7 +235,7 @@ pub fn (mut ss Store) add_import(imp Import) (&Import, bool) {
 }
 
 // import_modules_from_tree scans and imports the modules based from the AST tree
-pub fn (mut store Store) import_modules_from_tree(tree &tree_sitter.Tree<v.NodeType>, src []rune, lookup_paths ...string) {
+pub fn (mut store Store) import_modules_from_tree(tree &ast.Tree, src []rune, lookup_paths ...string) {
 	mut importer := Importer{
 		store: unsafe { store }
 	}

--- a/analyzer/imports_test.v
+++ b/analyzer/imports_test.v
@@ -2,7 +2,7 @@ module analyzer
 
 import tree_sitter
 import tree_sitter_v as v
-import parser
+import ast
 import os
 
 const (
@@ -20,7 +20,7 @@ const (
 )
 
 fn parse_content() &tree_sitter.Tree<v.NodeType> {
-	mut p := parser.new()
+	mut p := ast.new_parser()
 	return p.parse_string(source: analyzer.sample_content)
 }
 
@@ -90,7 +90,7 @@ fn test_import_modules_from_tree() ? {
 }
 
 fn test_import_modules_with_edits() ? {
-	mut p := parser.new()
+	mut p := ast.new_parser()
 	sample_content2 := '
 	import os
 	'

--- a/analyzer/semantic_analyzer.v
+++ b/analyzer/semantic_analyzer.v
@@ -2,7 +2,6 @@ module analyzer
 
 import strconv
 import errors
-import tree_sitter as ts
 import tree_sitter_v as v
 import ast
 import os
@@ -720,7 +719,7 @@ pub fn (mut an SemanticAnalyzer) analyze_from_cursor(mut cursor TreeCursor) {
 }
 
 // analyze analyzes the given tree
-pub fn (mut store Store) analyze(tree &ts.Tree<v.NodeType>, src_text []rune) {
+pub fn (mut store Store) analyze(tree &ast.Tree, src_text []rune) {
 	mut an := SemanticAnalyzer{
 		store: unsafe { store }
 		src_text: src_text

--- a/analyzer/semantic_analyzer.v
+++ b/analyzer/semantic_analyzer.v
@@ -4,6 +4,7 @@ import strconv
 import errors
 import tree_sitter as ts
 import tree_sitter_v as v
+import ast
 import os
 
 pub struct SemanticAnalyzer {
@@ -34,7 +35,7 @@ struct SemanticAnalyzerContext {
 	params []ReportData
 }
 
-fn (mut an SemanticAnalyzer) report(node ts.Node<v.NodeType>, code_or_msg string, data ...ReportData) IError {
+fn (mut an SemanticAnalyzer) report(node ast.Node, code_or_msg string, data ...ReportData) IError {
 	mut is_msg_code := false
 	if code_or_msg in errors.message_templates {
 		is_msg_code = true
@@ -81,7 +82,7 @@ fn (mut an SemanticAnalyzer) format_report(report Report) string {
 	return report.message
 }
 
-fn (mut an SemanticAnalyzer) import_decl(node ts.Node<v.NodeType>) ? {
+fn (mut an SemanticAnalyzer) import_decl(node ast.Node) ? {
 	// Most of the checking is already done in `import_modules_from_trees`
 	// Check only the symbols if they are available
 	symbols := node.child_by_field_name('symbols') ?
@@ -111,19 +112,19 @@ fn (mut an SemanticAnalyzer) import_decl(node ts.Node<v.NodeType>) ? {
 	}
 }
 
-fn (mut an SemanticAnalyzer) const_decl(node ts.Node<v.NodeType>) {
+fn (mut an SemanticAnalyzer) const_decl(node ast.Node) {
 }
 
-fn (mut an SemanticAnalyzer) struct_decl(node ts.Node<v.NodeType>) {
+fn (mut an SemanticAnalyzer) struct_decl(node ast.Node) {
 }
 
-fn (mut an SemanticAnalyzer) interface_decl(node ts.Node<v.NodeType>) {
+fn (mut an SemanticAnalyzer) interface_decl(node ast.Node) {
 }
 
-fn (mut an SemanticAnalyzer) enum_decl(node ts.Node<v.NodeType>) {
+fn (mut an SemanticAnalyzer) enum_decl(node ast.Node) {
 }
 
-fn (mut an SemanticAnalyzer) fn_decl(node ts.Node<v.NodeType>) {
+fn (mut an SemanticAnalyzer) fn_decl(node ast.Node) {
 	body_node := node.child_by_field_name('body') or { return }
 	if name_node := node.child_by_field_name('name') {
 		fn_name := name_node.code(an.src_text)
@@ -136,7 +137,7 @@ fn (mut an SemanticAnalyzer) fn_decl(node ts.Node<v.NodeType>) {
 	an.block(body_node)
 }
 
-fn (mut an SemanticAnalyzer) type_decl(node ts.Node<v.NodeType>) ? {
+fn (mut an SemanticAnalyzer) type_decl(node ast.Node) ? {
 	types_node := node.child_by_field_name('types')?
 	types_count := types_node.named_child_count()
 	
@@ -152,7 +153,7 @@ fn (mut an SemanticAnalyzer) type_decl(node ts.Node<v.NodeType>) ? {
 	}
 }
 
-pub fn (mut an SemanticAnalyzer) top_level_statement(current_node ts.Node<v.NodeType>) {
+pub fn (mut an SemanticAnalyzer) top_level_statement(current_node ast.Node) {
 	match current_node.type_name {
 		.import_declaration {
 			an.import_decl(current_node) or {
@@ -183,7 +184,7 @@ pub fn (mut an SemanticAnalyzer) top_level_statement(current_node ts.Node<v.Node
 	}
 }
 
-pub fn (mut an SemanticAnalyzer) assignment_statement(node ts.Node<v.NodeType>) ? {
+pub fn (mut an SemanticAnalyzer) assignment_statement(node ast.Node) ? {
 	op_node := node.child_by_field_name('operator')?
 	op := op_node.raw_node.type_name()[0].ascii_str()
 	is_multiplicative := op in multiplicative_operators
@@ -232,7 +233,7 @@ pub fn (mut an SemanticAnalyzer) assignment_statement(node ts.Node<v.NodeType>) 
 	}
 }
 
-pub fn (mut an SemanticAnalyzer) block(node ts.Node<v.NodeType>) {
+pub fn (mut an SemanticAnalyzer) block(node ast.Node) {
 	mut cursor := new_tree_cursor(node)
 	mut return_pos_byte := u32(0)
 	mut has_return := false
@@ -252,7 +253,7 @@ pub fn (mut an SemanticAnalyzer) block(node ts.Node<v.NodeType>) {
 	}
 }
 
-pub fn (mut an SemanticAnalyzer) short_var_declaration(node ts.Node<v.NodeType>) ? {
+pub fn (mut an SemanticAnalyzer) short_var_declaration(node ast.Node) ? {
 	right := node.child_by_field_name('right')?
 	right_count := right.named_child_count()
 	for i in u32(0) .. right_count {
@@ -261,7 +262,7 @@ pub fn (mut an SemanticAnalyzer) short_var_declaration(node ts.Node<v.NodeType>)
 	}
 }
 
-pub fn (mut an SemanticAnalyzer) assert_statement(node ts.Node<v.NodeType>) ? {
+pub fn (mut an SemanticAnalyzer) assert_statement(node ast.Node) ? {
 	expr_node := node.named_child(0)?
 	expr_typ_sym := an.expression(expr_node, as_value: true) or { analyzer.void_sym }
 	if expr_typ_sym.name != 'bool' {
@@ -269,7 +270,7 @@ pub fn (mut an SemanticAnalyzer) assert_statement(node ts.Node<v.NodeType>) ? {
 	}
 }
 
-pub fn (mut an SemanticAnalyzer) send_statement(node ts.Node<v.NodeType>) ? {
+pub fn (mut an SemanticAnalyzer) send_statement(node ast.Node) ? {
 	chan_node := node.child_by_field_name('channel')?
 	val_node := node.child_by_field_name('value')?
 	chan_typ_sym := an.expression(chan_node) or { analyzer.void_sym }
@@ -281,7 +282,7 @@ pub fn (mut an SemanticAnalyzer) send_statement(node ts.Node<v.NodeType>) ? {
 	}
 }
 
-pub fn (mut an SemanticAnalyzer) statement(node ts.Node<v.NodeType>) {
+pub fn (mut an SemanticAnalyzer) statement(node ast.Node) {
 	match node.type_name {
 		.assignment_statement {
 			an.assignment_statement(node) or {}
@@ -317,7 +318,7 @@ const comparative_operators = ["==", "!=", "<", "<=", ">", ">="]
 const and_operators = ["&&"]
 const or_operators = ["||"]
 
-fn (an &SemanticAnalyzer) convert_to_lit_type(node ts.Node<v.NodeType>) ?&Symbol {
+fn (an &SemanticAnalyzer) convert_to_lit_type(node ast.Node) ?&Symbol {
 	node_type := node.type_name
 	if node_type == .float_literal || (node_type == .int_literal && node.code(an.src_text).int() < 17) {
 		return an.store.find_symbol('', node.raw_node.type_name())
@@ -325,7 +326,7 @@ fn (an &SemanticAnalyzer) convert_to_lit_type(node ts.Node<v.NodeType>) ?&Symbol
 	return none
 }
 
-pub fn (mut an SemanticAnalyzer) binary_expression(node ts.Node<v.NodeType>, cfg SemanticExpressionAnalyzeConfig) ?&Symbol {
+pub fn (mut an SemanticAnalyzer) binary_expression(node ast.Node, cfg SemanticExpressionAnalyzeConfig) ?&Symbol {
 	left_node := node.child_by_field_name('left')?
 	right_node := node.child_by_field_name('right')?
 	op_node := node.child_by_field_name('operator')?
@@ -373,7 +374,7 @@ pub fn (mut an SemanticAnalyzer) binary_expression(node ts.Node<v.NodeType>, cfg
 	return left_sym
 }
 
-fn (an &SemanticAnalyzer) check_if_type_field_exists(node ts.Node<v.NodeType>, name string) bool {
+fn (an &SemanticAnalyzer) check_if_type_field_exists(node ast.Node, name string) bool {
 	if node.type_name != .literal_value {
 		return false
 	}
@@ -391,7 +392,7 @@ fn (an &SemanticAnalyzer) check_if_type_field_exists(node ts.Node<v.NodeType>, n
 	return false
 }
 
-pub fn (mut an SemanticAnalyzer) type_initializer(node ts.Node<v.NodeType>) ?&Symbol {
+pub fn (mut an SemanticAnalyzer) type_initializer(node ast.Node) ?&Symbol {
 	type_node := node.child_by_field_name('type')?
 	sym_kind, module_name, symbol_name := symbol_name_from_node(type_node, an.src_text)
 
@@ -450,7 +451,7 @@ pub fn (mut an SemanticAnalyzer) type_initializer(node ts.Node<v.NodeType>) ?&Sy
 	return an.store.find_symbol(module_name, symbol_name)
 }
 
-pub fn (mut an SemanticAnalyzer) selector_expression(node ts.Node<v.NodeType>) ?&Symbol {
+pub fn (mut an SemanticAnalyzer) selector_expression(node ast.Node) ?&Symbol {
 	operand := node.child_by_field_name('operand')?
 	mut root_sym := an.expression(operand, as_value: true) or {
 		an.store.infer_symbol_from_node(operand, an.src_text) or { analyzer.void_sym }
@@ -536,7 +537,7 @@ pub fn (mut an SemanticAnalyzer) selector_expression(node ts.Node<v.NodeType>) ?
 	return root_sym
 }
 
-pub fn (mut an SemanticAnalyzer) array(node ts.Node<v.NodeType>) ?&Symbol {
+pub fn (mut an SemanticAnalyzer) array(node ast.Node) ?&Symbol {
 	items_len := node.named_child_count()
 	if items_len == 0 {
 		return an.report(node, errors.untyped_empty_array_error)
@@ -572,7 +573,7 @@ pub fn (mut an SemanticAnalyzer) array(node ts.Node<v.NodeType>) ?&Symbol {
 	}
 }
 
-pub fn (mut an SemanticAnalyzer) call_expression(node ts.Node<v.NodeType>) ?&Symbol {
+pub fn (mut an SemanticAnalyzer) call_expression(node ast.Node) ?&Symbol {
 	fn_node := node.child_by_field_name('function')?
 	arguments_node := node.child_by_field_name('arguments')?
 	fn_sym := an.expression(fn_node) or { analyzer.void_sym }
@@ -624,7 +625,7 @@ pub fn (mut an SemanticAnalyzer) call_expression(node ts.Node<v.NodeType>) ?&Sym
 	}
 }
 
-pub fn (mut an SemanticAnalyzer) if_expression(node ts.Node<v.NodeType>, cfg SemanticExpressionAnalyzeConfig) ?&Symbol {
+pub fn (mut an SemanticAnalyzer) if_expression(node ast.Node, cfg SemanticExpressionAnalyzeConfig) ?&Symbol {
 	if cond_node := node.child_by_field_name('condition') {
 		if cond_node.type_name == .parenthesized_expression {
 			return an.report(cond_node, errors.unnecessary_if_parenthesis_error)
@@ -641,7 +642,7 @@ pub struct SemanticExpressionAnalyzeConfig {
 	as_value bool
 }
 
-pub fn (mut an SemanticAnalyzer) expression(node ts.Node<v.NodeType>, cfg SemanticExpressionAnalyzeConfig) ?&Symbol {
+pub fn (mut an SemanticAnalyzer) expression(node ast.Node, cfg SemanticExpressionAnalyzeConfig) ?&Symbol {
 	match node.type_name {
 		.call_expression {
 			return an.call_expression(node)
@@ -696,7 +697,7 @@ pub fn (mut an SemanticAnalyzer) expression(node ts.Node<v.NodeType>, cfg Semant
 	}
 }
 
-pub fn (mut an SemanticAnalyzer) analyze(node ts.Node<v.NodeType>) {
+pub fn (mut an SemanticAnalyzer) analyze(node ast.Node) {
 	match node.type_name.group() {
 		.top_level_declaration {
 			an.top_level_statement(node)

--- a/analyzer/semantic_analyzer_compliance_test_.skipvv
+++ b/analyzer/semantic_analyzer_compliance_test_.skipvv
@@ -1,5 +1,5 @@
 import os
-import parser
+import ast
 import analyzer { Collector, SemanticAnalyzer, Store, SymbolAnalyzer, new_tree_cursor, setup_builtin }
 import benchmark
 import v.util { formatted_error }
@@ -41,7 +41,7 @@ const skipped_tests = [
 
 // test_analyzer_from_v compares the output from V's checker to VLS' analyzer
 fn test_analyzer_from_v() ? {
-	mut p := parser.new()
+	mut p := ast.new_parser()
 	os.chdir(os.dir(@VEXE)) ?
 
 	input_file_paths := os.glob('vlib/v/checker/tests/*.vv') ?

--- a/analyzer/semantic_analyzer_test.v
+++ b/analyzer/semantic_analyzer_test.v
@@ -1,12 +1,12 @@
 import os
-import parser
+import ast
 import test_utils
 import benchmark
 import analyzer { Collector, SemanticAnalyzer, Store, SymbolAnalyzer, new_tree_cursor, setup_builtin }
 import analyzer.an_test_utils
 
 fn test_semantic_analysis() ? {
-	mut p := parser.new()
+	mut p := ast.new_parser()
 	vlib_path := os.join_path(os.dir(os.getenv('VEXE')), 'vlib')
 
 	mut bench := benchmark.new_benchmark()

--- a/analyzer/store.v
+++ b/analyzer/store.v
@@ -2,8 +2,7 @@ module analyzer
 
 import os
 import analyzer.depgraph
-import tree_sitter
-import tree_sitter_v as v
+import ast
 
 pub struct Store {
 mut:
@@ -358,7 +357,7 @@ pub fn (mut ss Store) delete(dir string, excluded_dir ...string) {
 }
 
 // get_scope_from_node returns a scope based on the given node
-pub fn (mut ss Store) get_scope_from_node(node tree_sitter.Node<v.NodeType>) ?&ScopeTree {
+pub fn (mut ss Store) get_scope_from_node(node ast.Node) ?&ScopeTree {
 	if node.is_null() {
 		return error('unable to create scope')
 	}
@@ -378,7 +377,7 @@ pub fn (mut ss Store) get_scope_from_node(node tree_sitter.Node<v.NodeType>) ?&S
 }
 
 // symbol_name_from_node extracts the symbol's kind, name, and module name from the given node
-pub fn symbol_name_from_node(node tree_sitter.Node<v.NodeType>, src_text []rune) (SymbolKind, string, string) {
+pub fn symbol_name_from_node(node ast.Node, src_text []rune) (SymbolKind, string, string) {
 	// if node.is_null() {
 	// 	return SymbolKind.typedef, '', 'void'
 	// }
@@ -486,7 +485,7 @@ pub fn symbol_name_from_node(node tree_sitter.Node<v.NodeType>, src_text []rune)
 }
 
 // find_symbol_by_type_node returns a symbol based on the given type node
-pub fn (mut store Store) find_symbol_by_type_node(node tree_sitter.Node<v.NodeType>, src_text []rune) ?&Symbol {
+pub fn (mut store Store) find_symbol_by_type_node(node ast.Node, src_text []rune) ?&Symbol {
 	if node.is_null() || src_text.len == 0 {
 		return none
 	}
@@ -575,7 +574,7 @@ pub fn (mut store Store) find_symbol_by_type_node(node tree_sitter.Node<v.NodeTy
 // infer_symbol_from_node returns the specified symbol based on the given node.
 // This is different from infer_value_type_from_node as this returns the symbol
 // instead of symbol's return type or parent for example
-pub fn (mut ss Store) infer_symbol_from_node(node tree_sitter.Node<v.NodeType>, src_text []rune) ?&Symbol {
+pub fn (mut ss Store) infer_symbol_from_node(node ast.Node, src_text []rune) ?&Symbol {
 	if node.is_null() {
 		return none
 	}
@@ -767,7 +766,7 @@ pub fn (mut ss Store) infer_symbol_from_node(node tree_sitter.Node<v.NodeType>, 
 }
 
 // infer_value_type_from_node returns the symbol based on the given node
-pub fn (mut ss Store) infer_value_type_from_node(node tree_sitter.Node<v.NodeType>, src_text []rune) &Symbol {
+pub fn (mut ss Store) infer_value_type_from_node(node ast.Node, src_text []rune) &Symbol {
 	if node.is_null() {
 		return void_sym
 	}
@@ -890,7 +889,7 @@ pub fn (mut ss Store) infer_value_type_from_node(node tree_sitter.Node<v.NodeTyp
 }
 
 // delete_symbol_at_node removes a specific symbol from a specific portion of the node
-pub fn (mut ss Store) delete_symbol_at_node(root_node tree_sitter.Node<v.NodeType>, src []rune, at_range C.TSRange) bool {
+pub fn (mut ss Store) delete_symbol_at_node(root_node ast.Node, src []rune, at_range C.TSRange) bool {
 	unsafe { ss.opened_scopes[ss.cur_file_path].free() }
 	nodes := get_nodes_within_range(root_node, at_range) or { return false }
 	for node in nodes {

--- a/analyzer/symbol_registration.v
+++ b/analyzer/symbol_registration.v
@@ -924,7 +924,7 @@ pub fn (mut sr SymbolAnalyzer) analyze_from_cursor(mut cursor TreeCursor) []&Sym
 }
 
 // register_symbols_from_tree scans and registers all the symbols based on the given tree
-pub fn (mut store Store) register_symbols_from_tree(tree &ts.Tree<v.NodeType>, src_text []rune, is_import bool) {
+pub fn (mut store Store) register_symbols_from_tree(tree &ast.Tree, src_text []rune, is_import bool) {
 	mut sr := new_symbol_analyzer(store, src_text, is_import)
 	mut cursor := new_tree_cursor(tree.root_node())
 	sr.analyze_from_cursor(mut cursor)

--- a/analyzer/symbol_registration.v
+++ b/analyzer/symbol_registration.v
@@ -3,6 +3,7 @@ module analyzer
 import os
 import tree_sitter as ts
 import tree_sitter_v as v
+import ast
 
 const (
 	mut_struct_keyword     = 'mut:'
@@ -26,7 +27,7 @@ mut:
 	first_var_decl_pos C.TSRange
 }
 
-fn (sr &SymbolAnalyzer) new_top_level_symbol(identifier_node ts.Node<v.NodeType>, access SymbolAccess, kind SymbolKind) ?&Symbol {
+fn (sr &SymbolAnalyzer) new_top_level_symbol(identifier_node ast.Node, access SymbolAccess, kind SymbolKind) ?&Symbol {
 	id_node_type_name := identifier_node.type_name
 	if id_node_type_name == .qualified_type {
 		return report_error('Invalid top-level node type `$id_node_type_name`', identifier_node.range())
@@ -77,7 +78,7 @@ fn (sr &SymbolAnalyzer) new_top_level_symbol(identifier_node ts.Node<v.NodeType>
 	return symbol
 }
 
-fn (mut sr SymbolAnalyzer) get_scope(node ts.Node<v.NodeType>) ?&ScopeTree {
+fn (mut sr SymbolAnalyzer) get_scope(node ast.Node) ?&ScopeTree {
 	if sr.is_import {
 		return error('Cannot use scope in import or test mode')
 	}
@@ -85,7 +86,7 @@ fn (mut sr SymbolAnalyzer) get_scope(node ts.Node<v.NodeType>) ?&ScopeTree {
 	return sr.store.get_scope_from_node(node)
 }
 
-fn (mut sr SymbolAnalyzer) const_decl(const_node ts.Node<v.NodeType>) ?[]&Symbol {
+fn (mut sr SymbolAnalyzer) const_decl(const_node ast.Node) ?[]&Symbol {
 	mut access := SymbolAccess.private
 	if const_node.child(0)?.raw_node.type_name() == 'pub' {
 		access = .public
@@ -123,7 +124,7 @@ fn (mut sr SymbolAnalyzer) const_decl(const_node ts.Node<v.NodeType>) ?[]&Symbol
 	return consts
 }
 
-fn (mut sr SymbolAnalyzer) struct_decl(struct_decl_node ts.Node<v.NodeType>) ?&Symbol {
+fn (mut sr SymbolAnalyzer) struct_decl(struct_decl_node ast.Node) ?&Symbol {
 	mut access := SymbolAccess.private
 	if struct_decl_node.child(0) ?.raw_node.type_name() == 'pub' {
 		access = .public
@@ -168,7 +169,7 @@ fn (mut sr SymbolAnalyzer) struct_decl(struct_decl_node ts.Node<v.NodeType>) ?&S
 	return sym
 }
 
-fn (mut sr SymbolAnalyzer) struct_field_decl(field_access SymbolAccess, field_decl_node ts.Node<v.NodeType>) ?&Symbol {
+fn (mut sr SymbolAnalyzer) struct_field_decl(field_access SymbolAccess, field_decl_node ast.Node) ?&Symbol {
 	field_type_node := field_decl_node.child_by_field_name('type') ?
 	field_sym := sr.store.find_symbol_by_type_node(field_type_node, sr.src_text) or { void_sym }
 	field_name_node := field_decl_node.child_by_field_name('name') or {
@@ -202,7 +203,7 @@ fn (mut sr SymbolAnalyzer) struct_field_decl(field_access SymbolAccess, field_de
 	}
 }
 
-fn (mut sr SymbolAnalyzer) interface_decl(interface_decl_node ts.Node<v.NodeType>) ?&Symbol {
+fn (mut sr SymbolAnalyzer) interface_decl(interface_decl_node ast.Node) ?&Symbol {
 	mut access := SymbolAccess.private
 	if interface_decl_node.child(0) ?.raw_node.type_name() == 'pub' {
 		access = SymbolAccess.public
@@ -275,7 +276,7 @@ fn (mut sr SymbolAnalyzer) interface_decl(interface_decl_node ts.Node<v.NodeType
 	return sym
 }
 
-fn (mut sr SymbolAnalyzer) enum_decl(enum_decl_node ts.Node<v.NodeType>) ?&Symbol {
+fn (mut sr SymbolAnalyzer) enum_decl(enum_decl_node ast.Node) ?&Symbol {
 	mut access := SymbolAccess.private
 	if enum_decl_node.child(0) ?.raw_node.type_name() == 'pub' {
 		access = SymbolAccess.public
@@ -331,7 +332,7 @@ fn (mut sr SymbolAnalyzer) enum_decl(enum_decl_node ts.Node<v.NodeType>) ?&Symbo
 	return sym
 }
 
-fn (mut sr SymbolAnalyzer) fn_decl(fn_node ts.Node<v.NodeType>) ?&Symbol {
+fn (mut sr SymbolAnalyzer) fn_decl(fn_node ast.Node) ?&Symbol {
 	mut access := SymbolAccess.private
 	if fn_node.child(0) ?.raw_node.type_name() == 'pub' {
 		access = SymbolAccess.public
@@ -392,7 +393,7 @@ fn (mut sr SymbolAnalyzer) fn_decl(fn_node ts.Node<v.NodeType>) ?&Symbol {
 	return fn_sym
 }
 
-fn (mut sr SymbolAnalyzer) type_decl(type_decl_node ts.Node<v.NodeType>) ?&Symbol {
+fn (mut sr SymbolAnalyzer) type_decl(type_decl_node ast.Node) ?&Symbol {
 	mut access := SymbolAccess.private
 	if type_decl_node.child(0) ?.raw_node.type_name() == 'pub' {
 		access = SymbolAccess.public
@@ -429,7 +430,7 @@ fn (mut sr SymbolAnalyzer) type_decl(type_decl_node ts.Node<v.NodeType>) ?&Symbo
 	return sym
 }
 
-fn (mut sr SymbolAnalyzer) top_level_decl(current_node ts.Node<v.NodeType>) ?[]&Symbol {
+fn (mut sr SymbolAnalyzer) top_level_decl(current_node ast.Node) ?[]&Symbol {
 	mut global_scope := sr.store.opened_scopes[sr.store.cur_file_path]
 	node_type_name := current_node.type_name
 	match node_type_name {
@@ -487,7 +488,7 @@ fn (mut sr SymbolAnalyzer) top_level_decl(current_node ts.Node<v.NodeType>) ?[]&
 	}
 }
 
-fn (mut sr SymbolAnalyzer) short_var_decl(var_decl ts.Node<v.NodeType>) ?[]&Symbol {
+fn (mut sr SymbolAnalyzer) short_var_decl(var_decl ast.Node) ?[]&Symbol {
 	left_expr_lists := var_decl.child_by_field_name('left') ?
 	right_expr_lists := var_decl.child_by_field_name('right') ?
 	left_len := left_expr_lists.named_child_count()
@@ -512,7 +513,7 @@ fn (mut sr SymbolAnalyzer) short_var_decl(var_decl ts.Node<v.NodeType>) ?[]&Symb
 	return vars
 }
 
-fn (mut sr SymbolAnalyzer) register_variable(sym &Symbol, left_expr_lists ts.Node<v.NodeType>, left_idx u32) ?&Symbol {
+fn (mut sr SymbolAnalyzer) register_variable(sym &Symbol, left_expr_lists ast.Node, left_idx u32) ?&Symbol {
 	mut var_access := SymbolAccess.private
 	mut left := left_expr_lists.named_child(left_idx) ?
 	if left.type_name == .mutable_expression {
@@ -532,7 +533,7 @@ fn (mut sr SymbolAnalyzer) register_variable(sym &Symbol, left_expr_lists ts.Nod
 	}
 }
 
-fn (mut sr SymbolAnalyzer) fn_literal(fn_node ts.Node<v.NodeType>) ?&Symbol {
+fn (mut sr SymbolAnalyzer) fn_literal(fn_node ast.Node) ?&Symbol {
 	body_node := fn_node.child_by_field_name('body') ?
 	params_list_node := fn_node.child_by_field_name('parameters') ?
 
@@ -569,7 +570,7 @@ fn (mut sr SymbolAnalyzer) fn_literal(fn_node ts.Node<v.NodeType>) ?&Symbol {
 	return new_sym
 }
 
-fn (mut sr SymbolAnalyzer) match_expression(match_node ts.Node<v.NodeType>) ?[]&Symbol {
+fn (mut sr SymbolAnalyzer) match_expression(match_node ast.Node) ?[]&Symbol {
 	mut cond_node := match_node.child_by_field_name('condition') ?
 	if cond_node.type_name == .mutable_expression {
 		cond_node = cond_node.named_child(0) ?
@@ -622,7 +623,7 @@ fn (mut sr SymbolAnalyzer) match_expression(match_node ts.Node<v.NodeType>) ?[]&
 	return expr_value_type
 }
 
-fn (mut sr SymbolAnalyzer) if_expression(if_stmt_node ts.Node<v.NodeType>) ?[]&Symbol {
+fn (mut sr SymbolAnalyzer) if_expression(if_stmt_node ast.Node) ?[]&Symbol {
 	body_node := if_stmt_node.child_by_field_name('consequence') ?
 	mut if_scope := sr.get_scope(body_node) or { &ScopeTree(0) }
 	mut has_initializer := false
@@ -660,7 +661,7 @@ fn (mut sr SymbolAnalyzer) if_expression(if_stmt_node ts.Node<v.NodeType>) ?[]&S
 	return void_sym_arr
 }
 
-fn (mut sr SymbolAnalyzer) for_statement(for_stmt_node ts.Node<v.NodeType>) ? {
+fn (mut sr SymbolAnalyzer) for_statement(for_stmt_node ast.Node) ? {
 	named_child_count := for_stmt_node.named_child_count()
 	body_node := for_stmt_node.child_by_field_name('body') ?
 	mut scope := sr.get_scope(body_node) or { &ScopeTree(0) }
@@ -733,7 +734,7 @@ fn (mut sr SymbolAnalyzer) for_statement(for_stmt_node ts.Node<v.NodeType>) ? {
 }
 
 // NOTE: make array of symbols return a multi-return instead (?)
-fn (mut sr SymbolAnalyzer) expression(node ts.Node<v.NodeType>) ?[]&Symbol {
+fn (mut sr SymbolAnalyzer) expression(node ast.Node) ?[]&Symbol {
 	match node.type_name {
 		.if_expression {
 			return sr.if_expression(node)
@@ -782,7 +783,7 @@ fn (mut sr SymbolAnalyzer) expression(node ts.Node<v.NodeType>) ?[]&Symbol {
 	return void_sym_arr
 }
 
-fn (mut sr SymbolAnalyzer) statement(node ts.Node<v.NodeType>, mut scope ScopeTree) ?[]&Symbol {
+fn (mut sr SymbolAnalyzer) statement(node ast.Node, mut scope ScopeTree) ?[]&Symbol {
 	match node.type_name {
 		.defer_statement {
 			block_node := node.named_child(0) ?
@@ -810,7 +811,7 @@ fn (mut sr SymbolAnalyzer) statement(node ts.Node<v.NodeType>, mut scope ScopeTr
 	return void_sym_arr
 }
 
-fn (mut sr SymbolAnalyzer) extract_block(node ts.Node<v.NodeType>, mut scope ScopeTree) ?[]&Symbol {
+fn (mut sr SymbolAnalyzer) extract_block(node ast.Node, mut scope ScopeTree) ?[]&Symbol {
 	if node.type_name != .block || sr.is_import {
 		return error('node should be a `block` and cannot be used in `is_import`.')
 	}
@@ -840,7 +841,7 @@ fn (mut sr SymbolAnalyzer) extract_block(node ts.Node<v.NodeType>, mut scope Sco
 	return return_syms
 }
 
-fn extract_parameter_list(node ts.Node<v.NodeType>, mut store Store, src_text []rune) []&Symbol {
+fn extract_parameter_list(node ast.Node, mut store Store, src_text []rune) []&Symbol {
 	params_len := node.named_child_count()
 	mut syms := []&Symbol{cap: int(params_len)}
 
@@ -871,7 +872,7 @@ fn extract_parameter_list(node ts.Node<v.NodeType>, mut store Store, src_text []
 }
 
 // analyze scans and returns a list of symbols and messages (errors/warnings)
-pub fn (mut sr SymbolAnalyzer) analyze(node ts.Node<v.NodeType>) ?[]&Symbol {
+pub fn (mut sr SymbolAnalyzer) analyze(node ast.Node) ?[]&Symbol {
 	match node.type_name.group() {
 		.top_level_declaration {
 			return sr.top_level_decl(node)

--- a/analyzer/symbol_registration_test.v
+++ b/analyzer/symbol_registration_test.v
@@ -1,12 +1,12 @@
 import os
-import parser
+import ast
 import test_utils
 import benchmark
 import analyzer.an_test_utils
 import analyzer { Collector, Store, SymbolAnalyzer, setup_builtin, new_tree_cursor }
 
 fn test_symbol_registration() ? {
-	mut p := parser.new()
+	mut p := ast.new_parser()
 	mut bench := benchmark.new_benchmark()
 	vlib_path := os.join_path(os.dir(os.getenv('VEXE')), 'vlib')
 	mut reporter := &Collector{}

--- a/analyzer/tree_cursor.v
+++ b/analyzer/tree_cursor.v
@@ -2,6 +2,7 @@ module analyzer
 
 import tree_sitter
 import tree_sitter_v as v
+import ast
 
 struct TreeCursor {
 mut:
@@ -11,7 +12,7 @@ mut:
 	cursor        tree_sitter.TreeCursor<v.NodeType> [required]
 }
 
-pub fn (mut tc TreeCursor) next() ?tree_sitter.Node<v.NodeType> {
+pub fn (mut tc TreeCursor) next() ?ast.Node {
 	for tc.cur_child_idx < tc.child_count {
 		if tc.cur_child_idx == -1 {
 			tc.cursor.to_first_child()
@@ -39,8 +40,9 @@ pub fn (mut tc TreeCursor) to_first_child() bool {
 	return tc.cursor.to_first_child()
 }
 
-pub fn (tc &TreeCursor) current_node() ?tree_sitter.Node<v.NodeType> {
-	return tc.cursor.current_node()
+pub fn (tc &TreeCursor) current_node() ?ast.Node {
+	node := tc.cursor.current_node()?
+	return node
 }
 
 [unsafe]
@@ -52,7 +54,7 @@ pub fn (tc &TreeCursor) free() {
 	}
 }
 
-pub fn new_tree_cursor(root_node tree_sitter.Node<v.NodeType>) TreeCursor {
+pub fn new_tree_cursor(root_node ast.Node) TreeCursor {
 	return TreeCursor{
 		child_count: int(root_node.child_count())
 		cursor: root_node.tree_cursor()

--- a/analyzer/tree_walker.v
+++ b/analyzer/tree_walker.v
@@ -2,6 +2,7 @@ module analyzer
 
 import tree_sitter
 import tree_sitter_v as v
+import ast
 
 struct TreeWalker {
 mut:
@@ -9,7 +10,7 @@ mut:
 	cursor                   tree_sitter.TreeCursor<v.NodeType> [required]
 }
 
-pub fn (mut tw TreeWalker) next() ?tree_sitter.Node<v.NodeType> {
+pub fn (mut tw TreeWalker) next() ?ast.Node {
 	if !tw.already_visited_children {
 		if tw.cursor.to_first_child() {
 			tw.already_visited_children = false
@@ -32,10 +33,11 @@ pub fn (mut tw TreeWalker) next() ?tree_sitter.Node<v.NodeType> {
 			return tw.next()
 		}
 	}
-	return tw.cursor.current_node()
+	node := tw.cursor.current_node()?
+	return node
 }
 
-pub fn new_tree_walker(root_node tree_sitter.Node<v.NodeType>) TreeWalker {
+pub fn new_tree_walker(root_node ast.Node) TreeWalker {
 	return TreeWalker{
 		cursor: root_node.tree_cursor()
 	}

--- a/ast/parser.v
+++ b/ast/parser.v
@@ -4,6 +4,7 @@ import tree_sitter
 import tree_sitter_v as v
 
 pub type Node = tree_sitter.Node<v.NodeType>
+pub type Tree = tree_sitter.Tree<v.NodeType>
 
 pub fn new_parser() &tree_sitter.Parser<v.NodeType> {
 	return tree_sitter.new_parser<v.NodeType>(v.language, v.type_factory)

--- a/ast/parser.v
+++ b/ast/parser.v
@@ -1,8 +1,8 @@
-module parser
+module ast
 
 import tree_sitter
 import tree_sitter_v as v
 
-pub fn new() &tree_sitter.Parser<v.NodeType> {
+pub fn new_parser() &tree_sitter.Parser<v.NodeType> {
 	return tree_sitter.new_parser<v.NodeType>(v.language, v.type_factory)
 }

--- a/ast/parser.v
+++ b/ast/parser.v
@@ -3,6 +3,8 @@ module ast
 import tree_sitter
 import tree_sitter_v as v
 
+pub type Node = tree_sitter.Node<v.NodeType>
+
 pub fn new_parser() &tree_sitter.Parser<v.NodeType> {
 	return tree_sitter.new_parser<v.NodeType>(v.language, v.type_factory)
 }

--- a/server/ast.v
+++ b/server/ast.v
@@ -1,7 +1,7 @@
 module server
 
-import tree_sitter
 import tree_sitter_v as v
+import ast
 
 // any node that is separated by a comma or other symbol
 const list_node_types = [v.NodeType.expression_list, .identifier_list, .argument_list, 
@@ -10,8 +10,8 @@ const list_node_types = [v.NodeType.expression_list, .identifier_list, .argument
 const other_node_types = [v.NodeType.if_expression, .for_statement, .return_statement, .for_in_operator,
 	.binary_expression, .unary_expression]
 
-fn traverse_node(root_node tree_sitter.Node<v.NodeType>, offset u32) tree_sitter.Node<v.NodeType> {
-	// TODO: return root_node for now. function must return ?tree_sitter.Node<v.NodeType>
+fn traverse_node(root_node ast.Node, offset u32) ast.Node {
+	// TODO: return root_node for now. function must return ?ast.Node
 	root_type_name := root_node.type_name
 	direct_named_child := root_node.first_named_child_for_byte(offset) or { return root_node }
 	child_type_name := direct_named_child.type_name
@@ -49,7 +49,7 @@ fn traverse_node(root_node tree_sitter.Node<v.NodeType>, offset u32) tree_sitter
 }
 
 // for auto-completion
-fn traverse_node2(starting_node tree_sitter.Node<v.NodeType>, offset u32) tree_sitter.Node<v.NodeType> {
+fn traverse_node2(starting_node ast.Node, offset u32) ast.Node {
 	mut root_node := starting_node
 	mut root_type_name := root_node.type_name
 
@@ -99,7 +99,7 @@ fn traverse_node2(starting_node tree_sitter.Node<v.NodeType>, offset u32) tree_s
 	return traverse_node2(direct_named_child, offset)
 }
 
-fn closest_named_child(starting_node tree_sitter.Node<v.NodeType>, offset u32) tree_sitter.Node<v.NodeType> {
+fn closest_named_child(starting_node ast.Node, offset u32) ast.Node {
 	named_child_count := starting_node.named_child_count()
 	mut selected_node := starting_node
 	for i in u32(0) .. named_child_count {
@@ -121,7 +121,7 @@ const other_symbol_node_types = [v.NodeType.assignment_statement, .call_expressi
 // closest_symbol_node_parent traverse back from child
 // to the nearest node that has a valid, lookup-able symbol node
 // (nodes with names, module name, and etc.)
-fn closest_symbol_node_parent(child_node tree_sitter.Node<v.NodeType>) tree_sitter.Node<v.NodeType> {
+fn closest_symbol_node_parent(child_node ast.Node) ast.Node {
 	parent_node := child_node.parent() or { return child_node }
 	parent_type_name := parent_node.type_name
 	if parent_type_name == .source_file || parent_type_name == .block {

--- a/server/file.v
+++ b/server/file.v
@@ -1,14 +1,13 @@
 module server
 
-import tree_sitter
-import tree_sitter_v as v
+import ast
 import lsp
 
 struct File {
 mut:
 	uri     lsp.DocumentUri
 	source  []rune
-	tree    &tree_sitter.Tree<v.NodeType> [required]
+	tree    &ast.Tree [required]
 	version int = 1
 }
 

--- a/server/vls.v
+++ b/server/vls.v
@@ -7,7 +7,7 @@ import lsp.log
 import os
 import tree_sitter
 import tree_sitter_v as v
-import parser
+import ast
 import analyzer
 import time
 import v.vmod
@@ -116,7 +116,7 @@ pub mut:
 pub fn new() &Vls {
 	reporter := &DiagnosticReporter{} 
 	inst := &Vls{
-		parser: parser.new() 
+		parser: ast.new_parser() 
 		reporter: reporter
 		store: analyzer.Store{
 			reporter: reporter


### PR DESCRIPTION
Now https://github.com/vlang/v/issues/14718 is out of the way, this minor convenience can be applied. The following `tree_sitter` symbols are aliased:

- `tree_sitter.Node<v.NodeType>` => `ast.Node`
- `tree_sitter.Tree<v.NodeType>` => `ast.Tree`
