### PR TITLE
server: implement ropes for handling text buffers

### DIFF
--- a/ropes/ropes.v
+++ b/ropes/ropes.v
@@ -52,7 +52,7 @@ pub fn (r &Rope) at(idx int) rune {
 	}
 
 	if r.is_leaf() {
-		return r.value[idx - 1]
+		return r.value[idx]
 	} else if idx > r.weight {
 		return r.right.at(idx - r.weight)
 	} else {

--- a/ropes/ropes.v
+++ b/ropes/ropes.v
@@ -1,0 +1,183 @@
+// this is a v port of https://github.com/vinzmay/go-rope/blob/master/rope.go
+module ropes
+
+[heap]
+pub struct Rope {
+pub mut:
+	value  []rune
+	weight int
+	length int
+	left   &Rope = &Rope(0)
+	right  &Rope = &Rope(0)
+}
+
+fn (r &Rope) is_leaf() bool {
+	return isnil(r.left)
+}
+
+// new returns a new rope initialized with given string.
+pub fn new(bootstrap string) &Rope {
+	rn := bootstrap.runes()
+	return &Rope{
+		value: rn
+		weight: rn.len
+		length: rn.len
+	}
+}
+
+pub fn (r &Rope) len() int {
+	if isnil(r) {
+		return 0
+	}
+	return r.length
+}
+
+// str() has & appended which is annoying ://
+pub fn (r &Rope) string() string {
+	return r.runes().string()
+}
+
+pub fn (r &Rope) str() string {
+	return r.string()
+}
+
+pub fn (r &Rope) runes() []rune {
+	return r.report(1, r.length)
+}
+
+// at is v equiv of rope.Index(idx)
+pub fn (r &Rope) at(idx int) rune {
+	if idx < 1 || idx > r.length {
+		panic('index out of bounds $idx/$r.length')
+	}
+
+	if r.is_leaf() {
+		return r.value[idx - 1]
+	} else if idx > r.weight {
+		return r.right.at(idx - r.weight)
+	} else {
+		return r.left.at(idx)
+	}
+}
+
+// + is equiv to Concat()
+pub fn (r &Rope) concat(other &Rope) &Rope {
+	if isnil(r) {
+		return other
+	} else if isnil(other) {
+		return r
+	}
+
+	r_len := if isnil(r) { 0 } else { r.length }
+	other_len := if isnil(other) { 0 } else { other.length }
+
+	return &Rope{
+		weight: r_len
+		length: r_len + other_len
+		left: r
+		right: other
+	}
+}
+
+fn (r &Rope) internal_split(idx int, second_rope &Rope) (&Rope, &Rope) {
+	if idx == r.weight {
+		if r.is_leaf() {
+			return r, r.right
+		} else {
+			return r.left, r.right
+		}
+	} else if idx > r.weight {
+		new_right, new_second_rope := r.right.internal_split(idx - r.weight, second_rope)
+		return r.left.concat(new_right), new_second_rope
+	} else {
+		if r.is_leaf() {
+			mut lr := &Rope(0)
+			if idx > 0 {
+				lr = &Rope{
+					weight: idx
+					value: r.value[..idx]
+					length: idx
+				}
+			}
+			return lr, &Rope{
+				weight: r.value.len - idx
+				value: r.value[idx..]
+				length: r.value.len - idx
+			}
+		} else {
+			new_left, new_second_rope := r.left.internal_split(idx, second_rope)
+			return new_left, new_second_rope.concat(r.right)
+		}
+	}
+}
+
+pub fn (r &Rope) split(idx int) (&Rope, &Rope) {
+	if isnil(r) {
+		panic('operation not permitted - rope is nil')
+	} else if idx < 0 || idx > r.len() {
+		panic('rope split out of bounds $idx/$r.len()')
+	}
+	a, b := r.internal_split(idx, &Rope(0))
+	return a, b
+}
+
+pub fn (r &Rope) insert(idx int, str string) &Rope {
+	if isnil(r) {
+		return new(str)
+	} else if str.len == 0 {
+		return r
+	}
+	r1, r2 := r.split(idx)
+	return r1.concat(new(str)).concat(r2)
+}
+
+pub fn (r &Rope) delete(idx int, len int) &Rope {
+	if isnil(r) {
+		panic('operation not permitted - rope is nil')
+	}
+	r1, r2 := r.split(idx)
+	_, r4 := r2.split(len)
+	return r1.concat(r4)
+}
+
+pub fn (r &Rope) report(idx int, len int) []rune {
+	if isnil(r) {
+		return []
+	}
+	mut res := []rune{len: len}
+	r.internal_report(idx, len, mut res)
+	return res
+}
+
+fn (r &Rope) internal_report(idx int, len int, mut res []rune) {
+	if idx > r.weight {
+		r.right.internal_report(idx - r.weight, len, mut res)
+	} else if r.weight >= idx + len - 1 {
+		if r.is_leaf() {
+			mut left_idx := 0
+			mut right_idx := idx - 1
+			for left_idx < res.len {
+				res[left_idx] = r.value[right_idx]
+				right_idx++
+				left_idx++
+			}
+		} else {
+			r.left.internal_report(idx, len, mut res)
+		}
+	} else {
+		r.left.internal_report(idx, r.weight - idx + 1, mut res[..r.weight])
+		r.right.internal_report(idx, len - r.weight + idx - 1, mut res[r.weight..])
+	}
+}
+
+pub fn (r &Rope) substr(idx int, len int) &Rope {
+	if idx < 1 {
+		r.report(1, len)
+	}
+	if idx + len - 1 > r.length {
+		r.report(idx, r.length - idx + 1)
+	}
+	_, r1 := r.split(idx - 1)
+	r2, _ := r1.split(len)
+	return r2
+}

--- a/ropes/ropes.v
+++ b/ropes/ropes.v
@@ -150,6 +150,10 @@ pub fn (r &Rope) report(idx int, len int) []rune {
 }
 
 fn (r &Rope) internal_report(idx int, len int, mut res []rune) {
+	if isnil(r) {
+		return
+	}
+
 	if idx > r.weight {
 		r.right.internal_report(idx - r.weight, len, mut res)
 	} else if r.weight >= idx + len - 1 {

--- a/ropes/ropes.v
+++ b/ropes/ropes.v
@@ -142,7 +142,7 @@ pub fn (r &Rope) delete(idx int, len int) &Rope {
 
 pub fn (r &Rope) report(idx int, len int) []rune {
 	if isnil(r) {
-		return []
+		return []rune{len: 0}
 	}
 	mut res := []rune{len: len}
 	r.internal_report(idx, len, mut res)

--- a/ropes/ropes_test.v
+++ b/ropes/ropes_test.v
@@ -1,0 +1,33 @@
+// a v port of the https://github.com/vinzmay/go-rope/blob/master/rope_test.go test file
+import ropes
+
+fn test_rope_creation() ? {
+	r := ropes.new('test')
+	assert r.str() == 'test'
+	assert r.len() == 4
+}
+
+fn test_rope_concat() ? {
+	r := ropes.new('abcdef')
+	r2 := ropes.new('ghilmno')
+	r3 := r.concat(r2)
+	assert r.str() == 'abcdef'
+	assert r.len() == 6
+	assert r2.str() == 'ghilmno'
+	assert r2.len() == 7
+	assert r3.str() == 'abcdefghilmno'
+	assert r3.len() == 13
+}
+
+fn test_rope_split() ? {
+	r := ropes.new('abcdef')
+	r1, r2 := r.split(4)
+	assert r.str() == 'abcdef'
+	assert r.len() == 6
+	assert r1.str() == 'abcd'
+	assert r1.len() == 4
+	assert r2.str() == 'ef'
+	assert r2.len() == 2
+
+	assert r.delete(1, 4).string() == 'af'
+}

--- a/server/file.v
+++ b/server/file.v
@@ -2,21 +2,22 @@ module server
 
 import ast
 import lsp
+import ropes
 
 struct File {
 mut:
 	uri     lsp.DocumentUri
-	source  []rune
+	source  &ropes.Rope
 	tree    &ast.Tree [required]
 	version int = 1
 }
 
 fn (file &File) get_offset(line int, col int) int {
-	return compute_offset(file.source, line, col)
+	return compute_offset(file.source.runes(), line, col)
 }
 
 fn (file &File) get_position(offset int) lsp.Position {
-	return compute_position(file.source, offset)
+	return compute_position(file.source.runes(), offset)
 }
 
 fn (file_map map[string]File) count(dir string) int {

--- a/server/text_synchronization.v
+++ b/server/text_synchronization.v
@@ -3,18 +3,20 @@ module server
 import lsp
 import os
 import analyzer
+import ropes
 
 fn (mut ls Vls) analyze_file(file File) {
 	ls.reporter.clear(file.uri)
 	file_path := file.uri.path()
+	src := file.source.runes()
 	ls.store.set_active_file_path(file_path, file.version)
-	ls.store.import_modules_from_tree(file.tree, file.source, os.join_path(file.uri.dir_path(),
+	ls.store.import_modules_from_tree(file.tree, src, os.join_path(file.uri.dir_path(),
 		'modules'), ls.root_uri.path(), os.dir(os.dir(file_path)))
 
-	ls.store.register_symbols_from_tree(file.tree, file.source, false)
+	ls.store.register_symbols_from_tree(file.tree, src, false)
 	ls.store.cleanup_imports()
 	if Feature.analyzer_diagnostics in ls.enabled_features {
-		ls.store.analyze(file.tree, file.source)
+		ls.store.analyze(file.tree, src)
 	}
 	ls.reporter.publish(mut ls.writer, file.uri)
 }
@@ -59,11 +61,9 @@ pub fn (mut ls Vls) did_open(params lsp.DidOpenTextDocumentParams, mut wr Respon
 		// Create file only if source does not exist
 		if !has_file {
 			source_str := if file_uri != uri { os.read_file(file_path) or { '' } } else { src }
-			source := source_str.runes()
-
 			ls.files[file_uri] = File{
 				uri: file_uri
-				source: source
+				source: ropes.new(source_str)
 				tree: ls.parser.parse_string(source: source_str)
 				version: 1
 			}
@@ -102,45 +102,33 @@ pub fn (mut ls Vls) did_change(params lsp.DidChangeTextDocumentParams, mut wr Re
 	mut new_src := ls.files[uri].source
 
 	for content_change in params.content_changes {
-		change_text := content_change.text.runes()
-		start_idx := compute_offset(new_src, content_change.range.start.line, content_change.range.start.character)
-		old_end_idx := compute_offset(new_src, content_change.range.end.line, content_change.range.end.character)
+		change_text := content_change.text
+		new_src_runes := new_src.runes()
+		start_idx := compute_offset(new_src_runes, content_change.range.start.line, content_change.range.start.character)
+		old_end_idx := compute_offset(new_src_runes, content_change.range.end.line, content_change.range.end.character)
 		new_end_idx := start_idx + change_text.len
 		start_pos := content_change.range.start
 		old_end_pos := content_change.range.end
-		new_end_pos := compute_position(new_src, new_end_idx)
+		new_end_pos := compute_position(new_src_runes, new_end_idx)
 
-		old_len := new_src.len
+		old_len := new_src.len()
 		new_len := old_len - (old_end_idx - start_idx) + change_text.len
 		diff := new_len - old_len
-		right_text := new_src[old_end_idx..].clone()
 
 		// remove immediately the symbol
 		if change_text.len == 0 && diff < 0 {
-			ls.store.delete_symbol_at_node(ls.files[uri].tree.root_node(), new_src,
+			ls.store.delete_symbol_at_node(ls.files[uri].tree.root_node(), new_src_runes,
 				start_point: lsp_pos_to_tspoint(start_pos)
 				end_point: lsp_pos_to_tspoint(old_end_pos)
 				start_byte: u32(start_idx)
 				end_byte: u32(old_end_idx)
 			)
+
+			// shrink rope
+			new_src = new_src.delete(start_idx, old_end_idx - start_idx)
 		}
 
-		// the new source should grow or shrink
-		unsafe { new_src.grow_len(diff) }
-
-		// copy(new_src[new_end_idx ..], old_src[old_end_idx ..])
-		mut new_idx := new_end_idx
-		for right_idx := 0; new_idx < new_src.len && right_idx < right_text.len; right_idx++ {
-			new_src[new_idx] = right_text[right_idx]
-			new_idx++
-		}
-
-		// add the remaining characters to the remaining items
-		mut insert_idx := start_idx
-		for change_idx := 0; insert_idx < new_src.len && change_idx < change_text.len; change_idx++ {
-			new_src[insert_idx] = change_text[change_idx]
-			insert_idx++
-		}
+		new_src = new_src.insert(start_idx, change_text)
 
 		// edit the tree
 		ls.files[uri].tree.raw_tree.edit(


### PR DESCRIPTION
This PR implements a rope data structure based on https://github.com/vinzmay/go-rope . Before this, VLS uses `[]runes` directly and manipulates the buffer through a combination of `grow_len` and loop insertion which is not suitable. With this tree-like structure, we will be able to manipulate text buffers of files/documents in a proper manner.