### PR TITLE
lsp/log: simplify code, fix "incomplete log" bug

### DIFF
--- a/cmd/vls/main.v
+++ b/cmd/vls/main.v
@@ -92,14 +92,9 @@ fn setup_and_configure_io(cmd cli.Command, is_child bool) ?io.ReaderWriter {
 
 fn setup_logger(cmd cli.Command) jsonrpc.Interceptor {
 	debug_mode := cmd.flags.get_bool('debug') or { false }
-	mut logger := &LogRecorder{
-		filter_kinds: [.recv_request, .send_response]
+	return &LogRecorder{
+		enabled: !debug_mode
 	}
-	if !debug_mode {
-		logger.disable()
-	}
-
-	return logger
 }
 
 fn validate_options(cmd cli.Command) ? {

--- a/lsp/log/log.v
+++ b/lsp/log/log.v
@@ -7,38 +7,14 @@ import io
 import jsonrpc
 import strings
 
-pub interface Logger {
-mut:
-	close()
-	flush()
-	enable()
-	disable()
-	request(msg string, kind TransportKind)
-	response(msg string, kind TransportKind)
-	notification(msg string, kind TransportKind)
-	set_logpath(path string) ?
-}
-
-const default_log_kind_filter = [
-	LogKind.send_notification,
-	.recv_notification,
-	.send_request,
-	.recv_request,
-	.send_response,
-	.recv_response
-]
-
 pub struct LogRecorder {
-	filter_kinds   []LogKind = log.default_log_kind_filter
 mut:
 	file           os.File
 	buffer         strings.Builder
 	file_opened    bool
 	enabled        bool
-	last_timestamp time.Time = time.now()
 pub mut:
 	file_path    string
-	cur_requests map[int]string
 }
 
 pub enum TransportKind {
@@ -56,10 +32,8 @@ struct Payload {
 pub enum LogKind {
 	send_notification
 	recv_notification
-	send_request
 	recv_request
 	send_response
-	recv_response
 }
 
 pub fn (lk LogKind) str() string {
@@ -75,16 +49,15 @@ pub fn (lk LogKind) str() string {
 
 pub struct LogItem {
 	kind      LogKind
-	message   []u8
-	method    string
 	timestamp time.Time = time.now()
+	payload   []u8 // raw JSON
 }
 
 // json is a JSON string representation of the log item.
 pub fn (li LogItem) encode_json(mut wr io.Writer) ? {
-	wr.write('{"kind":"$li.kind","message":'.bytes()) ?
-	wr.write(li.message) ?
-	wr.write(',"timestamp":$li.timestamp.unix}'.bytes()) ?
+	wr.write('{"kind":"$li.kind","timestamp":$li.timestamp.unix,"payload":'.bytes()) ?
+	wr.write(li.payload) ?
+	wr.write('}\n'.bytes()) ?
 }
 
 pub fn new() &LogRecorder {
@@ -101,8 +74,7 @@ pub fn (mut l LogRecorder) set_logpath(path string) ? {
 		l.close()
 	}
 
-	file := os.open_append(os.real_path(path)) ?
-	l.file = file
+	l.file = os.open_append(os.real_path(path)) ?
 	l.file_path = path
 	l.file_opened = true
 	l.enabled = true
@@ -133,16 +105,13 @@ pub fn (mut l LogRecorder) disable() {
 	l.enabled = false
 }
 
-const newline = [u8(`\n`)]
-
 // write writes the log item into the log file or in the
 // buffer if the file is not opened yet.
 [manualfree]
-fn (mut l LogRecorder) write(item LogItem) {
+fn (mut l LogRecorder) log(item LogItem) {
 	if !l.enabled || item.kind !in l.filter_kinds {
 		return
-	}
-	if l.file_opened {
+	} else if l.file_opened {
 		if l.buffer.len != 0 {
 			unsafe {
 				l.file.write_ptr(l.buffer.data, l.buffer.len)
@@ -150,64 +119,16 @@ fn (mut l LogRecorder) write(item LogItem) {
 			}
 		}
 		item.encode_json(mut l.file) or { eprintln(err) }
-		l.file.write(newline) or {}
+		l.flush()
 	} else {
 		item.encode_json(mut l.buffer) or { eprintln(err) }
-		l.buffer.write(newline) or {}
 	}
-
-	l.last_timestamp = item.timestamp
-	// unsafe { content.free() }
-}
-
-// request logs a request message.
-pub fn (mut l LogRecorder) request(msg string, kind TransportKind) {
-	req_kind := match kind {
-		.send { LogKind.send_request }
-		.receive { LogKind.recv_request }
-	}
-
-	mut req_method := ''
-	if kind == .receive {
-		payload := json.decode(Payload, msg) or { Payload{} }
-		l.cur_requests[payload.id] = payload.method
-		req_method = payload.method
-	}
-
-	l.write(kind: req_kind, message: msg.bytes(), method: req_method)
-}
-
-// notification logs a notification message.
-pub fn (mut l LogRecorder) notification(msg string, kind TransportKind) {
-	notif_kind := match kind {
-		.send { LogKind.send_notification }
-		.receive { LogKind.recv_notification }
-	}
-
-	l.write(kind: notif_kind, message: msg.bytes())
-}
-
-// response logs a response message.
-pub fn (mut l LogRecorder) response(msg string, kind TransportKind) {
-	resp_kind := match kind {
-		.send { LogKind.send_response }
-		.receive { LogKind.recv_response }
-	}
-
-	payload := json.decode(Payload, msg) or { Payload{} }
-	mut resp_method := ''
-	if payload.id in l.cur_requests {
-		resp_method = l.cur_requests[payload.id]
-		l.cur_requests.delete(payload.id)
-	}
-
-	l.write(kind: resp_kind, message: msg.bytes(), method: resp_method)
 }
 
 // as a JSON-RPC interceptor
-const event_prefix = 'lspLogger'
+const event_prefix = '$/lspLogger'
 
-pub const set_logpath_event = '$event_prefix/setLogpath'
+pub const set_logpath_event = '$event_prefix/setPath'
 pub const close_event = '$event_prefix/close'
 pub const state_event = '$event_prefix/state'
 
@@ -230,15 +151,18 @@ pub fn (l &LogRecorder) on_raw_request(req []u8) ? {}
 pub fn (l &LogRecorder) on_raw_response(raw_resp []u8) ? {}
 
 pub fn (mut l LogRecorder) on_request(req &jsonrpc.Request) ? {
-	mut log_kind := LogKind.recv_request
-	mut req_method := req.method
-	if req.id.len == 0 {
-		req_method = ''
-		log_kind = .recv_notification
+	log_kind := if req.id.len == 0 {
+		LogKind.recv_notification
+	} else {
+		LogKind.recv_request
 	}
-	l.write(kind: log_kind, message: req.json().bytes(), method: req_method)
+	l.log(kind: log_kind, payload: req.json().bytes())
 }
 
 pub fn (mut l LogRecorder) on_encoded_response(resp []u8) {
-	l.response(resp.bytestr(), .send)
+	if 15 < resp.len && 23 < resp.len && resp[15..23].bytestr() == ',"method"' {
+		l.log(kind: .send_response, payload: resp)
+	} else {
+		l.log(kind: .send_notification, payload: resp)
+	}
 }

--- a/lsp/log/log.v
+++ b/lsp/log/log.v
@@ -2,7 +2,6 @@ module log
 
 import os
 import time
-import json
 import io
 import jsonrpc
 import strings
@@ -107,7 +106,7 @@ pub fn (mut l LogRecorder) disable() {
 // buffer if the file is not opened yet.
 [manualfree]
 fn (mut l LogRecorder) log(item LogItem) {
-	if !l.enabled || item.kind !in l.filter_kinds {
+	if !l.enabled {
 		return
 	} else if l.file_opened {
 		if l.buffer.len != 0 {

--- a/lsp/log/log.v
+++ b/lsp/log/log.v
@@ -40,10 +40,8 @@ pub fn (lk LogKind) str() string {
 	return match lk {
 		.send_notification { 'send-notification' }
 		.recv_notification { 'recv-notification' }
-		.send_request { 'send-request' }
 		.recv_request { 'recv-request' }
 		.send_response { 'send-response' }
-		.recv_response { 'recv-response' }
 	}
 }
 

--- a/lsp/log/log_test.v
+++ b/lsp/log/log_test.v
@@ -4,71 +4,71 @@ import json
 
 struct TestLogItem {
 	kind    string
-	message string
+	payload string
 }
 
 fn test_notification_send() ? {
 	mut lg := new()
 
-	lg.notification('"Hello!"', .send)
+	lg.log(kind: .send_notification, payload: '"Hello!"'.bytes())
 	buf := lg.buffer.str()
 	result := json.decode(TestLogItem, buf) ?
 
 	assert result.kind == 'send-notification'
-	assert result.message == 'Hello!'
+	assert result.payload == 'Hello!'
 }
 
 fn test_notification_receive() ? {
 	mut lg := new()
 
-	lg.notification('"Received!"', .receive)
+	lg.log(kind: .recv_notification, payload: '"Received!"'.bytes())
 	buf := lg.buffer.str()
 	result := json.decode(TestLogItem, buf) ?
 
 	assert result.kind == 'recv-notification'
-	assert result.message == 'Received!'
+	assert result.payload == 'Received!'
 }
 
 fn test_request_send() ? {
 	mut lg := new()
 
-	lg.request('"Request sent."', .send)
+	lg.log(kind: .send_request, payload: '"Request sent."'.bytes())
 	buf := lg.buffer.str()
 	result := json.decode(TestLogItem, buf) ?
 
 	assert result.kind == 'send-request'
-	assert result.message == 'Request sent.'
+	assert result.payload == 'Request sent.'
 }
 
 fn test_request_receive() ? {
 	mut lg := new()
 
-	lg.request('"Request received."', .receive)
+	lg.log(kind: .recv_request, payload: '"Request received."'.bytes())
 	buf := lg.buffer.str()
 	result := json.decode(TestLogItem, buf) ?
 
 	assert result.kind == 'recv-request'
-	assert result.message == 'Request received.'
+	assert result.payload == 'Request received.'
 }
 
 fn test_response_send() ? {
 	mut lg := new()
 
-	lg.response('"Response sent."', .send)
+	lg.log(kind: .send_response, payload: '"Response sent."'.bytes())
 	buf := lg.buffer.str()
 	result := json.decode(TestLogItem, buf) ?
 
 	assert result.kind == 'send-response'
-	assert result.message == 'Response sent.'
+	assert result.payload == 'Response sent.'
 }
 
 fn test_response_receive() ? {
 	mut lg := new()
 
-	lg.response('"Response received."', .receive)
+	lg.log(kind: .recv_response, payload: '"Response received."'.bytes())
 	buf := lg.buffer.str()
 	result := json.decode(TestLogItem, buf) ?
 
 	assert result.kind == 'recv-response'
-	assert result.message == 'Response received.'
+	assert result.payload == 'Response received.'
 }

--- a/lsp/log/log_test.v
+++ b/lsp/log/log_test.v
@@ -32,11 +32,11 @@ fn test_notification_receive() ? {
 fn test_request_send() ? {
 	mut lg := new()
 
-	lg.log(kind: .send_request, payload: '"Request sent."'.bytes())
+	lg.log(kind: .recv_request, payload: '"Request sent."'.bytes())
 	buf := lg.buffer.str()
 	result := json.decode(TestLogItem, buf) ?
 
-	assert result.kind == 'send-request'
+	assert result.kind == 'recv-request'
 	assert result.payload == 'Request sent.'
 }
 
@@ -65,10 +65,10 @@ fn test_response_send() ? {
 fn test_response_receive() ? {
 	mut lg := new()
 
-	lg.log(kind: .recv_response, payload: '"Response received."'.bytes())
+	lg.log(kind: .send_response, payload: '"Response received."'.bytes())
 	buf := lg.buffer.str()
 	result := json.decode(TestLogItem, buf) ?
 
-	assert result.kind == 'recv-response'
+	assert result.kind == 'send-response'
 	assert result.payload == 'Response received.'
 }


### PR DESCRIPTION
This PR simplifies the code for the `lsp/log` module with the logging designed for `jsonrpc.Server` only. Including in this PR is the fix for the "incomplete log" bug when the server is closed unexpectedly by flushing the contents on each log.