### PR TITLE
ropes: reimplement rebalancing concat, and split

### DIFF
--- a/ropes/ropes_test.v
+++ b/ropes/ropes_test.v
@@ -42,8 +42,7 @@ fn test_rope_balance() {
 
 	r = r.insert(4, 'ef')
 	assert r.str() == 'abcdef'
-	assert r.left.str() == 'abcd'
-	assert r.right.str() == 'ef'
+	assert r.is_leaf()
 
 	r = r.rebalance()
 	assert r.str() == 'abcdef'


### PR DESCRIPTION
This PR primarily reimplements the rebalancing feature of the rope data structure which is based on another rope implementation in Go by deadpixi (https://github.com/deadpixi/rope/blob/main/rope.go)

Also, the implementations for split and concat have been reimplemented based on the same implementation in order for the rebalancing to be possible.