### PR TITLE
analyzer, server: partial symbol, import, and semantic analysis

### DIFF
--- a/analyzer/semantic_analyzer.v
+++ b/analyzer/semantic_analyzer.v
@@ -1131,12 +1131,12 @@ pub fn (mut an SemanticAnalyzer) analyze_from_cursor(mut cursor TreeCursor) {
 }
 
 // analyze analyzes the given tree
-pub fn (mut store Store) analyze(tree &ast.Tree, src_text tree_sitter.SourceText) {
+pub fn (mut store Store) analyze(tree &ast.Tree, src_text tree_sitter.SourceText, cfg NewTreeCursorConfig) {
 	mut an := SemanticAnalyzer{
 		store: unsafe { store }
 		src_text: src_text
 	}
 
-	mut cursor := new_tree_cursor(tree.root_node())
+	mut cursor := new_tree_cursor(tree.root_node(), cfg)
 	an.analyze_from_cursor(mut cursor)
 }

--- a/analyzer/store.v
+++ b/analyzer/store.v
@@ -239,10 +239,11 @@ pub fn (mut ss Store) register_symbol(mut info Symbol) ?&Symbol {
 
 		// Remove this?
 		if existing_sym.kind !in analyzer.container_symbol_kinds  {
-			if info.range.start_point.row > existing_sym.range.start_point.row 
-				|| ((existing_sym.kind != .placeholder && existing_sym.kind == info.kind)
+			if existing_sym.kind != .placeholder 
+				&& (info.range.start_point.row > existing_sym.range.start_point.row 
+				|| (existing_sym.kind == info.kind
 				&& (existing_sym.file_path == info.file_path
-				&& existing_sym.file_version >= info.file_version)) {
+				&& existing_sym.file_version >= info.file_version))) {
 				return report_error('Symbol already exists. (idx=$existing_idx) (name="$existing_sym.name")',
 					info.range)
 			}

--- a/analyzer/store.v
+++ b/analyzer/store.v
@@ -238,10 +238,11 @@ pub fn (mut ss Store) register_symbol(mut info Symbol) ?&Symbol {
 		}
 
 		// Remove this?
-		if existing_sym.kind !in analyzer.container_symbol_kinds {
-			if (existing_sym.kind != .placeholder && existing_sym.kind == info.kind)
+		if existing_sym.kind !in analyzer.container_symbol_kinds  {
+			if info.range.start_point.row > existing_sym.range.start_point.row 
+				|| ((existing_sym.kind != .placeholder && existing_sym.kind == info.kind)
 				&& (existing_sym.file_path == info.file_path
-				&& existing_sym.file_version >= info.file_version) {
+				&& existing_sym.file_version >= info.file_version)) {
 				return report_error('Symbol already exists. (idx=$existing_idx) (name="$existing_sym.name")',
 					info.range)
 			}

--- a/analyzer/symbol_registration.v
+++ b/analyzer/symbol_registration.v
@@ -924,9 +924,9 @@ pub fn (mut sr SymbolAnalyzer) analyze_from_cursor(mut cursor TreeCursor) []&Sym
 }
 
 // register_symbols_from_tree scans and registers all the symbols based on the given tree
-pub fn (mut store Store) register_symbols_from_tree(tree &ast.Tree, src_text ts.SourceText, is_import bool) {
+pub fn (mut store Store) register_symbols_from_tree(tree &ast.Tree, src_text ts.SourceText, is_import bool, cfg NewTreeCursorConfig) {
 	mut sr := new_symbol_analyzer(store, src_text, is_import)
-	mut cursor := new_tree_cursor(tree.root_node())
+	mut cursor := new_tree_cursor(tree.root_node(), cfg)
 	sr.analyze_from_cursor(mut cursor)
 }
 

--- a/analyzer/tree_cursor.v
+++ b/analyzer/tree_cursor.v
@@ -6,6 +6,7 @@ import ast
 
 struct TreeCursor {
 mut:
+	start_line_nr u32
 	cur_child_idx int  = -1
 	named_only    bool = true
 	child_count   int                                [required]
@@ -22,7 +23,7 @@ pub fn (mut tc TreeCursor) next() ?ast.Node {
 
 		tc.cur_child_idx++
 		if cur_node := tc.current_node() {
-			if tc.named_only && (cur_node.is_named() && !cur_node.is_extra()) {
+			if tc.named_only && cur_node.raw_node.start_point().row >= tc.start_line_nr && (cur_node.is_named() && !cur_node.is_extra()) {
 				return cur_node
 			}
 		}
@@ -54,9 +55,15 @@ pub fn (tc &TreeCursor) free() {
 	}
 }
 
-pub fn new_tree_cursor(root_node ast.Node) TreeCursor {
+[params]
+pub struct NewTreeCursorConfig {
+	start_line_nr u32
+}
+
+pub fn new_tree_cursor(root_node ast.Node, cfg NewTreeCursorConfig) TreeCursor {	
 	return TreeCursor{
 		child_count: int(root_node.child_count())
 		cursor: root_node.tree_cursor()
+		start_line_nr: cfg.start_line_nr
 	}
 }

--- a/server/text_synchronization.v
+++ b/server/text_synchronization.v
@@ -24,8 +24,8 @@ fn (mut ls Vls) analyze_file(file File, affected_node_type v.NodeType, affected_
 	}
 
 	ls.store.register_symbols_from_tree(file.tree, file.source, false, start_line_nr: affected_line)
-	if Feature.analyzer_diagnostics in ls.enabled_features {
-		ls.store.analyze(file.tree, file.source)
+	if !is_import && Feature.analyzer_diagnostics in ls.enabled_features {
+		ls.store.analyze(file.tree, file.source, start_line_nr: affected_line)
 	}
 
 	ls.reporter.publish(mut ls.writer, file.uri)

--- a/server/vls.v
+++ b/server/vls.v
@@ -382,7 +382,9 @@ pub fn monitor_changes(mut ls Vls, mut resp_wr ResponseWriter) {
 				}
 
 				uri := lsp.document_uri_from_path(ls.store.cur_file_path)
-				ls.analyze_file(ls.files[uri])
+				ls.analyze_file(ls.files[uri], ls.last_affected_node, ls.last_modified_line)
+				ls.last_modified_line = 0
+				ls.last_affected_node = .unknown
 				ls.is_typing = false
 			}
 		}

--- a/server/vls.v
+++ b/server/vls.v
@@ -108,23 +108,24 @@ mut:
 
 struct Vls {
 mut:
-	vroot_path       string
-	parser           &tree_sitter.Parser<v.NodeType>
-	store            analyzer.Store
-	status           ServerStatus = .off
-	root_uri         lsp.DocumentUri
-	is_typing        bool
-	typing_ch        chan int
-	enabled_features []Feature = server.default_features_list
-	capabilities     lsp.ServerCapabilities
-	panic_count      int
-	shutdown_timeout time.Duration = 5 * time.minute
-	client_pid       int
+	vroot_path         string
+	parser             &tree_sitter.Parser<v.NodeType>
+	store              analyzer.Store
+	status             ServerStatus = .off
+	root_uri           lsp.DocumentUri
+	last_modified_line u32 // for did_change
+	is_typing          bool
+	typing_ch          chan int
+	enabled_features   []Feature = server.default_features_list
+	capabilities       lsp.ServerCapabilities
+	panic_count        int
+	shutdown_timeout   time.Duration = 5 * time.minute
+	client_pid         int
 	// client_capabilities lsp.ClientCapabilities
-	reporter         &DiagnosticReporter
-	writer           &ResponseWriter = &ResponseWriter(0)
+	reporter           &DiagnosticReporter
+	writer             &ResponseWriter = &ResponseWriter(0)
 pub mut:
-	files            map[string]File
+	files              map[string]File
 }
 
 pub fn new() &Vls {

--- a/server/vls.v
+++ b/server/vls.v
@@ -114,6 +114,7 @@ mut:
 	status             ServerStatus = .off
 	root_uri           lsp.DocumentUri
 	last_modified_line u32 // for did_change
+	last_affected_node v.NodeType = v.NodeType.unknown
 	is_typing          bool
 	typing_ch          chan int
 	enabled_features   []Feature = server.default_features_list


### PR DESCRIPTION
This PR improves analysis efficiency by only analyzing the affected AST nodes through its line number. Import analysis is now executed if the affected node is an import statement and semantic analysis is executed if its otherwise.

This will hopefully alleviate concerns surrounding #360.