### PR TITLE
cmd/vls: fix child stderr output monitoring

### DIFF
--- a/cmd/vls/host.v
+++ b/cmd/vls/host.v
@@ -104,22 +104,7 @@ fn (mut host VlsHost) listen() {
 	go host.listen_for_errors()
 	go host.listen_for_output()
 	go host.listen_for_input()
-	host.receive_data()
 }
-
-fn (mut host VlsHost) receive_data() {
-	// mut stdout_buffer := strings.new_builder(4096)
-	for !host.has_child_exited() {
-		select {
-			incoming_stderr := <-host.stderr_chan {
-				// Set the last_len to the length of the latest entry so that
-				// the last stderr output will be logged into the error report.
-				host.stderr_logger.writeln(incoming_stderr)
-			}
-		}
-	}
-}
-
 
 fn (mut host VlsHost) listen_for_input() {
 	mut buf := strings.new_builder(1024 * 1024)

--- a/cmd/vls/host.v
+++ b/cmd/vls/host.v
@@ -80,7 +80,6 @@ mut:
 		reset_builder_on_max_count: true
 	}
 	generate_report bool
-	stderr_chan     chan string
 }
 
 fn (mut host VlsHost) has_child_exited() bool {
@@ -125,7 +124,10 @@ fn (mut host VlsHost) listen_for_input() {
 
 fn (mut host VlsHost) listen_for_errors() {
 	for !host.has_child_exited() {
-		host.stderr_chan <- host.child.stderr_read()
+		buf := host.child.stderr_slurp()
+		if buf.len != 0 {
+			host.stderr_logger.writeln(buf)
+		}
 	}
 }
 

--- a/cmd/vls/host.v
+++ b/cmd/vls/host.v
@@ -144,11 +144,7 @@ fn (mut host VlsHost) listen_for_output() {
 }
 
 fn (mut host VlsHost) handle_exit() {
-	if !host.generate_report && host.child.code > 0 {
-		host.generate_report = true
-	}
-
-	if host.generate_report {
+	if host.generate_report || host.child.code != 0 {
 		report_path := host.generate_report() or {
 			// should not happen
 			panic(err)


### PR DESCRIPTION
Fixes #360. This PR fixes the increased CPU usage of host process on Windows caused by a "less used" select loop and a continuous logging of stderr regardless of its content. The offending code has been removed and `stderr_read` is replaced with `stderr_flush` so that it would only be logged if whenever it has content or is in EOF. 

Before the patch, CPU usage of the host process on standby ranges from 20% up to 45% compared to 0.5% to 6% after the patch.

The change shouldn't regress on platforms other than Windows.