### PR TITLE
server: fix exec_v_diagnostics hang on Windows

### DIFF
--- a/server/diagnostics.v
+++ b/server/diagnostics.v
@@ -131,7 +131,7 @@ fn (mut ls Vls) exec_v_diagnostics(uri lsp.DocumentUri) ?int {
 	defer {
 		p.close()
 	}
-	p.wait()
+	p.run()
 	if p.code == 0 {
 		return none
 	}


### PR DESCRIPTION
This PR fixes the server hang upon executing `executing_v_diagnostics` on `textDocument/didOpen` on Windows after opening a text document/file by running the process only and not wait for it to finish processing. 

This should not regress on platforms other than Windows.