### PR TITLE
server, jsonrpc, lsp/log: fix setup logger process

### DIFF
--- a/cmd/vls/main.v
+++ b/cmd/vls/main.v
@@ -36,7 +36,7 @@ fn run_host(cmd cli.Command) ? {
 				server_args << flag_value
 			}
 			'debug' {
-				flag_value := cmd.flags.get_bool(flag.name) or { continue }
+				flag_value := cmd.flags.get_bool(flag.name) or { false }
 				if !flag_value {
 					continue
 				}

--- a/jsonrpc/server.v
+++ b/jsonrpc/server.v
@@ -237,17 +237,24 @@ fn (mut wr InterceptorWriter) write(buf []u8) ?int {
 }
 
 // PassiveHandler is an implementation of a Handler
-// used as a default value for Server.handler 
+// used as a default value for Server.handler
 pub struct PassiveHandler {}
 
 fn (mut h PassiveHandler) handle_jsonrpc(req &Request, mut rw ResponseWriter) ? {}
 
 // is_intercepter_enabled checks if the given T is enabled in a Server.
 pub fn is_interceptor_enabled<T>(server &Server) bool {
-	for inter in server.interceptors {
-		if inter is T {
-			return true
-		}
+	get_interceptor<T>(server) or {
+		return true
 	}
 	return false
+}
+
+pub fn get_interceptor<T>(server &Server) ?&T {
+	for inter in server.interceptors {
+		if inter is T {
+			return inter
+		}
+	}
+	return none
 }

--- a/lsp/log/log.v
+++ b/lsp/log/log.v
@@ -65,6 +65,10 @@ pub fn new() &LogRecorder {
 	}
 }
 
+pub fn (l &LogRecorder) is_enabled() bool {
+	return l.enabled
+}
+
 // set_logpath sets the filepath of the log file and opens the file.
 pub fn (mut l LogRecorder) set_logpath(path string) ? {
 	if l.file_opened {

--- a/server/general.v
+++ b/server/general.v
@@ -94,8 +94,6 @@ pub fn (mut ls Vls) initialize(params lsp.InitializeParams, mut wr ResponseWrite
 		}
 	}
 
-	wr.log_message('is_logger_installed: $is_logger_installed | is_logger_enabled: $is_logger_enabled | params.trace: ${params.trace}\n', .info)
-
 	// Create the file either in debug mode or when the client trace is set to verbose.
 	if is_logger_installed && is_logger_enabled {
 		// set up logger set to the workspace path
@@ -104,6 +102,9 @@ pub fn (mut ls Vls) initialize(params lsp.InitializeParams, mut wr ResponseWrite
 
 	// print initial info
 	ls.print_info(params.process_id, params.client_info, mut wr)
+
+	// print debug options info to avoid general_test failing
+	wr.log_message('is_logger_installed: $is_logger_installed | is_logger_enabled: $is_logger_enabled | params.trace: ${params.trace}', .info)
 
 	// since builtin is used frequently, they should be parsed first and only once
 	analyzer.setup_builtin(mut ls.store, os.join_path(ls.vroot_path, 'vlib', 'builtin'))

--- a/server/general_test.v
+++ b/server/general_test.v
@@ -86,6 +86,7 @@ fn test_setup_logger() ? {
 	println('test_setup_logger')
 	mut io := new_test_client(server.new(), &LogRecorder{})
 	io.send<lsp.InitializeParams, lsp.InitializeResult>('initialize', lsp.InitializeParams{
+		trace: 'verbose'
 		root_uri: lsp.document_uri_from_path(os.join_path('non_existent', 'path'))
 	}) ?
 


### PR DESCRIPTION
Fixes the issue when VLS sets up a log file even if `--debug` is set to false. This is caused by having a logic that a `LogRecorder` installed is automatically assumed that a logger is activated.