### PR TITLE
api: migrate the reader API

### DIFF
--- a/cmd/vls/streams.v
+++ b/cmd/vls/streams.v
@@ -22,7 +22,7 @@ fn new_stdio_stream() ?io.ReaderWriter {
 
 struct StdioStream {
 mut:
-	stdin os.File = os.stdin()
+	stdin  os.File = os.stdin()
 	stdout os.File = os.stdout()
 }
 
@@ -33,13 +33,15 @@ fn (stream &StdioStream) stdin_file() &C.FILE {
 }
 
 pub fn (mut stream StdioStream) write(buf []u8) ?int {
-	defer { stream.stdout.flush() }
+	defer {
+		stream.stdout.flush()
+	}
 	return stream.stdout.write(buf)
 }
 
-pub fn (mut stream StdioStream) read(mut buf []u8) ?int {
+pub fn (mut stream StdioStream) read(mut buf []u8) !int {
 	stdin_file := stream.stdin_file()
-	initial_len := get_raw_input(stdin_file, mut buf) ?
+	initial_len := get_raw_input(stdin_file, mut buf) or { return IError(io.Eof{}) }
 	if buf.len < 1 || !buf.bytestr().starts_with(content_length) {
 		return error('content length is missing')
 	}
@@ -92,7 +94,7 @@ fn new_socket_stream_server(port int, log bool) ?io.ReaderWriter {
 
 	// Open the connection.
 	address := '$base_ip:$port'
-	mut listener := net.listen_tcp(.ip, address) ?
+	mut listener := net.listen_tcp(.ip, address)?
 
 	if log {
 		eprintln(term.yellow('Warning: TCP connection is used primarily for debugging purposes only \n\tand may have performance issues. Use it on your own risk.\n'))
@@ -121,7 +123,7 @@ fn new_socket_stream_server(port int, log bool) ?io.ReaderWriter {
 fn new_socket_stream_client(port int) ?io.ReaderWriter {
 	// Open the connection.
 	address := '$base_ip:$port'
-	mut conn := net.dial_tcp(address) ?
+	mut conn := net.dial_tcp(address)?
 	mut reader := io.new_buffered_reader(reader: conn, cap: 1024 * 1024)
 	conn.set_blocking(true) or {}
 
@@ -137,10 +139,10 @@ fn new_socket_stream_client(port int) ?io.ReaderWriter {
 
 struct SocketStream {
 	log_label string = 'vls'
-	log       bool = true
+	log       bool   = true
 mut:
-	conn     &net.TcpConn       = &net.TcpConn(0)
-	reader   &io.BufferedReader = voidptr(0)
+	conn   &net.TcpConn       = &net.TcpConn(0)
+	reader &io.BufferedReader = unsafe { nil }
 pub mut:
 	port  int = 5007
 	debug bool
@@ -155,23 +157,23 @@ pub fn (mut sck SocketStream) write(buf []u8) ?int {
 	}
 
 	// if output.starts_with(content_length) {
-		// sck.conn.write_string(output) or { panic(err) }
+	// sck.conn.write_string(output) or { panic(err) }
 	// } else {
-		// sck.conn.write_string(make_lsp_payload(output)) or { panic(err) }
+	// sck.conn.write_string(make_lsp_payload(output)) or { panic(err) }
 	// }
 	return sck.conn.write(buf)
 }
 
-const newlines = [u8(`\r`),`\n`]
+const newlines = [u8(`\r`), `\n`]
 
 [manualfree]
-pub fn (mut sck SocketStream) read(mut buf []u8) ?int {
+pub fn (mut sck SocketStream) read(mut buf []u8) !int {
 	mut conlen := 0
 	mut header_len := 0
 
 	for {
 		// read header line
-		got_header := sck.reader.read_line() ?
+		got_header := sck.reader.read_line() or { return IError(io.Eof{}) }
 		buf << got_header.bytes()
 		buf << newlines
 		// $if !test {
@@ -183,7 +185,7 @@ pub fn (mut sck SocketStream) read(mut buf []u8) ?int {
 		} else if got_header.starts_with(content_length) {
 			conlen = got_header.all_after(content_length).int()
 			// read blank line
-			empty := sck.reader.read_line() ?
+			empty := sck.reader.read_line() or { return IError(io.Eof{}) }
 			buf << empty.bytes()
 			buf << newlines
 			header_len = got_header.len + 4
@@ -195,10 +197,12 @@ pub fn (mut sck SocketStream) read(mut buf []u8) ?int {
 
 	if conlen > 0 {
 		mut rbody := []u8{len: conlen}
-		defer { unsafe { rbody.free() } }
+		defer {
+			unsafe { rbody.free() }
+		}
 
 		for read_data_len := 0; read_data_len != conlen; {
-			read_data_len = sck.reader.read(mut rbody) ?
+			read_data_len = sck.reader.read(mut rbody) or { return IError(io.Eof{}) }
 		}
 
 		buf << rbody

--- a/jsonrpc/server.v
+++ b/jsonrpc/server.v
@@ -14,20 +14,20 @@ import io
 pub struct Server {
 mut:
 	// internal fields
-	req_buf strings.Builder = strings.new_builder(4096)
+	req_buf    strings.Builder = strings.new_builder(4096)
 	conlen_buf strings.Builder = strings.new_builder(4096)
-	res_buf strings.Builder = strings.new_builder(4096)
+	res_buf    strings.Builder = strings.new_builder(4096)
 pub mut:
-	stream  io.ReaderWriter
+	stream       io.ReaderWriter
 	interceptors []Interceptor
-	handler Handler
+	handler      Handler
 }
 
 // intercept_raw_request intercepts the incoming raw request buffer
 // to the interceptors.
 pub fn (mut s Server) intercept_raw_request(req []u8) ? {
 	for mut interceptor in s.interceptors {
-		interceptor.on_raw_request(req) ?
+		interceptor.on_raw_request(req)?
 	}
 }
 
@@ -35,7 +35,7 @@ pub fn (mut s Server) intercept_raw_request(req []u8) ? {
 // to the interceptors.
 pub fn (mut s Server) intercept_request(req &Request) ? {
 	for mut interceptor in s.interceptors {
-		interceptor.on_request(req) ?
+		interceptor.on_request(req)?
 	}
 }
 
@@ -52,7 +52,7 @@ pub interface InterceptorData {}
 // dispatch_event sends a custom event to the interceptors.
 pub fn (mut s Server) dispatch_event(event_name string, data InterceptorData) ? {
 	for mut i in s.interceptors {
-		i.on_event(event_name, data) ?
+		i.on_event(event_name, data)?
 	}
 }
 
@@ -70,8 +70,14 @@ pub fn (mut s Server) respond() ? {
 }
 
 fn (mut s Server) internal_respond(mut base_rw ResponseWriter) ? {
-	defer { s.req_buf.go_back_to(0) }
-	s.stream.read(mut s.req_buf) ?
+	defer {
+		s.req_buf.go_back_to(0)
+	}
+	s.stream.read(mut s.req_buf) or {
+		if err !is io.Eof {
+			return err
+		}
+	}
 
 	req := s.process_raw_request(s.req_buf.after(0)) or {
 		base_rw.write_error(response_error(error: parse_error))
@@ -97,7 +103,7 @@ fn (mut s Server) internal_respond(mut base_rw ResponseWriter) ? {
 				rw.write(null)
 			} else if err is ResponseError {
 				rw.write_error(err)
-			} else if err.code() !in jsonrpc.error_codes {
+			} else if err.code() !in error_codes {
 				rw.write_error(response_error(error: unknown_error))
 			} else {
 				rw.write_error(response_error(error: err))
@@ -128,7 +134,7 @@ pub fn (s &Server) writer(cfg NewWriterConfig) &ResponseWriter {
 				Writer{
 					clen_sb: if cfg.own_buffer { s.conlen_buf.clone() } else { s.conlen_buf }
 					read_writer: s.stream
-				}
+				},
 			]
 		}
 		sb: if cfg.own_buffer { s.res_buf.clone() } else { s.res_buf }
@@ -139,9 +145,7 @@ pub fn (s &Server) writer(cfg NewWriterConfig) &ResponseWriter {
 pub fn (mut s Server) start() {
 	mut rw := s.writer()
 	for {
-		s.internal_respond(mut rw) or {
-			continue
-		}
+		s.internal_respond(mut rw) or { continue }
 	}
 }
 
@@ -165,10 +169,10 @@ mut:
 // ResponseWriter constructs and sends a JSONRPC response to the stream.
 pub struct ResponseWriter {
 mut:
-	sb     strings.Builder
+	sb strings.Builder
 pub mut:
 	req_id string = 'null' // raw JSON
-	server  &Server
+	server &Server
 	writer io.Writer
 }
 
@@ -179,7 +183,7 @@ fn (mut rw ResponseWriter) close() {
 
 // write sends the given payload to the stream.
 pub fn (mut rw ResponseWriter) write<T>(payload T) {
-	final_resp := jsonrpc.Response<T>{
+	final_resp := Response<T>{
 		id: rw.req_id
 		result: payload
 	}
@@ -190,7 +194,7 @@ pub fn (mut rw ResponseWriter) write<T>(payload T) {
 // write_notify sends the given method and params as
 // a server notification to the stream.
 pub fn (mut rw ResponseWriter) write_notify<T>(method string, params T) {
-	notif := jsonrpc.NotificationMessage<T>{
+	notif := NotificationMessage<T>{
 		method: method
 		params: params
 	}
@@ -200,7 +204,7 @@ pub fn (mut rw ResponseWriter) write_notify<T>(method string, params T) {
 
 // write_error sends a ResponseError to the stream.
 pub fn (mut rw ResponseWriter) write_error(err &ResponseError) {
-	final_resp := jsonrpc.Response<string>{
+	final_resp := Response<string>{
 		id: rw.req_id
 		error: err
 	}
@@ -218,7 +222,9 @@ mut:
 }
 
 fn (mut w Writer) write(byt []u8) ?int {
-	defer { w.clen_sb.go_back_to(0) }
+	defer {
+		w.clen_sb.go_back_to(0)
+	}
 	w.clen_sb.write_string('Content-Length: $byt.len\r\n\r\n')
 	w.clen_sb.write(byt) or {}
 	return w.read_writer.write(w.clen_sb)
@@ -244,9 +250,7 @@ fn (mut h PassiveHandler) handle_jsonrpc(req &Request, mut rw ResponseWriter) ? 
 
 // is_intercepter_enabled checks if the given T is enabled in a Server.
 pub fn is_interceptor_enabled<T>(server &Server) bool {
-	get_interceptor<T>(server) or {
-		return false
-	}
+	get_interceptor<T>(server) or { return false }
 	return true
 }
 

--- a/server/general_test.v
+++ b/server/general_test.v
@@ -1,4 +1,4 @@
-import jsonrpc.server_test_utils { new_test_client, RpcResult, TestClient }
+import jsonrpc.server_test_utils { new_test_client }
 import jsonrpc
 import server
 import lsp
@@ -21,7 +21,9 @@ fn test_wrong_first_request() ? {
 fn test_initialize_with_capabilities() ? {
 	mut ls := server.new()
 	mut io := new_test_client(ls)
-	result := io.send<map[string]string, lsp.InitializeResult>('initialize', map[string]string{}) ?
+	result := io.send<map[string]string, lsp.InitializeResult>('initialize', map[string]string{}) or {
+		return err
+	}
 
 	assert ls.status() == .initialized
 	assert result == lsp.InitializeResult{
@@ -30,8 +32,8 @@ fn test_initialize_with_capabilities() ? {
 }
 
 fn test_initialized() ? {
-	mut io, mut ls := init_tests() ?
-	io.notify('initialized', map[string]string{}) ?
+	mut io, mut ls := init_tests()?
+	io.notify('initialized', map[string]string{})?
 	assert ls.status() == .initialized
 }
 
@@ -55,7 +57,7 @@ fn test_set_features() {
 		.definition,
 		.implementation,
 		.code_lens,
-		.document_link
+		.document_link,
 	]
 	ls.set_features(['formatting'], true) or {
 		assert false
@@ -88,9 +90,9 @@ fn test_setup_logger() ? {
 	io.send<lsp.InitializeParams, lsp.InitializeResult>('initialize', lsp.InitializeParams{
 		trace: 'verbose'
 		root_uri: lsp.document_uri_from_path(os.join_path('non_existent', 'path'))
-	}) ?
+	}) or { return err }
 
-	notif := io.stream.notification_at<lsp.ShowMessageParams>(0) ?
+	notif := io.stream.notification_at<lsp.ShowMessageParams>(0)?
 	assert notif.method == 'window/showMessage'
 
 	expected_err_path := os.join_path('non_existent', 'path', 'vls.log')
@@ -104,6 +106,8 @@ fn test_setup_logger() ? {
 fn init_tests() ?(&TestClient, &server.Vls) {
 	mut ls := server.new()
 	mut io := new_test_client(ls)
-	io.send<map[string]string, lsp.InitializeResult>('initialize', map[string]string{}) ?
+	io.send<map[string]string, lsp.InitializeResult>('initialize', map[string]string{}) or {
+		return err
+	}
 	return io, ls
 }

--- a/test_utils/test_utils.v
+++ b/test_utils/test_utils.v
@@ -35,11 +35,14 @@ pub mut:
 pub fn (mut t Tester) initialize() ?TestFilesIterator {
 	t.client.send<lsp.InitializeParams, lsp.InitializeResult>('initialize', lsp.InitializeParams{
 		root_uri: lsp.document_uri_from_path(os.join_path(t.test_files_dir, t.folder_name))
-	}) ?
+	}) or { return none }
 
-	files := load_test_file_paths(t.test_files_dir, t.folder_name) ?
+	files := load_test_file_paths(t.test_files_dir, t.folder_name)?
 	t.bench.set_total_expected_steps(files.len)
-	return TestFilesIterator{file_paths: files, tester: unsafe { t }}
+	return TestFilesIterator{
+		file_paths: files
+		tester: unsafe { t }
+	}
 }
 
 pub fn (mut t Tester) fail(file TestFile, msg string) {
@@ -55,7 +58,8 @@ pub fn (mut t Tester) ok(file TestFile) {
 
 pub fn (mut t Tester) is_equal<T>(expected T, actual T) ? {
 	if expected != actual {
-		println(diff.color_compare_strings(diff_cmd, 'vls_symbol_registration_test', expected.str(), actual.str()))
+		println(diff.color_compare_strings(test_utils.diff_cmd, 'vls_symbol_registration_test',
+			expected.str(), actual.str()))
 		return error('actual != expected')
 	}
 }
@@ -73,7 +77,7 @@ pub fn (t &Tester) is_ok() bool {
 }
 
 pub fn (mut t Tester) diagnostics() ?lsp.PublishDiagnosticsParams {
-	got := t.client.stream.last_notification_at_method<lsp.PublishDiagnosticsParams>('textDocument/publishDiagnostics') ?
+	got := t.client.stream.last_notification_at_method<lsp.PublishDiagnosticsParams>('textDocument/publishDiagnostics')?
 	return got.params
 }
 
@@ -103,7 +107,7 @@ pub fn (mut t Tester) open_document(file TestFile) ?lsp.TextDocumentIdentifier {
 			version: 1
 			text: file.contents
 		}
-	}) ?
+	})?
 	return lsp.TextDocumentIdentifier{
 		uri: doc_uri
 	}
@@ -113,20 +117,20 @@ pub fn (mut t Tester) open_document(file TestFile) ?lsp.TextDocumentIdentifier {
 pub fn (mut t Tester) close_document(doc_id lsp.TextDocumentIdentifier) ? {
 	t.client.notify('textDocument/didClose', lsp.DidCloseTextDocumentParams{
 		text_document: doc_id
-	}) ?
+	})?
 }
 
 pub struct TestFile {
 pub:
 	file_name string [required]
 	file_path string [required]
-	contents   string
+	contents  string
 }
 
 pub struct TestFilesIterator {
 mut:
 	tester &Tester
-	idx int = -1
+	idx    int = -1
 pub mut:
 	file_paths []string
 }
@@ -134,7 +138,7 @@ pub mut:
 pub fn (iter &TestFilesIterator) get(idx int) ?TestFile {
 	test_file_path := iter.file_paths[idx]
 	test_file_name := os.base(test_file_path)
-	content := os.read_file(test_file_path) ?
+	content := os.read_file(test_file_path)?
 	return TestFile{
 		file_name: test_file_name
 		file_path: test_file_path
@@ -151,13 +155,10 @@ pub fn (mut iter TestFilesIterator) next() ?TestFile {
 
 	iter.tester.bench.step()
 	test_file := iter.get(iter.idx) or {
-		iter.tester.fail(
-			TestFile{
-				file_name: os.base(iter.file_paths[iter.idx])
-				file_path: ''
-			},
-			'file is missing',
-		)
+		iter.tester.fail(TestFile{
+			file_name: os.base(iter.file_paths[iter.idx])
+			file_path: ''
+		}, 'file is missing')
 		return iter.next()
 	}
 
@@ -223,19 +224,19 @@ pub fn (io Testio) notification() ?(string, string) {
 
 // notification verifies the parameters of the notification.
 pub fn (io Testio) notification_at_index(idx int) ?(string, string) {
-	resp := json.decode(TestNotification, io.raw_responses[idx]) ?
+	resp := json.decode(TestNotification, io.raw_responses[idx])?
 	return resp.method, resp.params
 }
 
 // response_error returns the error code and message from the response.
 pub fn (mut io Testio) response_error() ?(int, string) {
-	io.decode_response_at_index(io.raw_responses.len - 1) ?
+	io.decode_response_at_index(io.raw_responses.len - 1)?
 	return io.response.error.code, io.response.error.message
 }
 
 fn (mut io Testio) decode_response_at_index(idx int) ? {
 	if io.decoded_resp_idx != idx {
-		io.response = json.decode(TestResponse, io.raw_responses[idx]) ?
+		io.response = json.decode(TestResponse, io.raw_responses[idx])?
 		io.decoded_resp_idx = idx
 	}
 }
@@ -318,8 +319,8 @@ pub fn (mut io Testio) close_document(doc_id lsp.TextDocumentIdentifier) string 
 // from the server after executing the `textDocument/didOpen` request.
 pub fn (mut io Testio) file_errors() ?[]lsp.Diagnostic {
 	mut errors := []lsp.Diagnostic{}
-	_, diag_params := io.notification() ?
-	diag_info := json.decode(lsp.PublishDiagnosticsParams, diag_params) ?
+	_, diag_params := io.notification()?
+	diag_info := json.decode(lsp.PublishDiagnosticsParams, diag_params)?
 	for diag in diag_info.diagnostics {
 		if diag.severity != .error {
 			continue


### PR DESCRIPTION
Start to migrate to the new read API https://github.com/vlang/v/pull/15229

This is a work in progress, and I think there are some things wrong with the tests, but let's start to run the same things