### PR TITLE
vlib: migrate to the new reader API

### DIFF
--- a/jsonrpc/server.v
+++ b/jsonrpc/server.v
@@ -71,7 +71,12 @@ pub fn (mut s Server) respond() ? {
 
 fn (mut s Server) internal_respond(mut base_rw ResponseWriter) ? {
 	defer { s.req_buf.go_back_to(0) }
-	s.stream.read(mut s.req_buf) ?
+	s.stream.read(mut s.req_buf) or {
+		if err is io.Eof {
+			return
+		}
+		return err
+	}
 
 	req := s.process_raw_request(s.req_buf.after(0)) or {
 		base_rw.write_error(response_error(error: parse_error))

--- a/test_utils/test_utils.v
+++ b/test_utils/test_utils.v
@@ -4,6 +4,7 @@ import json
 import jsonrpc
 import jsonrpc.server_test_utils
 import os
+import io
 import lsp
 import benchmark
 import v.util.diff
@@ -35,7 +36,12 @@ pub mut:
 pub fn (mut t Tester) initialize() ?TestFilesIterator {
 	t.client.send<lsp.InitializeParams, lsp.InitializeResult>('initialize', lsp.InitializeParams{
 		root_uri: lsp.document_uri_from_path(os.join_path(t.test_files_dir, t.folder_name))
-	}) ?
+	}) or {
+		if err is io.Eof {
+			return none
+		}
+		return err
+	}
 
 	files := load_test_file_paths(t.test_files_dir, t.folder_name) ?
 	t.bench.set_total_expected_steps(files.len)


### PR DESCRIPTION
this overrides the PR https://github.com/vlang/vls/pull/373 to revert the fmt changes, and I started to debug the CI failure but requires still some more love.