### PR TITLE
server: fix enum and embedded field incomplete selector autocompletion

### DIFF
--- a/server/features_completion.v
+++ b/server/features_completion.v
@@ -274,12 +274,15 @@ fn (mut builder CompletionBuilder) build_suggestions_from_sym(sym &analyzer.Symb
 				continue
 			}
 
-			if child_sym.kind == .embedded_field {
-				builder.build_suggestions_from_sym(child_sym.return_sym, is_selector)
-			}
-
 			if existing_completion_item := symbol_to_completion_item(child_sym, with_snippet: true, prefix: params.prefix) {
 				builder.add(existing_completion_item)
+			}
+
+			if child_sym.kind == .embedded_field {
+				builder.build_suggestions_from_sym(child_sym.return_sym, BuildSuggestionsFromSymParams{
+					...params
+					prefix: params.prefix + child_sym.name + '.'
+				})
 			}
 		} else if child_sym.kind == .field && sym.kind == .struct_ {
 			builder.add(lsp.CompletionItem{

--- a/server/tests/completion_test.v
+++ b/server/tests/completion_test.v
@@ -27,6 +27,10 @@ const completion_inputs = {
 		context: lsp.CompletionContext{.invoked, ''}
 		position: lsp.Position{10, 14}
 	}
+	'enum_method.vv':                       lsp.CompletionParams{
+		context: lsp.CompletionContext{.trigger_character, '.'}
+		position: lsp.Position{5, 27}
+	}
 	'enum_val_in_struct.vv':                lsp.CompletionParams{
 		context: lsp.CompletionContext{.trigger_character, ' '}
 		position: lsp.Position{18, 20}
@@ -278,6 +282,12 @@ const completion_results = {
 			detail: 'pub fn connect(config Config) ?DB'
 			insert_text: 'connect'
 		},
+		lsp.CompletionItem{
+			label: 'Oid'
+			kind: .enum_
+			detail: 'pub enum Oid'
+			insert_text: 'Oid'
+		}
 	]
 	'import.vv':                            [
 		lsp.CompletionItem{
@@ -393,6 +403,24 @@ const completion_results = {
 			detail: 'pub fn this_is_a_function() string'
 			insert_text: 'this_is_a_function()'
 		},
+		lsp.CompletionItem{
+			label: 'KeyCode'
+			kind: .enum_
+			detail: 'pub enum KeyCode'
+			insert_text: 'KeyCode'
+		},
+		lsp.CompletionItem{
+			label: 'KeyCode.shift'
+			kind: .enum_member
+			detail: 'pub KeyCode.shift KeyCode'
+			insert_text: 'KeyCode.shift'
+		},
+		lsp.CompletionItem{
+			label: 'KeyCode.control'
+			kind: .enum_member
+			detail: 'pub KeyCode.control KeyCode'
+			insert_text: 'KeyCode.control'
+		}
 	]
 	'self_reference_var_in_struct_field.vv':                [
 		lsp.CompletionItem{

--- a/server/tests/completion_test.v
+++ b/server/tests/completion_test.v
@@ -31,6 +31,10 @@ const completion_inputs = {
 		context: lsp.CompletionContext{.trigger_character, '.'}
 		position: lsp.Position{15, 15}
 	}
+	'enum_member.vv':                       lsp.CompletionParams{
+		context: lsp.CompletionContext{.trigger_character, '.'}
+		position: lsp.Position{5, 20}
+	}
 	'enum_method.vv':                       lsp.CompletionParams{
 		context: lsp.CompletionContext{.trigger_character, '.'}
 		position: lsp.Position{5, 27}
@@ -199,6 +203,20 @@ const completion_results = {
 			detail: 'ThreeDPoint.z int'
 			insert_text: 'z'
 		},
+	]
+	'enum_member.vv':                       [
+		lsp.CompletionItem{
+			label: 'shift'
+			kind: .enum_member
+			detail: 'pub KeyCode.shift KeyCode'
+			insert_text: 'shift'
+		},
+		lsp.CompletionItem{
+			label: 'control'
+			kind: .enum_member
+			detail: 'pub KeyCode.control KeyCode'
+			insert_text: 'control'
+		}
 	]
 	'enum_method.vv':                       [
 		lsp.CompletionItem{

--- a/server/tests/completion_test.v
+++ b/server/tests/completion_test.v
@@ -27,6 +27,10 @@ const completion_inputs = {
 		context: lsp.CompletionContext{.invoked, ''}
 		position: lsp.Position{10, 14}
 	}
+	'embedded_struct_field.vv':             lsp.CompletionParams{
+		context: lsp.CompletionContext{.trigger_character, '.'}
+		position: lsp.Position{15, 15}
+	}
 	'enum_method.vv':                       lsp.CompletionParams{
 		context: lsp.CompletionContext{.trigger_character, '.'}
 		position: lsp.Position{5, 27}
@@ -169,6 +173,40 @@ const completion_results = {
 			insert_text: 'add_to_four(\$0)'
 			insert_text_format: .snippet
 		},
+	]
+	'embedded_struct_field.vv':             [
+		lsp.CompletionItem{
+			label: 'Point'
+			kind: .property
+			detail: 'Point'
+			insert_text: 'Point'
+		},
+		lsp.CompletionItem{
+			label: 'Point.a'
+			kind: .property
+			detail: 'pub Point.a int'
+			insert_text: 'Point.a'
+		},
+		lsp.CompletionItem{
+			label: 'Point.b'
+			kind: .property
+			detail: 'pub Point.b int'
+			insert_text: 'Point.b'
+		},
+		lsp.CompletionItem{
+			label: 'z'
+			kind: .property
+			detail: 'ThreeDPoint.z int'
+			insert_text: 'z'
+		},
+	]
+	'enum_method.vv':                       [
+		lsp.CompletionItem{
+			label: 'print'
+			kind: .method
+			detail: 'pub fn (code KeyCode) print()'
+			insert_text: 'print()'
+		}
 	]
 	'enum_val_in_struct.vv':                [
 		lsp.CompletionItem{

--- a/server/tests/test_files/completion/abc/abc.v
+++ b/server/tests/test_files/completion/abc/abc.v
@@ -8,3 +8,10 @@ pub struct Point {
 pub fn this_is_a_function() string {
 	return 'wee'
 }
+
+pub enum KeyCode {
+	shift
+	control
+}
+
+pub fn (code KeyCode) print() {}

--- a/server/tests/test_files/completion/abc/abc.v
+++ b/server/tests/test_files/completion/abc/abc.v
@@ -1,6 +1,7 @@
 module abc
 
 pub struct Point {
+pub:
 	a int
 	b int
 }

--- a/server/tests/test_files/completion/embedded_struct_field.vv
+++ b/server/tests/test_files/completion/embedded_struct_field.vv
@@ -1,0 +1,17 @@
+module main
+
+import abc
+
+pub struct ThreeDPoint {
+	abc.Point
+	z int
+}
+
+fn main() {
+	point := ThreeDPoint{
+		Point: Point{1,2}
+		z: 3
+	}
+
+	println(point.)
+}

--- a/server/tests/test_files/completion/enum_member.vv
+++ b/server/tests/test_files/completion/enum_member.vv
@@ -1,0 +1,7 @@
+module main
+
+import abc
+
+fn main() {
+	println(abc.KeyCode.)
+}

--- a/server/tests/test_files/completion/enum_method.vv
+++ b/server/tests/test_files/completion/enum_method.vv
@@ -1,0 +1,7 @@
+module main
+
+import abc
+
+fn main() {
+	println(abc.KeyCode.shift.)
+}


### PR DESCRIPTION
This PR fixes the following types of incomplete selector auto completions:

- Enums and it's members are not showing on top-level auto completion (when using from imports or not)
- Enum members not showing when enum type is already present (aka `EnumType.`)
- Embedded struct's fields are not showing when invoked on an incomplete selector