### PR TITLE
analyzer/errors: fix sprintf deprecation, create custom error template compiler

### DIFF
--- a/analyzer/errors/formatter.v
+++ b/analyzer/errors/formatter.v
@@ -1,0 +1,39 @@
+module errors
+
+import strings.textscanner
+import strings
+
+pub interface ErrorData {}
+
+pub type DataFormatterFn = fn (ErrorData) string 
+
+pub fn format(data_formatter_fn DataFormatterFn, code_or_msg string, datum ...ErrorData) string {
+	mut error_template := code_or_msg
+	if code_or_msg in errors.message_templates {
+		error_template = errors.message_templates[code_or_msg]
+	}
+
+	if datum.len == 0 {
+		return error_template
+	}
+
+	mut scanner := textscanner.new(error_template)
+	defer { unsafe { scanner.free() } }
+
+	mut builder := strings.new_builder(error_template.len)
+	mut cur_data_idx := 0
+	for scanner.remaining() != 0 {
+		chr := scanner.next()
+		if chr == `%` && scanner.peek() == `s` {
+			builder.write_string(data_formatter_fn(datum[cur_data_idx % datum.len]))
+			cur_data_idx++
+
+			scanner.skip_n(1)
+		} else {
+			// TODO: maps
+			builder.write_rune(chr)
+		}
+	}
+
+	return builder.str()
+}

--- a/analyzer/errors/formatter.v
+++ b/analyzer/errors/formatter.v
@@ -21,6 +21,9 @@ pub fn format(data_formatter_fn DataFormatterFn, code_or_msg string, datum ...Er
 	defer { unsafe { scanner.free() } }
 
 	mut builder := strings.new_builder(error_template.len)
+	mut var_name := strings.new_builder(100)
+	defer { unsafe { var_name.free() } }
+
 	mut cur_data_idx := 0
 	for scanner.remaining() != 0 {
 		chr := scanner.next()
@@ -29,6 +32,33 @@ pub fn format(data_formatter_fn DataFormatterFn, code_or_msg string, datum ...Er
 			cur_data_idx++
 
 			scanner.skip_n(1)
+		} else if chr == `{` && scanner.peek() == chr && (datum.last() is map[string]ErrorData || datum.last() is map[string]string) {
+			// maps are used for accepting named parameters in error messages
+			// e.g. "cannot selectively import {{var}} from {{mod}}. use {{mod}}.{{var}} instead"
+			scanner.skip_n(1)
+
+			// get var name
+			for scanner.current() != `}` && scanner.peek() != `}` {
+				var_chr := scanner.next()
+				if var_chr == ` ` {
+					continue
+				}
+
+				var_name.write_rune(var_chr)
+			}
+
+			// get data
+			last := datum.last()
+			got_var_name := var_name.str()
+			if last is map[string]ErrorData {
+				value := (*last)[got_var_name] or { ErrorData('missing value') }
+				builder.write_string(data_formatter_fn(value))
+			} else if last is map[string]string {
+				value := (*last)[got_var_name] or { 'missing value' }
+				builder.write_string(value)
+			}
+
+			scanner.skip_n(2)
 		} else {
 			// TODO: maps
 			builder.write_rune(chr)

--- a/analyzer/errors/formatter_test.v
+++ b/analyzer/errors/formatter_test.v
@@ -12,3 +12,7 @@ fn test_format() {
 	assert errors.format(simple_data_formatter, 'hello %s', 'world') == 'hello world'
 	assert errors.format(simple_data_formatter, errors.undefined_operation_error, 'int', '+', 'int') == 'undefined operation `int` + `int`'
 }
+
+fn test_format_map() {
+	assert errors.format(simple_data_formatter, errors.selective_const_import_error, {'var': 'foo', 'module': 'modz'}) == 'cannot selective import constant `foo` from `modz`, import `modz` and use `modz.foo` instead'
+}

--- a/analyzer/errors/formatter_test.v
+++ b/analyzer/errors/formatter_test.v
@@ -1,0 +1,14 @@
+import analyzer.errors
+
+fn simple_data_formatter (data errors.ErrorData) string {
+	if data is string {
+		return *data
+	} else {
+		return '$data'
+	}
+}
+
+fn test_format() {
+	assert errors.format(simple_data_formatter, 'hello %s', 'world') == 'hello world'
+	assert errors.format(simple_data_formatter, errors.undefined_operation_error, 'int', '+', 'int') == 'undefined operation `int` + `int`'
+}

--- a/analyzer/semantic_analyzer.v
+++ b/analyzer/semantic_analyzer.v
@@ -86,7 +86,7 @@ fn (mut an SemanticAnalyzer) format_report(report Report) string {
 		final_report := Report{
 			...report
 			message: errors.format(unsafe { an.format_report_data }, report.message, ...report.data.params)
-			data: unsafe { nil }
+			data: 0
 		}
 
 		an.context.store.report(final_report)

--- a/analyzer/semantic_analyzer.v
+++ b/analyzer/semantic_analyzer.v
@@ -1,6 +1,5 @@
 module analyzer
 
-import strconv
 import errors
 import tree_sitter_v as v
 import ast
@@ -52,29 +51,24 @@ fn (an &SemanticAnalyzer) with_symbol(sym &Symbol) &SemanticAnalyzer {
 }
 
 struct SemanticAnalyzerContext {
-	params []ReportData
+	params []errors.ErrorData
 }
 
-fn (mut an SemanticAnalyzer) report(node ast.Node, code_or_msg string, data ...ReportData) IError {
-	mut is_msg_code := false
-	if code_or_msg in errors.message_templates {
-		is_msg_code = true
-	}
-
+fn (mut an SemanticAnalyzer) report(node ast.Node, code_or_msg string, data ...errors.ErrorData) IError {
 	return SemanticAnalyzerError{
-		typ: if is_msg_code { code_or_msg } else { 'custom_error' }
+		typ: if code_or_msg in errors.message_templates { code_or_msg } else { 'custom_error' }
 		content: an.format_report(
 			kind: .error
-			message: if is_msg_code { errors.message_templates[code_or_msg] } else { code_or_msg }
+			message: code_or_msg
 			range: node.range()
 			file_path: an.context.file_path
-			code: if is_msg_code { code_or_msg } else { '' }
+			code: if code_or_msg in errors.message_templates { code_or_msg } else { '' }
 			data: SemanticAnalyzerContext{data}
 		)
 	}
 }
 
-fn (an &SemanticAnalyzer) format_report_data(d ReportData) string {
+fn (an &SemanticAnalyzer) format_report_data(d errors.ErrorData) string {
 	if d is string {
 		return *d
 	} else if d is Symbol {
@@ -89,35 +83,14 @@ fn (an &SemanticAnalyzer) format_report_data(d ReportData) string {
 
 fn (mut an SemanticAnalyzer) format_report(report Report) string {
 	if report.data is SemanticAnalyzerContext {
-		if report.data.params.len != 0 {
-			mut final_params := []string{cap: report.data.params.len}
-			mut final_msg := report.message
-			for d in report.data.params {
-				// maps are used for accepting named parameters in error messages
-				// e.g. "cannot selectively import {{var}} from {{mod}}. use {{mod}}.{{var}} instead"
-				if d is map[string]ReportData {
-					for var_name, val in d {
-						final_msg = final_msg.replace('{{$var_name}}', an.format_report_data(val))
-					}
-				} else if d is map[string]string {
-					for var_name, val in d {
-						final_msg = final_msg.replace('{{$var_name}}', an.format_report_data(unsafe { val }))
-					}
-				} else {
-					final_params << an.format_report_data(d)
-				}
-			}
-
-			ptrs := unsafe { final_params.pointers() }
-			final_report := Report{
-				...report
-				message: strconv.v_sprintf(final_msg, ...ptrs)
-				data: 0
-			}
-
-			an.context.store.report(final_report)
-			return final_report.message
+		final_report := Report{
+			...report
+			message: errors.format(unsafe { an.format_report_data }, report.message, ...report.data.params)
+			data: unsafe { nil }
 		}
+
+		an.context.store.report(final_report)
+		return final_report.message
 	}
 
 	an.context.store.report(report)


### PR DESCRIPTION
In the upcoming versions of the V compiler, `v_sprintf` will not be available to the public. Thus, this PR is in preparation for that change without migrating existing analyzer error templates to other means such as string interpolation. 