### PR TITLE
server/tests: fix flaky completion test

### DIFF
--- a/server/tests/completion_test.v
+++ b/server/tests/completion_test.v
@@ -588,10 +588,13 @@ fn test_completion() ? {
 		}, mut writer) {
 			// compare content
 			mut expected := completion_results[test_name].clone()
-			expected.sort_with_compare(sort_completion_item)
-
 			mut aactual := actual.clone()
-			aactual.sort_with_compare(sort_completion_item)
+
+			// sort results only if test case is flaky
+			if test_name in flaky_tests {
+				expected.sort_with_compare(sort_completion_item)
+				aactual.sort_with_compare(sort_completion_item)
+			}
 
 			if _ := t.is_equal(expected, aactual) {
 				t.ok(file)

--- a/server/tests/completion_test.v
+++ b/server/tests/completion_test.v
@@ -539,6 +539,15 @@ const completion_results = {
 	]
 }
 
+fn sort_completion_item(a &lsp.CompletionItem, b &lsp.CompletionItem) int {
+	if int(a.kind) < int(b.kind) {
+		return 1
+	} else if int(a.kind) > int(b.kind) {
+		return -1
+	}
+	return 0
+}
+
 fn test_completion() ? {
 	mut ls := server.new()
 	mut t := &test_utils.Tester{
@@ -578,8 +587,13 @@ fn test_completion() ? {
 			text_document: doc_id
 		}, mut writer) {
 			// compare content
-			expected := completion_results[test_name]
-			if _ := t.is_equal(expected, actual) {
+			mut expected := completion_results[test_name].clone()
+			expected.sort_with_compare(sort_completion_item)
+
+			mut aactual := actual.clone()
+			aactual.sort_with_compare(sort_completion_item)
+
+			if _ := t.is_equal(expected, aactual) {
 				t.ok(file)
 			} else {
 				t.fail(file, err.msg())


### PR DESCRIPTION
This is a fix related to the temporary [f218aea](https://github.com/vlang/vls/commit/f218aea557fa328f8fd851d7de3cccb13d14ca63) commit which skips the test due to invalid order of items which occurred yesterday.