### PR TITLE
Windows uri fix

### DIFF
--- a/lsp/lsp.v
+++ b/lsp/lsp.v
@@ -39,11 +39,7 @@ pub fn (du DocumentUri) path() string {
 
 		result = result.replace('/', '\\')
 	} $else {
-		if authority != '' && path != '' {
-			result = '//${authority}/${path}'
-		} else {
-			result = '/' + path
-		}
+		result = '/' + path
 	}
 
 	return result

--- a/lsp/lsp.v
+++ b/lsp/lsp.v
@@ -9,22 +9,155 @@ pub fn (du DocumentUri) dir() string {
 }
 
 pub fn (du DocumentUri) path() string {
-	$if windows {
-		return du.all_after('file:///').replace_each(['/', '\\', '%3A', ':'])
+	scheme := 'file://'
+	if !du.starts_with(scheme) {
+		return ''
 	}
-	return if du.starts_with('file://') { du.all_after('file://') } else { '' }
+
+	mut authority := du.all_after(scheme).all_before('/')
+	mut path := du.all_after(scheme).all_after('/')
+
+	authority = unescape(authority)
+	path = unescape(path)
+
+	mut result := ''
+	$if windows {
+		if authority != '' && path != '' {
+			result = '//${authority}/${path}'
+		} else if path[0].is_letter() && path[1] == `:` {
+			// convert driver name to upper case
+			drive_name := if path[0].is_capital() {
+				path[0]
+			} else {
+				path[0] - 32
+			}
+
+			result = rune(drive_name).str() + path[1..]
+		} else {
+			result = path
+		}
+
+		result = result.replace('/', '\\')
+	} $else {
+		if authority != '' && path != '' {
+			result = '//${authority}/${path}'
+		} else {
+			result = '/' + path
+		}
+	}
+
+	return result
 }
 
 pub fn (du DocumentUri) dir_path() string {
 	return os.dir(du.path())
 }
 
-pub fn document_uri_from_path(path string) DocumentUri {
-	$if windows {
-		uri_path := path.replace_each(['file:///', 'file:///', '\\', '/', ':', '%3A'])
-		return if !path.starts_with('file:///') { 'file:///' + uri_path } else { uri_path }
+fn escape(s string) string {
+	byte_array := s.bytes()
+
+	return byte_array.map(if it.is_alnum() || it in [`-`, `.`, `_`, `~`, `/`] {
+		rune(it).str()
+	} else {
+		'%${it:02X}'
+	})
+		.join('')
+}
+
+fn unescape(s string) string {
+	rune_array := s.runes()
+	mut results := []u8{}
+
+	for i := 0; i < rune_array.len; i++ {
+		if rune_array[i] != `%` {
+			results << rune_array[i].bytes()
+		} else {
+			v1_rune := rune_array[i + 1] or { `\0` }
+			v2_rune := rune_array[i + 2] or { `\0` }
+
+			v1 := try_into_hex_int(v1_rune) or {
+				results << rune_array[i].bytes()
+				continue
+			}
+			v2 := try_into_hex_int(v2_rune) or {
+				results << rune_array[i].bytes()
+				continue
+			}
+			v := (v1 << 4) + v2
+
+			results << v
+			i += 2
+		}
 	}
-	return if !path.starts_with('file://') { 'file://' + path } else { path }
+
+	return results.bytestr()
+}
+
+fn try_into_hex_int(r rune) ?rune {
+	return if r >= `0` && r <= `9` {
+		r - `0`
+	} else if r >= `A` && r <= `F` {
+		r - `A` + 10
+	} else if r >= `a` && r <= `f` {
+		r - `a` + 10
+	} else {
+		none
+	}
+}
+
+pub fn document_uri_from_path(path string) DocumentUri {
+	scheme := 'file://'
+	is_has_scheme := path.starts_with(scheme)
+
+	mut fixed_path := if is_has_scheme {
+		path.all_after(scheme)
+	} else {
+		path
+	}
+
+	mut authority := ''
+	$if windows {
+		fixed_path = fixed_path.replace('\\', '/')
+
+		// UNC paths for accessing network resources
+		if !is_has_scheme && fixed_path.starts_with('//') {
+			authority = fixed_path.find_between('//', '/')
+			fixed_path = fixed_path.all_after('//').all_after('/')
+			if fixed_path == '' {
+				fixed_path = '/'
+			}
+		}
+	}
+
+	mut is_need_prepend_slash := false
+	$if windows {
+		// paths start with '/' without specifying drive name are paths
+		// relative to root of current drive.
+		// an extra '/' needs to be prepended.
+		is_need_prepend_slash = !fixed_path.starts_with('/')
+			|| (fixed_path[1] != `/` && fixed_path[2] != `:`)
+	} $else {
+		is_need_prepend_slash = !fixed_path.starts_with('/')
+	}
+
+	if is_need_prepend_slash {
+		fixed_path = '/' + fixed_path
+	}
+
+	$if windows {
+		// convert driver name to lower case, e.g. /C:/foo ->  /c:/foo
+		if fixed_path[2] == `:` && fixed_path[1].is_letter() {
+			driver_name := if fixed_path[1].is_capital() {
+				fixed_path[1] + 32
+			} else {
+				fixed_path[1]
+			}
+			fixed_path = '/${rune(driver_name).str()}${fixed_path[2..]}'
+		}
+	}
+
+	uri := scheme + escape(authority) + escape(fixed_path)
+	return uri
 }
 
 pub struct NotificationMessage {

--- a/lsp/lsp.v
+++ b/lsp/lsp.v
@@ -53,6 +53,10 @@ pub fn (du DocumentUri) dir_path() string {
 	return os.dir(du.path())
 }
 
+pub fn (du DocumentUri) normalize() DocumentUri {
+	return document_uri_from_path(du.path())
+}
+
 fn escape(s string) string {
 	byte_array := s.bytes()
 

--- a/lsp/lsp_test.v
+++ b/lsp/lsp_test.v
@@ -43,7 +43,7 @@ fn test_document_uri_unicode() {
 		expected << 'file:///c%3A/files/C%253A%255Cfiles'
 	} $else {
 		expected << 'file:///usr/home/%E4%BD%A0%E5%A5%BD%E4%B8%96%E7%95%8C'
-		expected << 'file://C%3A/files/C%253A%255Cfiles'
+		expected << 'file:///C%3A/files/C%253A%255Cfiles'
 	}
 
 	for i in 0 .. input.len {

--- a/lsp/lsp_test.v
+++ b/lsp/lsp_test.v
@@ -16,16 +16,65 @@ fn test_document_uri_from_path_windows() {
 		return
 	}
 
-	assert document_uri_from_path('C:\\coding\\test.v') == 'file:///C%3A/coding/test.v'
+	input := [
+		'C:\\coding\\test.v',
+		'file:///C:/my/files',
+		r'\\server\share\foo',
+	]
+	expected := [
+		'file:///c%3A/coding/test.v',
+		'file:///c%3A/my/files',
+		'file://server/share/foo',
+	]
+
+	for i in 0 .. input.len {
+		assert document_uri_from_path(input[i]) == expected[i]
+	}
+}
+
+fn test_document_uri_unicode() {
+	input := [
+		'/usr/home/你好世界',
+		r'C:/files/C%3A%5Cfiles'
+	]
+	mut expected := []string{}
+	$if windows {
+		expected << 'file:////usr/home/%E4%BD%A0%E5%A5%BD%E4%B8%96%E7%95%8C'
+		expected << 'file:///c%3A/files/C%253A%255Cfiles'
+	} $else {
+		expected << 'file:///usr/home/%E4%BD%A0%E5%A5%BD%E4%B8%96%E7%95%8C'
+		expected << 'file://C%3A/files/C%253A%255Cfiles'
+	}
+
+	for i in 0 .. input.len {
+		assert document_uri_from_path(input[i]) == expected[i]
+	}
 }
 
 fn test_document_uri_path() {
-	uri := DocumentUri('file:///baz/foo/hello.v')
-	mut expected := ''
+	input := [
+		'file:///baz/foo/hello.v',
+		'file:///C%3A/upper_case/files',
+		'file:///c%3A/lower_case/files',
+		'file://server/share/foo',
+		'file:///usr/home/%E4%BD%A0%E5%A5%BD%E4%B8%96%E7%95%8C',
+	]
+	mut expected := []string{}
 	$if windows {
-		expected = 'baz\\foo\\hello.v'
+		expected << r'baz\foo\hello.v'
+		expected << r'C:\upper_case\files'
+		expected << r'C:\lower_case\files'
+		expected << r'\\server\share\foo'
+		expected << r'usr\home\你好世界'
 	} $else {
-		expected = '/baz/foo/hello.v'
+		expected << '/baz/foo/hello.v'
+		expected << '/C:/upper_case/files'
+		expected << '/c:/lower_case/files'
+		expected << '/share/foo'
+		expected << '/usr/home/你好世界'
 	}
-	assert uri.path() == expected
+
+	for i in 0 .. input.len {
+		assert DocumentUri(input[i]).path() == expected[i]
+	}
 }

--- a/server/features.v
+++ b/server/features.v
@@ -11,7 +11,7 @@ const temp_formatting_file_path = os.join_path(os.temp_dir(), 'vls_temp_formatti
 
 [manualfree]
 pub fn (mut ls Vls) formatting(params lsp.DocumentFormattingParams, mut wr ResponseWriter) ![]lsp.TextEdit {
-	uri := params.text_document.uri
+	uri := params.text_document.uri.normalize()
 	source := ls.files[uri].source
 	tree_range := ls.files[uri].tree.root_node().range()
 	if source.len() == 0 {
@@ -131,7 +131,7 @@ fn symbol_to_symbol_info(uri lsp.DocumentUri, sym &analyzer.Symbol) ?lsp.SymbolI
 }
 
 fn (mut ls Vls) document_symbol(params lsp.DocumentSymbolParams, mut wr ResponseWriter) ![]lsp.SymbolInformation {
-	uri := params.text_document.uri
+	uri := params.text_document.uri.normalize()
 	retrieved_symbols := ls.store.get_symbols_by_file_path(uri.path())
 	mut document_symbols := []lsp.SymbolInformation{}
 	for sym in retrieved_symbols {
@@ -146,7 +146,7 @@ fn (mut ls Vls) signature_help(params lsp.SignatureHelpParams, mut wr ResponseWr
 		return none
 	}
 
-	uri := params.text_document.uri
+	uri := params.text_document.uri.normalize()
 	pos := params.position
 	ctx := params.context
 	file := ls.files[uri] or { return none }
@@ -224,7 +224,7 @@ fn (mut ls Vls) signature_help(params lsp.SignatureHelpParams, mut wr ResponseWr
 }
 
 pub fn (mut ls Vls) hover(params lsp.HoverParams, mut wr ResponseWriter) ?lsp.Hover {
-	uri := params.text_document.uri
+	uri := params.text_document.uri.normalize()
 	pos := params.position
 	file := ls.files[uri] or { return none }
 	offset := file.get_offset(pos.line, pos.character)
@@ -297,7 +297,7 @@ fn get_hover_data(mut store analyzer.Store, node ast.Node, uri lsp.DocumentUri, 
 
 // [manualfree]
 pub fn (mut ls Vls) folding_range(params lsp.FoldingRangeParams, mut wr ResponseWriter) ?[]lsp.FoldingRange {
-	uri := params.text_document.uri
+	uri := params.text_document.uri.normalize()
 	file := ls.files[uri] or { return none }
 	root_node := file.tree.root_node()
 
@@ -401,7 +401,7 @@ pub fn (mut ls Vls) definition(params lsp.TextDocumentPositionParams, mut wr Res
 		return none
 	}
 
-	uri := params.text_document.uri
+	uri := params.text_document.uri.normalize()
 	pos := params.position
 	file := ls.files[uri] or { return none }
 	source := file.source
@@ -475,7 +475,7 @@ pub fn (mut ls Vls) implementation(params lsp.TextDocumentPositionParams, mut wr
 		return none
 	}
 
-	uri := params.text_document.uri
+	uri := params.text_document.uri.normalize()
 	file_path := uri.path()
 	file_dir := uri.dir_path()
 	pos := params.position

--- a/server/features_completion.v
+++ b/server/features_completion.v
@@ -639,7 +639,7 @@ pub fn (mut ls Vls) completion(params lsp.CompletionParams, mut wr ResponseWrite
 		return none
 	}
 
-	uri := params.text_document.uri
+	uri := params.text_document.uri.normalize()
 	file := ls.files[uri]
 	root_node := file.tree.root_node()
 	pos := params.position

--- a/server/general_test.v
+++ b/server/general_test.v
@@ -94,7 +94,7 @@ fn test_setup_logger() {
 	mut io := new_test_client(server.new(), &LogRecorder{})
 	io.send<lsp.InitializeParams, lsp.InitializeResult>('initialize', lsp.InitializeParams{
 		trace: 'verbose'
-		root_uri: lsp.document_uri_from_path(os.join_path('non_existent', 'path'))
+		root_uri: lsp.document_uri_from_path(os.join_path('/non_existent', 'path'))
 	}) or {
 		if err is io.Eof {
 			return
@@ -103,11 +103,11 @@ fn test_setup_logger() {
 		return
 	}
 
-	notif := io.stream.notification_at<lsp.ShowMessageParams>(0)?
+	notif := io.stream.notification_at<lsp.ShowMessageParams>(0)!
 	assert notif.method == 'window/showMessage'
 
-	expected_err_path := os.join_path('non_existent', 'path', 'vls.log')
-	expected_alt_log_path := os.join_path(server.get_folder_path(), 'logs', 'vls__non_existent_path.log')
+	expected_err_path := os.join_path('/non_existent', 'path', 'vls.log')
+	expected_alt_log_path := os.join_path(server.get_folder_path(), 'logs', 'vls___non_existent_path.log')
 	assert notif.params == lsp.ShowMessageParams{
 		@type: .error
 		message: 'Cannot save log to ${expected_err_path}. Saving log to $expected_alt_log_path'

--- a/server/text_synchronization.v
+++ b/server/text_synchronization.v
@@ -34,7 +34,7 @@ fn (mut ls Vls) analyze_file(file File, affected_node_type v.NodeType, affected_
 pub fn (mut ls Vls) did_open(params lsp.DidOpenTextDocumentParams, mut wr ResponseWriter) {
 	ls.parser.reset()
 	src := params.text_document.text
-	uri := params.text_document.uri
+	uri := params.text_document.uri.normalize()
 	project_dir := uri.dir_path()
 	mut should_scan_whole_dir := false
 
@@ -101,7 +101,7 @@ pub fn (mut ls Vls) did_open(params lsp.DidOpenTextDocumentParams, mut wr Respon
 }
 
 pub fn (mut ls Vls) did_change(params lsp.DidChangeTextDocumentParams, mut wr ResponseWriter) {
-	uri := params.text_document.uri
+	uri := params.text_document.uri.normalize()
 	if ls.current_file_uri != uri {
 		ls.current_file_uri = uri
 		ls.parser.reset()
@@ -178,7 +178,7 @@ pub fn (mut ls Vls) did_change(params lsp.DidChangeTextDocumentParams, mut wr Re
 }
 
 pub fn (mut ls Vls) did_close(params lsp.DidCloseTextDocumentParams, mut wr ResponseWriter) {
-	uri := params.text_document.uri
+	uri := params.text_document.uri.normalize()
 	ls.files.delete(uri)
 	ls.store.opened_scopes.delete(uri.path())
 
@@ -197,7 +197,7 @@ pub fn (mut ls Vls) did_close(params lsp.DidCloseTextDocumentParams, mut wr Resp
 }
 
 pub fn (mut ls Vls) did_save(params lsp.DidSaveTextDocumentParams, mut wr ResponseWriter) {
-	uri := params.text_document.uri
+	uri := params.text_document.uri.normalize()
 	ls.reporter.clear(uri)
 	ls.exec_v_diagnostics(uri) or {}
 	ls.reporter.publish(mut wr, uri)


### PR DESCRIPTION
Fixing problem mentioned in [issue 407](https://github.com/vlang/vls/issues/407).

Rewrite methods of URI struct for better Windows URI support.

Adding normalize method call to all URI query for client request parameter.

Diagnostic report currently doesn't record correct file path, this pull request also fix that.