### PR TITLE
Adding debug print support for ast.Node type

### DIFF
--- a/analyzer/imports.v
+++ b/analyzer/imports.v
@@ -179,7 +179,7 @@ pub fn (mut imp Importer) inject_paths_of_new_imports(mut new_imports []Import, 
 		if !new_imports[import_idx].resolved {
 			for file_path, range in new_imports[import_idx].ranges {
 				imp.context.store.report(
-					message: 'Module `$new_imports[import_idx].absolute_module_name` not found'
+					message: 'Module `${new_imports[import_idx].absolute_module_name}` not found'
 					file_path: file_path
 					range: range
 				)

--- a/ast/parser.v
+++ b/ast/parser.v
@@ -1,5 +1,6 @@
 module ast
 
+import strings
 import tree_sitter
 import tree_sitter_v as v
 
@@ -8,4 +9,62 @@ pub type Tree = tree_sitter.Tree<v.NodeType>
 
 pub fn new_parser() &tree_sitter.Parser<v.NodeType> {
 	return tree_sitter.new_parser<v.NodeType>(v.language, v.type_factory)
+}
+
+fn (n Node) str() string {
+	mut cursor := n.tree_cursor()
+	if !cursor.to_first_child() {
+		return ""
+	}
+
+	mut builder := strings.new_builder(0)
+	mut indent_level := 0
+	for {
+		current := cursor.current_node() or { break }
+
+		if current.type_name != v.NodeType.unknown {
+			for _ in 0 .. indent_level {
+				builder.write_string('  ')
+			}
+
+			builder.write_string('${current.type_name}')
+			builder.write_string(' *')
+
+			st := current.start_point()
+			builder.write_string('[${st.row}, ${st.column}]')
+
+			builder.write_string(' - ')
+
+			ed := current.end_point()
+			builder.write_string('[${ed.row}, ${ed.column}]')
+
+			builder.write_string('\n')
+		}
+
+		if cursor.to_first_child() {
+			indent_level += 1
+		} else if cursor.next() {
+			// do nothing
+		} else if cursor.to_parent() {
+			indent_level -= 1
+
+			mut ok := true
+			for !cursor.next() {
+				if cursor.to_parent() {
+					indent_level -= 1
+				} else {
+					ok = false
+					break
+				}
+			}
+
+			if !ok {
+				break
+			}
+		} else {
+			break
+		}
+	}
+
+	return builder.str()
 }


### PR DESCRIPTION
To make AST and text synchronization debuging easier, add `str()` method to `ast.Node` type.

Example usage:

```v
import ast

fn log_ast(mut ls Vls, uri lsp.DocumentUri) {
	file := ls.files[uri] or { return }
	node := file.tree.root_node()
	msg := '- * - Source - * -\n${file.source.string()}'
		+ '\n- * - AST - * -\n${ast.Node(node)}'
		+ '\n- * - Sexpr - * -\n${node}'
	ls.writer.log_message(msg, .info)
}
```
Output:
```
- * - Source - * -
module main

import net.htp

fn main() {
	test := 'this'
}

- * - AST - * -
module_clause *[0, 0] - [0, 11]
  module_identifier *[0, 7] - [0, 11]
import_declaration *[2, 0] - [2, 14]
  import_path *[2, 7] - [2, 14]
function_declaration *[4, 0] - [6, 1]
  identifier *[4, 3] - [4, 7]
  parameter_list *[4, 7] - [4, 9]
  block *[4, 10] - [6, 1]
    short_var_declaration *[5, 1] - [5, 15]
      expression_list *[5, 1] - [5, 5]
        identifier *[5, 1] - [5, 5]
      expression_list *[5, 9] - [5, 15]
        interpreted_string_literal *[5, 9] - [5, 15]

- * - Sexpr - * -
(source_file (module_clause (module_identifier)) (import_declaration path: (import_path)) (function_declaration name: (identifier) parameters: (parameter_list) body: (block (short_var_declaration left: (expression_list (identifier)) right: (expression_list (interpreted_string_literal))))))
```