### PR TITLE
Make `Rope.substr` method to index content with byte index.

### DIFF
--- a/analyzer/text.v
+++ b/analyzer/text.v
@@ -11,7 +11,7 @@ pub fn (r Runes) len() int {
 }
 
 pub fn (r Runes) substr(start_index int, end_index int) string {
-	mut st, mut ed := -1, 0
+	mut st, mut ed := -1, -1
 	mut offset := 0
 	for i, v in r {
 		if offset >= end_index {
@@ -21,6 +21,10 @@ pub fn (r Runes) substr(start_index int, end_index int) string {
 			st = i
 		}
 		offset += v.length_in_bytes()
+	}
+
+	if ed < 0 {
+		ed = r.len
 	}
 
 	return r[st..ed].string()

--- a/analyzer/text.v
+++ b/analyzer/text.v
@@ -11,5 +11,17 @@ pub fn (r Runes) len() int {
 }
 
 pub fn (r Runes) substr(start_index int, end_index int) string {
-	return r[start_index..end_index].string()
+	mut st, mut ed := -1, 0
+	mut offset := 0
+	for i, v in r {
+		if offset >= end_index {
+			ed = i
+			break
+		} else if offset >= start_index && st < 0 {
+			st = i
+		}
+		offset += v.length_in_bytes()
+	}
+
+	return r[st..ed].string()
 }

--- a/structures/ropes/ropes.v
+++ b/structures/ropes/ropes.v
@@ -178,7 +178,7 @@ fn (r &Rope) internal_report(idx int, len int, mut res []rune) {
 	}
 }
 
-fn (r &Rope) internal_report_with_byte_index(cur_offset int, start int, end int, mut res []rune) (int, int) {
+fn (r &Rope) b_internal_report(cur_offset int, start int, end int, mut res []rune) (int, int) {
 	if isnil(r) || end <= start {
 		return 0, cur_offset
 	}
@@ -195,8 +195,8 @@ fn (r &Rope) internal_report_with_byte_index(cur_offset int, start int, end int,
 		}
 		read_cnt = offset - cur_offset
 	} else {
-		left_cnt, l_offset := r.left.internal_report_with_byte_index(offset, start, end, mut res)
-		right_cnt, r_offset := r.right.internal_report_with_byte_index(l_offset, start + left_cnt, end, mut res)
+		left_cnt, l_offset := r.left.b_internal_report(offset, start, end, mut res)
+		right_cnt, r_offset := r.right.b_internal_report(l_offset, start + left_cnt, end, mut res)
 		read_cnt += left_cnt + right_cnt
 		offset = r_offset
 	}
@@ -204,19 +204,19 @@ fn (r &Rope) internal_report_with_byte_index(cur_offset int, start int, end int,
 	return read_cnt, offset
 }
 
-fn (r &Rope) report_with_byte_index(start int, end int) []rune {
+fn (r &Rope) b_report(start int, end int) []rune {
 	mut res := []rune{}
 	if end <= start {
 		return res
 	}
 
-	r.internal_report_with_byte_index(0, start, end, mut res)
+	r.b_internal_report(0, start, end, mut res)
 
 	return res
 }
 
 pub fn (r &Rope) substr(start int, end int) string {
-	res := r.report_with_byte_index(start, end)
+	res := r.b_report(start, end)
 	return res.string()
 }
 

--- a/structures/ropes/ropes.v
+++ b/structures/ropes/ropes.v
@@ -178,17 +178,46 @@ fn (r &Rope) internal_report(idx int, len int, mut res []rune) {
 	}
 }
 
+fn (r &Rope) internal_report_with_byte_index(cur_offset int, start int, end int, mut res []rune) (int, int) {
+	if isnil(r) || end <= start {
+		return 0, cur_offset
+	}
+
+	mut read_cnt, mut offset := 0, cur_offset
+	if r.is_leaf() {
+		for v in r.value {
+			if offset >= end {
+				break
+			} else if offset >= start {
+				res << v
+			}
+			offset += v.length_in_bytes()
+		}
+		read_cnt = offset - cur_offset
+	} else {
+		left_cnt, l_offset := r.left.internal_report_with_byte_index(offset, start, end, mut res)
+		right_cnt, r_offset := r.right.internal_report_with_byte_index(l_offset, start + left_cnt, end, mut res)
+		read_cnt += left_cnt + right_cnt
+		offset = r_offset
+	}
+
+	return read_cnt, offset
+}
+
+fn (r &Rope) report_with_byte_index(start int, end int) []rune {
+	mut res := []rune{}
+	if end <= start {
+		return res
+	}
+
+	r.internal_report_with_byte_index(0, start, end, mut res)
+
+	return res
+}
+
 pub fn (r &Rope) substr(start int, end int) string {
-	len := end - start
-	if start < 1 {
-		r.report(1, len)
-	}
-	if start + len - 1 > r.length {
-		r.report(start, r.length - start + 1)
-	}
-	_, r1 := r.split(start)
-	r2, _ := r1.split(len)
-	return r2.string()
+	res := r.report_with_byte_index(start, end)
+	return res.string()
 }
 
 pub fn (r &Rope) rebalance_if_needed() &Rope {


### PR DESCRIPTION
VLS uses `[]rune` for storing source code content in memory, but `tree_sitter.SourceText` interface uses byte index.

When source code contains non-ASCII characters, this implementation causes problem.

This PR is a quick and simple fix. An optimization for rope type is planed.