### PR TITLE
Add trace diagnostics to symbol registration phase.

### DIFF
--- a/analyzer/context.v
+++ b/analyzer/context.v
@@ -36,7 +36,7 @@ pub fn new_context(params AnalyzerContextParams) AnalyzerContext {
 
 pub fn (mut ctx AnalyzerContext) trace_report(report Report) {
 	$if trace ? {
-		r := Report {
+		r := Report{
 			...report
 			file_path: ctx.file_path
 		}

--- a/analyzer/context.v
+++ b/analyzer/context.v
@@ -34,6 +34,22 @@ pub fn new_context(params AnalyzerContextParams) AnalyzerContext {
 	}
 }
 
+pub fn (mut ctx AnalyzerContext) trace_report(report Report) {
+	$if trace ? {
+		r := Report {
+			...report
+			file_path: ctx.file_path
+		}
+		ctx.store.trace_report(r)
+	}
+}
+
+pub fn (mut ctx AnalyzerContext) trace_report_error(err IError) {
+	$if trace ? {
+		ctx.store.report_error_with_path(err, ctx.file_path)
+	}
+}
+
 pub fn (mut ctx AnalyzerContext) replace_file_path(new_file_path string) AnalyzerContext {
 	ctx.file_path = new_file_path
 	ctx.file_name = os.base(new_file_path)

--- a/analyzer/report.v
+++ b/analyzer/report.v
@@ -10,7 +10,7 @@ pub struct AnalyzerError {
 pub fn (err AnalyzerError) msg() string {
 	start := '${err.range.start_point.row}:${err.range.start_point.column}'
 	end := '${err.range.end_point.row}:${err.range.end_point.column}'
-	return '[$start -> $end] $err.msg'
+	return '[${start} -> ${end}] ${err.msg}'
 }
 
 pub fn (err AnalyzerError) str() string {

--- a/analyzer/report.v
+++ b/analyzer/report.v
@@ -36,6 +36,8 @@ pub fn (mut ss Store) report_error(err IError) {
 	}
 }
 
+// report_error_with_path reports AnalyzerError to the messages array, and allow
+// you to specify file path of this error with an argument.
 pub fn (mut ss Store) report_error_with_path(err IError, file_path string) {
 	if err is AnalyzerError {
 		ss.report(

--- a/analyzer/report.v
+++ b/analyzer/report.v
@@ -8,8 +8,8 @@ pub struct AnalyzerError {
 }
 
 pub fn (err AnalyzerError) msg() string {
-	start := '{$err.range.start_point.row:$err.range.start_point.column}'
-	end := '{$err.range.end_point.row:$err.range.end_point.column}'
+	start := '${err.range.start_point.row}:${err.range.start_point.column}'
+	end := '${err.range.end_point.row}:${err.range.end_point.column}'
 	return '[$start -> $end] $err.msg'
 }
 

--- a/analyzer/report.v
+++ b/analyzer/report.v
@@ -35,3 +35,14 @@ pub fn (mut ss Store) report_error(err IError) {
 		)
 	}
 }
+
+pub fn (mut ss Store) report_error_with_path(err IError, file_path string) {
+	if err is AnalyzerError {
+		ss.report(
+			kind: .error
+			message: err.msg
+			range: err.range
+			file_path: file_path
+		)
+	}
+}

--- a/analyzer/store.v
+++ b/analyzer/store.v
@@ -62,6 +62,12 @@ pub fn (mut ss Store) report(report Report) {
 	ss.reporter.report(report)
 }
 
+pub fn (mut ss Store) trace_report(report Report) {
+	$if trace ? {
+		ss.reporter.report(report)
+	}
+}
+
 // get_module_path_opt is a variant of `get_module_path` that returns
 // an optional if not found
 pub fn (ss &Store) get_module_path_opt(file_path string, module_name string) ?string {

--- a/analyzer/store.v
+++ b/analyzer/store.v
@@ -799,7 +799,9 @@ pub fn (mut ss Store) infer_symbol_from_node(file_path string, node ast.Node, sr
 				return error('no name node found')
 			}
 			parent_sym := ss.infer_symbol_from_node(file_path, parent_name_node, src_text)!
-			child_name_node := node.child_by_field_name('name') or { return error('no name node found')}
+			child_name_node := node.child_by_field_name('name') or {
+				return error('no name node found')
+			}
 			return parent_sym.children_syms.get(child_name_node.text(src_text)) or {
 				error('no symbol found')
 			}

--- a/analyzer/symbol.v
+++ b/analyzer/symbol.v
@@ -260,7 +260,7 @@ pub fn (mut info Symbol) add_child(mut new_child_sym Symbol, add_as_parent ...bo
 	}
 
 	if info.children_syms.exists(new_child_sym.name) {
-		return error('child exists. (name="$new_child_sym.name")')
+		return error('child exists. (name="${new_child_sym.name}")')
 	}
 
 	info.children_syms << new_child_sym

--- a/analyzer/symbol_registration.v
+++ b/analyzer/symbol_registration.v
@@ -182,7 +182,7 @@ fn (mut sr SymbolAnalyzer) struct_decl(struct_decl_node ast.Node) !&Symbol {
 	for i in 0 .. fields_len {
 		field_node := decl_list_node.named_child(i) or {
 			sr.trace_report(
-				message: 'failed to get field ${i}',
+				message: 'failed to get field ${i}'
 				range: decl_list_node.range()
 			)
 			continue
@@ -268,7 +268,7 @@ fn (mut sr SymbolAnalyzer) interface_decl(interface_decl_node ast.Node) !&Symbol
 	for i in 0 .. fields_len {
 		field_node := fields_list_node.named_child(i) or {
 			sr.trace_report(
-				message: 'failed to get field ${i}',
+				message: 'failed to get field ${i}'
 				range: fields_list_node.range()
 			)
 			continue
@@ -356,7 +356,7 @@ fn (mut sr SymbolAnalyzer) enum_decl(enum_decl_node ast.Node) !&Symbol {
 	for i in 0 .. members_len {
 		member_node := member_list_node.named_child(i) or {
 			sr.trace_report(
-				message: 'failed to get member ${i}',
+				message: 'failed to get member ${i}'
 				range: member_list_node.range()
 			)
 			continue
@@ -367,7 +367,7 @@ fn (mut sr SymbolAnalyzer) enum_decl(enum_decl_node ast.Node) !&Symbol {
 
 		member_name_node := member_node.child_by_field_name('name') or {
 			sr.trace_report(
-				message: 'name not found in member ${i}',
+				message: 'name not found in member ${i}'
 				range: member_node.range()
 			)
 			continue
@@ -492,7 +492,7 @@ fn (mut sr SymbolAnalyzer) type_decl(type_decl_node ast.Node) !&Symbol {
 		for i in 0 .. types_count {
 			selected_type_node := types_node.named_child(i) or {
 				sr.trace_report(
-					message: 'failed to get type ${i}',
+					message: 'failed to get type ${i}'
 					range: types_node.range()
 				)
 				continue
@@ -500,7 +500,7 @@ fn (mut sr SymbolAnalyzer) type_decl(type_decl_node ast.Node) !&Symbol {
 			mut found_sym := sr.context.find_symbol_by_type_node(selected_type_node) or {
 				name := selected_type_node.text(sr.context.text)
 				sr.trace_report(
-					message: 'invalid type ${name}',
+					message: 'invalid type ${name}'
 					range: selected_type_node.range()
 				)
 				continue
@@ -685,7 +685,7 @@ fn (mut sr SymbolAnalyzer) match_expression(match_node ast.Node) ![]&Symbol {
 	for i in u32(1) .. named_child_count {
 		case_node := match_node.named_child(i) or {
 			sr.trace_report(
-				message: 'failed to get case ${i}',
+				message: 'failed to get case ${i}'
 				range: match_node.range()
 			)
 			continue
@@ -697,7 +697,7 @@ fn (mut sr SymbolAnalyzer) match_expression(match_node ast.Node) ![]&Symbol {
 			for j in u32(0) .. case_list_count {
 				value_node := case_list_node.named_child(j) or {
 					sr.trace_report(
-						message: 'failed to get value ${j} in case',
+						message: 'failed to get value ${j} in case'
 						range: case_list_node.range()
 					)
 					continue
@@ -706,7 +706,7 @@ fn (mut sr SymbolAnalyzer) match_expression(match_node ast.Node) ![]&Symbol {
 					&& value_node.type_name == .type_selector_expression {
 					field_node := value_node.child_by_field_name('field_name') or {
 						sr.trace_report(
-							message: 'failed to get enum field name in value ${j}',
+							message: 'failed to get enum field name in value ${j}'
 							range: value_node.range()
 						)
 						continue
@@ -727,7 +727,7 @@ fn (mut sr SymbolAnalyzer) match_expression(match_node ast.Node) ![]&Symbol {
 
 		conseq_block := case_node.child_by_field_name('consequence') or {
 			sr.trace_report(
-				message: 'case body not found for case ${i}',
+				message: 'case body not found for case ${i}'
 				range: case_node.range()
 			)
 			continue
@@ -1036,7 +1036,7 @@ fn (mut sr SymbolAnalyzer) extract_block(node ast.Node, mut scope ScopeTree) ![]
 	for i := u32(0); i < body_sym_len; i++ {
 		stmt_node := node.named_child(i) or {
 			sr.trace_report(
-				message: 'failed to get child ${i} in block',
+				message: 'failed to get child ${i} in block'
 				range: node.range()
 			)
 			continue
@@ -1050,7 +1050,7 @@ fn (mut sr SymbolAnalyzer) extract_block(node ast.Node, mut scope ScopeTree) ![]
 			for j in u32(0) .. list_len {
 				expr_node := stmt_node.named_child(j) or {
 					sr.trace_report(
-						message: 'failed to get child ${j} in statement',
+						message: 'failed to get child ${j} in statement'
 						range: stmt_node.range()
 					)
 					continue
@@ -1132,7 +1132,8 @@ pub fn (mut sr SymbolAnalyzer) analyze(node ast.Node) ![]&Symbol {
 			return sr.expression(node)
 		}
 		else {
-			/* return report_error('unsupported node type: `${node.type_name}`', node.range()) */
+			// return report_error('unsupported node type: `${node.type_name}`', node.range())
+			return error('')
 		}
 	}
 }

--- a/analyzer/symbol_registration.v
+++ b/analyzer/symbol_registration.v
@@ -1132,7 +1132,7 @@ pub fn (mut sr SymbolAnalyzer) analyze(node ast.Node) ![]&Symbol {
 			return sr.expression(node)
 		}
 		else {
-			return report_error('unsupported node type: `${node.type_name}`', node.range())
+			/* return report_error('unsupported node type: `${node.type_name}`', node.range()) */
 		}
 	}
 }

--- a/analyzer/symbol_registration.v
+++ b/analyzer/symbol_registration.v
@@ -1029,11 +1029,12 @@ pub fn (mut sr SymbolAnalyzer) analyze_from_cursor(mut cursor TreeCursor) []&Sym
 		sr.get_scope(cur_node) or {}
 	}
 
+	file_path := sr.context.file_path
 	mut global_scope := unsafe { sr.context.store.opened_scopes[sr.context.file_path] }
 	mut symbols := []&Symbol{cap: 255}
 	for got_node in cursor {
 		mut syms := sr.analyze(got_node) or {
-			sr.context.store.report_error(err)
+			sr.context.store.report_error_with_path(err, file_path)
 			continue
 		}
 		for i, mut sym in syms {

--- a/analyzer/symbol_registration.v
+++ b/analyzer/symbol_registration.v
@@ -164,7 +164,11 @@ fn (mut sr SymbolAnalyzer) struct_decl(struct_decl_node ast.Node) !&Symbol {
 
 	mut field_access := SymbolAccess.private
 	for i in 0 .. fields_len {
-		field_node := decl_list_node.named_child(i) or { continue }
+		field_node := decl_list_node.named_child(i) or {
+			analyze_err := report_error('failed to get field ${i}', decl_list_node.range())
+			sr.debug_report_error(analyze_err)
+			continue
+		}
 		match field_node.type_name {
 			.struct_field_scope {
 				scope_text := field_node.text(sr.context.text)
@@ -244,7 +248,11 @@ fn (mut sr SymbolAnalyzer) interface_decl(interface_decl_node ast.Node) !&Symbol
 	fields_len := interface_decl_node.named_child_count()
 
 	for i in 0 .. fields_len {
-		field_node := fields_list_node.named_child(i) or { continue }
+		field_node := fields_list_node.named_child(i) or {
+			analyze_err := report_error('failed to get field ${i}', fields_list_node.range())
+			sr.debug_report_error(analyze_err)
+			continue
+		}
 		match field_node.type_name {
 			.interface_field_scope {
 				// TODO: add if mut: check
@@ -326,12 +334,20 @@ fn (mut sr SymbolAnalyzer) enum_decl(enum_decl_node ast.Node) !&Symbol {
 	}
 	members_len := member_list_node.named_child_count()
 	for i in 0 .. members_len {
-		member_node := member_list_node.named_child(i) or { continue }
+		member_node := member_list_node.named_child(i) or {
+			analyze_err := report_error('failed to get member ${i}', member_list_node.range())
+			sr.debug_report_error(analyze_err)
+			continue
+		}
 		if member_node.type_name != .enum_member {
 			continue
 		}
 
-		member_name_node := member_node.child_by_field_name('name') or { continue }
+		member_name_node := member_node.child_by_field_name('name') or {
+			analyze_err := report_error('name not found in member ${i}', member_node.range())
+			sr.debug_report_error(analyze_err)
+			continue
+		}
 		mut member_sym := &Symbol{
 			name: member_name_node.text(sr.context.text)
 			kind: .field
@@ -450,8 +466,17 @@ fn (mut sr SymbolAnalyzer) type_decl(type_decl_node ast.Node) !&Symbol {
 	} else {
 		// sum type
 		for i in 0 .. types_count {
-			selected_type_node := types_node.named_child(i) or { continue }
-			mut found_sym := sr.context.find_symbol_by_type_node(selected_type_node) or { continue }
+			selected_type_node := types_node.named_child(i) or {
+				analyze_err := report_error('failed to get type ${i}', types_node.range())
+				sr.debug_report_error(analyze_err)
+				continue
+			}
+			mut found_sym := sr.context.find_symbol_by_type_node(selected_type_node) or {
+				name := selected_type_node.text(sr.context.text)
+				analyze_err := report_error('invalid type ${name}', selected_type_node.range())
+				sr.debug_report_error(analyze_err)
+				continue
+			}
 			sym.add_child(mut found_sym, false) or { continue }
 			sym.sumtype_children_len++
 		}
@@ -554,8 +579,13 @@ fn (mut sr SymbolAnalyzer) register_variable(sym &Symbol, left_expr_lists ast.No
 		}
 	}
 
+	name := left.text(sr.context.text)
+	if sym.is_void() {
+		return report_error('invalid type for identifier `${name}`', left_expr_lists.range())
+	}
+
 	return &Symbol{
-		name: left.text(sr.context.text)
+		name: name
 		kind: .variable
 		access: var_access
 		range: left.range()
@@ -625,16 +655,28 @@ fn (mut sr SymbolAnalyzer) match_expression(match_node ast.Node) ![]&Symbol {
 	mut expr_value_type := unsafe { void_sym_arr }
 	named_child_count := match_node.named_child_count()
 	for i in u32(1) .. named_child_count {
-		case_node := match_node.named_child(i) or { continue }
+		case_node := match_node.named_child(i) or {
+			analyze_err := report_error('failed to get case ${i}', match_node.range())
+			sr.debug_report_error(analyze_err)
+			continue
+		}
 		if case_node.type_name == .expression_case {
 			case_list_node := case_node.child_by_field_name('value') or { return void_sym_arr }
 
 			case_list_count := case_list_node.named_child_count()
 			for j in u32(0) .. case_list_count {
-				value_node := case_list_node.named_child(j) or { continue }
+				value_node := case_list_node.named_child(j) or {
+					analyze_err := report_error('failed to get value ${j} in case', case_list_node.range())
+					sr.debug_report_error(analyze_err)
+					continue
+				}
 				if cond_value_type.kind == .enum_
 					&& value_node.type_name == .type_selector_expression {
-					field_node := value_node.child_by_field_name('field_name') or { continue }
+					field_node := value_node.child_by_field_name('field_name') or {
+						analyze_err := report_error('failed to get enum field name in value ${j}', value_node.range())
+						sr.debug_report_error(analyze_err)
+						continue
+					}
 					if !cond_value_type.children_syms.exists(field_node.text(sr.context.text)) {
 						return void_sym_arr
 					}
@@ -649,7 +691,11 @@ fn (mut sr SymbolAnalyzer) match_expression(match_node ast.Node) ![]&Symbol {
 			}
 		}
 
-		conseq_block := case_node.child_by_field_name('consequence') or { continue }
+		conseq_block := case_node.child_by_field_name('consequence') or {
+			analyze_err := report_error('case body not found for case ${i}', case_node.range())
+			sr.debug_report_error(analyze_err)
+			continue
+		}
 		got_block_type := sr.extract_block(conseq_block, mut &ScopeTree(0)) or {
 			return void_sym_arr
 		}
@@ -837,10 +883,11 @@ fn (mut sr SymbolAnalyzer) for_statement(for_stmt_node ast.Node) ! {
 			}
 			if vars := sr.short_var_decl(initializer_node) {
 				for var in vars {
-					scope.register(&Symbol{
+					sym := &Symbol{
 						...(*var)
 						access: .private_mutable
-					}) or { continue }
+					}
+					scope.register(sym) or { continue }
 				}
 			}
 		}
@@ -951,7 +998,11 @@ fn (mut sr SymbolAnalyzer) extract_block(node ast.Node, mut scope ScopeTree) ![]
 	body_sym_len := node.named_child_count()
 	mut return_syms := [void_sym]
 	for i := u32(0); i < body_sym_len; i++ {
-		stmt_node := node.named_child(i) or { continue }
+		stmt_node := node.named_child(i) or {
+			analyze_err := report_error('failed to get child ${i} in block', node.range())
+			sr.debug_report_error(analyze_err)
+			continue
+		}
 		if stmt_node.type_name == .expression_list && i == body_sym_len - 1 {
 			list_len := stmt_node.named_child_count()
 			if list_len != 0 {
@@ -959,11 +1010,18 @@ fn (mut sr SymbolAnalyzer) extract_block(node ast.Node, mut scope ScopeTree) ![]
 				return_syms.grow_cap(int(list_len) - return_syms.len)
 			}
 			for j in u32(0) .. list_len {
-				expr_node := stmt_node.named_child(j) or { continue }
+				expr_node := stmt_node.named_child(j) or {
+					analyze_err := report_error('failed to get child ${j} in statement', stmt_node.range())
+					sr.debug_report_error(analyze_err)
+					continue
+				}
 				return_syms << sr.expression(expr_node) or { void_sym_arr }
 			}
 		} else {
-			got_return_sym := sr.statement(stmt_node, mut scope)!
+			got_return_sym := sr.statement(stmt_node, mut scope) or {
+				sr.debug_report_error(err)
+				continue
+			}
 			if i == body_sym_len - 1 {
 				return_syms[0] = got_return_sym[0]
 			}
@@ -979,9 +1037,21 @@ fn extract_parameter_list(mut ctx AnalyzerContext, node ast.Node) []&Symbol {
 
 	for i := u32(0); i < params_len; i++ {
 		mut access := SymbolAccess.private
-		param_node := node.named_child(i) or { continue }
-		mut param_name_node := param_node.child_by_field_name('name') or { continue }
-		param_type_node := param_node.child_by_field_name('type') or { continue }
+		param_node := node.named_child(i) or {
+			analyze_err := report_error('failed to get param ${i}', node.range())
+			debug_report_error(mut ctx, analyze_err)
+			continue
+		}
+		mut param_name_node := param_node.child_by_field_name('name') or {
+			analyze_err := report_error('name node not found', param_node.range())
+			debug_report_error(mut ctx, analyze_err)
+			continue
+		}
+		param_type_node := param_node.child_by_field_name('type') or {
+			analyze_err := report_error('type node not found', param_node.range())
+			debug_report_error(mut ctx, analyze_err)
+			continue
+		}
 		return_sym := ctx.find_symbol_by_type_node(param_type_node) or { void_sym }
 		if param_name_node.type_name == .mutable_identifier {
 			access = SymbolAccess.private_mutable
@@ -1029,12 +1099,11 @@ pub fn (mut sr SymbolAnalyzer) analyze_from_cursor(mut cursor TreeCursor) []&Sym
 		sr.get_scope(cur_node) or {}
 	}
 
-	file_path := sr.context.file_path
 	mut global_scope := unsafe { sr.context.store.opened_scopes[sr.context.file_path] }
 	mut symbols := []&Symbol{cap: 255}
 	for got_node in cursor {
 		mut syms := sr.analyze(got_node) or {
-			sr.context.store.report_error_with_path(err, file_path)
+			sr.debug_report_error(err)
 			continue
 		}
 		for i, mut sym in syms {
@@ -1055,6 +1124,18 @@ pub fn (mut sr SymbolAnalyzer) analyze_from_cursor(mut cursor TreeCursor) []&Sym
 		}
 	}
 	return symbols
+}
+
+pub fn (mut sr SymbolAnalyzer) debug_report_error(err IError) {
+	$if debug {
+		sr.context.store.report_error_with_path(err, sr.context.file_path)
+	}
+}
+
+fn debug_report_error(mut ctx AnalyzerContext, err IError) {
+	$if debug {
+		ctx.store.report_error_with_path(err, ctx.file_path)
+	}
 }
 
 // register_symbols_from_tree scans and registers all the symbols based on the given tree

--- a/analyzer/symbol_registration.v
+++ b/analyzer/symbol_registration.v
@@ -945,7 +945,7 @@ fn (mut sr SymbolAnalyzer) extract_block(node ast.Node, mut scope ScopeTree) ![]
 	if node.type_name != .block {
 		return report_error('expected a `block` node', node.range())
 	} else if sr.is_import {
-		return report_error('cannot be used in `is_import` mode', node.range())
+		return error('cannot be used in `is_import` mode')
 	}
 
 	body_sym_len := node.named_child_count()
@@ -963,7 +963,7 @@ fn (mut sr SymbolAnalyzer) extract_block(node ast.Node, mut scope ScopeTree) ![]
 				return_syms << sr.expression(expr_node) or { void_sym_arr }
 			}
 		} else {
-			got_return_sym := sr.statement(stmt_node, mut scope) or { void_sym_arr }
+			got_return_sym := sr.statement(stmt_node, mut scope)!
 			if i == body_sym_len - 1 {
 				return_syms[0] = got_return_sym[0]
 			}

--- a/build.vsh
+++ b/build.vsh
@@ -56,4 +56,4 @@ if ret != 0 {
 }
 
 println('> VLS built successfully!')
-println('Executable saved in: $full_vls_exec_path')
+println('Executable saved in: ${full_vls_exec_path}')

--- a/build.vsh
+++ b/build.vsh
@@ -33,8 +33,21 @@ if vls_git_hash.exit_code != 0 {
 }
 os.setenv('VLS_BUILD_COMMIT', vls_git_hash.output.trim_space(), true)
 
-use_libbacktrace_flag := if cc == 'msvc' { '' } else { '-d use_libbacktrace' }
-cmd := 'v -g -gc boehm $use_libbacktrace_flag -cc $cc cmd/vls -o $full_vls_exec_path'
+mut buffer := ['v', 'cmd/vls']
+buffer << '-g'
+buffer << ['-o', full_vls_exec_path]
+buffer << ['-gc', 'boehm']
+buffer << ['-cc', cc]
+if cc != 'msvc' {
+	buffer << ['-d', 'use_libbacktrace']
+}
+
+index_extra := os.args.index('--')
+if index_extra > 0 {
+	buffer << os.args[index_extra + 1..]
+}
+
+cmd := buffer.join(' ')
 println(cmd)
 ret := system(cmd)
 if ret != 0 {


### PR DESCRIPTION
To bring comfort to development, adding diagnostic message for errors in symbol registration phase.

![图片](https://user-images.githubusercontent.com/38665076/215832936-72759bf3-55a2-40a1-a7fc-cd815b60a11a.png)

Those messages will only be shown when VLS is compiled with `-d trace` flag.

Adding support to directly pass parameters to `v` for `build.vsh`. Now one can use `--` to separate arguments for `build.vsh` and `v` command called by this script.

For example, to build VLS with `trace` flag:

```
v run build.vsh clang -- -d trace
```