### PR TITLE
Move reports and logs to `os.cache_dir()`

### DIFF
--- a/cmd/vls/host.v
+++ b/cmd/vls/host.v
@@ -162,9 +162,9 @@ fn (mut host VlsHost) handle_exit() {
 }
 
 fn (mut host VlsHost) generate_report() !string {
-	reports_dir_path := os.join_path(server.get_folder_path(), 'reports')
+	reports_dir_path := os.join_path(os.cache_dir(), 'vls', 'reports')
 	if !os.exists(reports_dir_path) {
-		os.mkdir(reports_dir_path)!
+		os.mkdir_all(reports_dir_path)!
 	}
 
 	report_file_name := 'vls_report_' + time.utc().unix.str() + '.md'

--- a/server/general.v
+++ b/server/general.v
@@ -123,9 +123,9 @@ fn (mut ls Vls) setup_logger(mut rw ResponseWriter) !string {
 
 	rw.server.dispatch_event(log.set_logpath_event, log_path) or {
 		sanitized_root_uri := ls.root_uri.path().replace_each(['/', '_', ':', '_', '\\', '_'])
-		logs_dir_path := os.join_path(get_folder_path(), 'logs')
+		logs_dir_path := os.join_path(os.cache_dir(), 'vls', 'logs')
 		if !os.exists(logs_dir_path) {
-			os.mkdir(logs_dir_path)!
+			os.mkdir_all(logs_dir_path)!
 		}
 
 		alt_log_path := os.join_path(logs_dir_path, 'vls__${sanitized_root_uri}.log')

--- a/server/general_test.v
+++ b/server/general_test.v
@@ -107,7 +107,7 @@ fn test_setup_logger() {
 	assert notif.method == 'window/showMessage'
 
 	expected_err_path := os.join_path('/non_existent', 'path', 'vls.log')
-	expected_alt_log_path := os.join_path(server.get_folder_path(), 'logs', 'vls___non_existent_path.log')
+	expected_alt_log_path := os.join_path(os.cache_dir(), 'vls', 'logs', 'vls___non_existent_path.log')
 	assert notif.params == lsp.ShowMessageParams{
 		@type: .error
 		message: 'Cannot save log to ${expected_err_path}. Saving log to $expected_alt_log_path'


### PR DESCRIPTION
Fixes #367.