### PR TITLE
fix(treesitter): always free token contents to prevent a memory leak

### DIFF
--- a/tree_sitter_v/src/scanner.c
+++ b/tree_sitter_v/src/scanner.c
@@ -418,9 +418,7 @@ void *tree_sitter_v_external_scanner_create() {
 
 void tree_sitter_v_external_scanner_destroy(void *p) {
     Scanner *scanner = (Scanner*) p;
-    if (scanner->tokens->top + 1 > 0) {
-        free(scanner->tokens->contents);
-    }
+    free(scanner->tokens->contents);
     free(scanner->tokens);
     free(scanner);
 }


### PR DESCRIPTION
Detected with libfuzzer

Also just inlined the stack so there's no need to allocate twice for the stack and its data ptr