### PR TITLE
fix goto-definition, code cleanup

### DIFF
--- a/handlers.v
+++ b/handlers.v
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a GPL license that can be found in the LICENSE file.
 
 fn (mut app App) operation_at_pos(method Method, request Request) Response {
-	line_nr := request.params.position.line
+	line_nr := request.params.position.line + 1
 	col := request.params.position.char
 	path := request.params.text_document.uri
 	line_info := match method {

--- a/main.v
+++ b/main.v
@@ -188,6 +188,10 @@ struct JsonError {
 	len     int
 }
 
+struct JsonVarAC {
+	details []Detail
+}
+
 fn v_error_to_lsp_diagnostic(e JsonError) LSPDiagnostic {
 	start_line := e.line_nr - 1 // LSP is 0-indexed, V parser is 1-indexed
 	start_char := e.col - 1 // LSP is 0-indexed, V parser is 1-indexed


### PR DESCRIPTION
- Simplify `vls` design
- change goto definition `-line-info` from `gd^expr` to `gd^col`