### PR TITLE
use system path instead of uri for go to definition

### DIFF
--- a/handlers.v
+++ b/handlers.v
@@ -1,5 +1,6 @@
 // Copyright (c) 2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by a GPL license that can be found in the LICENSE file.
+module main
 
 fn (mut app App) operation_at_pos(method Method, request Request) Response {
 	line_nr := request.params.position.line + 1

--- a/interop.v
+++ b/interop.v
@@ -1,5 +1,7 @@
 // Copyright (c) 2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by a GPL license that can be found in the LICENSE file.
+module main
+
 import json
 import os
 import time

--- a/lsp.v
+++ b/lsp.v
@@ -1,5 +1,7 @@
 // Copyright (c) 2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by a GPL license that can be found in the LICENSE file.
+module main
+
 struct Request {
 	id      int
 	method  string

--- a/main.v
+++ b/main.v
@@ -1,5 +1,7 @@
 // Copyright (c) 2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by a GPL license that can be found in the LICENSE file.
+module main
+
 import json
 import os
 import v.pref


### PR DESCRIPTION
This fixes go to definition on zed, haven't tested if other functionality is hindered by the uri.

Go to defintion seems to only work for functions for now, not sure if it's implemented for other exprs yet.