### PR TITLE
Address static audit: protocol, security, position encoding, indexing, and correctness

### DIFF
--- a/call_hierarchy.v
+++ b/call_hierarchy.v
@@ -2,14 +2,14 @@
 // Use of this source code is governed by a GPL license that can be found in the LICENSE file.
 module main
 
-import json
+import json2
 import os
 
 // handle_prepare_call_hierarchy handles textDocument/prepareCallHierarchy.
 // It resolves the function or method at the given cursor position and returns
 // a CallHierarchyItem that can be used for subsequent incoming/outgoing queries.
 fn (mut app App) handle_prepare_call_hierarchy(request Request) Response {
-	params := json.decode(PrepareCallHierarchyParams, request.params) or {
+	params := json2.decode[PrepareCallHierarchyParams](request.params) or {
 		$if debug { log('Failed to decode PrepareCallHierarchyParams: ${err}') }
 		return Response{
 			id:     request.id
@@ -63,7 +63,7 @@ fn (mut app App) handle_prepare_call_hierarchy(request Request) Response {
 // For each .v file reachable from the item's working directory it scans for
 // calls to the queried function and groups them by the enclosing caller.
 fn (mut app App) handle_call_hierarchy_incoming(request Request) Response {
-	params := json.decode(CallHierarchyIncomingCallsParams, request.params) or {
+	params := json2.decode[CallHierarchyIncomingCallsParams](request.params) or {
 		$if debug { log('Failed to decode CallHierarchyIncomingCallsParams: ${err}') }
 		return Response{
 			id:     request.id
@@ -129,7 +129,7 @@ fn (mut app App) handle_call_hierarchy_incoming(request Request) Response {
 // handle_call_hierarchy_outgoing handles callHierarchy/outgoingCalls.
 // It identifies every function called within the body of the queried function.
 fn (mut app App) handle_call_hierarchy_outgoing(request Request) Response {
-	params := json.decode(CallHierarchyOutgoingCallsParams, request.params) or {
+	params := json2.decode[CallHierarchyOutgoingCallsParams](request.params) or {
 		$if debug { log('Failed to decode CallHierarchyOutgoingCallsParams: ${err}') }
 		return Response{
 			id:     request.id

--- a/call_hierarchy.v
+++ b/call_hierarchy.v
@@ -41,7 +41,7 @@ fn (mut app App) handle_prepare_call_hierarchy(request Request) Response {
 		}
 	}
 	// Search the current file first, then the wider workspace.
-	mut item := find_fn_in_content(word, content, uri)
+	mut item := find_fn_in_content(word, content, uri, app.position_encoding)
 	if item.name == '' {
 		working_dir := os.dir(uri_to_path(uri))
 		search_dirs := app.workspace_search_dirs(working_dir)
@@ -94,7 +94,7 @@ fn (mut app App) handle_call_hierarchy_incoming(request Request) Response {
 			continue
 		}
 		processed[uri] = true
-		scan_for_callers(fn_name, uri, fc, mut results)
+		scan_for_callers(fn_name, uri, fc, app.position_encoding, mut results)
 	}
 	// Scan on-disk .v files in the working directory.
 	for dir in search_dirs {
@@ -117,7 +117,7 @@ fn (mut app App) handle_call_hierarchy_incoming(request Request) Response {
 			}
 			processed[uri] = true
 			fc := os.read_file(f) or { continue }
-			scan_for_callers(fn_name, uri, fc, mut results)
+			scan_for_callers(fn_name, uri, fc, app.position_encoding, mut results)
 		}
 	}
 	return Response{
@@ -149,7 +149,7 @@ fn (mut app App) handle_call_hierarchy_outgoing(request Request) Response {
 		if li >= lines.len {
 			break
 		}
-		find_fn_calls_in_line(lines[li], li, mut call_map)
+		find_fn_calls_in_line(lines[li], li, app.position_encoding, mut call_map)
 	}
 
 	working_dir := os.dir(uri_to_path(uri))
@@ -193,8 +193,9 @@ fn extract_simple_fn_name(full_name string) string {
 
 // find_fn_in_content searches `content` for a function/method whose simple
 // (bare) name equals `fn_name` and returns a CallHierarchyItem on success.
-fn find_fn_in_content(fn_name string, content string, uri string) CallHierarchyItem {
-	syms := parse_document_symbols(content)
+fn find_fn_in_content(fn_name string, content string, uri string, enc PositionEncoding) CallHierarchyItem {
+	syms :=
+		encode_document_symbols(parse_document_symbols(content), content.split_into_lines(), enc)
 	for sym in syms {
 		if sym.kind != sym_kind_function && sym.kind != sym_kind_method {
 			continue
@@ -234,9 +235,9 @@ fn (mut app App) find_fn_declaration(fn_name string, search_dirs []string, reque
 // call site, appends a CallHierarchyIncomingCall entry to `results` keyed by
 // the enclosing function symbol (nearest preceding function declaration).
 // String literals and line comments are skipped to avoid false positives.
-fn scan_for_callers(fn_name string, file_uri string, file_content string, mut results []CallHierarchyIncomingCall) {
+fn scan_for_callers(fn_name string, file_uri string, file_content string, enc PositionEncoding, mut results []CallHierarchyIncomingCall) {
 	file_lines := file_content.split_into_lines()
-	syms := parse_document_symbols(file_content)
+	syms := encode_document_symbols(parse_document_symbols(file_content), file_lines, enc)
 
 	// For each function symbol, scan its body for calls to fn_name.
 	for sym in syms {
@@ -282,8 +283,8 @@ fn scan_for_callers(fn_name string, file_uri string, file_content string, mut re
 					col = abs + 1
 					continue
 				}
-				start_char := utf8_byte_to_char_index(line, abs)
-				end_char := utf8_byte_to_char_index(line, abs + fn_name.len)
+				start_char := byte_to_encoded_col(line, abs, enc)
+				end_char := byte_to_encoded_col(line, abs + fn_name.len, enc)
 				call_ranges << LSPRange{
 					start: Position{
 						line: li
@@ -314,7 +315,7 @@ fn scan_for_callers(fn_name string, file_uri string, file_content string, mut re
 
 // find_fn_calls_in_line scans a single source line for `identifier(` patterns
 // and adds them to `call_map` keyed by the unqualified callee name.
-fn find_fn_calls_in_line(line string, line_idx int, mut call_map map[string][]LSPRange) {
+fn find_fn_calls_in_line(line string, line_idx int, enc PositionEncoding, mut call_map map[string][]LSPRange) {
 	n := line.len
 	mut col := 0
 	for col < n {
@@ -357,8 +358,8 @@ fn find_fn_calls_in_line(line string, line_idx int, mut call_map map[string][]LS
 				parts := word.split('.')
 				simple := parts.last()
 				if simple.len > 0 && simple !in v_keywords {
-					start_char := utf8_byte_to_char_index(line, start)
-					end_char := utf8_byte_to_char_index(line, col)
+					start_char := byte_to_encoded_col(line, start, enc)
+					end_char := byte_to_encoded_col(line, col, enc)
 					cr := LSPRange{
 						start: Position{
 							line: line_idx

--- a/call_hierarchy.v
+++ b/call_hierarchy.v
@@ -219,13 +219,23 @@ fn find_fn_in_content(fn_name string, content string, uri string, enc PositionEn
 fn (mut app App) find_fn_declaration(fn_name string, search_dirs []string, request_id int, include_tests bool) CallHierarchyItem {
 	// Answer from the persistent symbol index instead of re-scanning every file.
 	app.ensure_dirs_indexed(search_dirs)
-	if uri, sym := app.find_indexed_fn(fn_name, include_tests) {
-		return CallHierarchyItem{
-			name:            sym.name
-			kind:            sym.kind
-			uri:             uri
-			range:           sym.range
-			selection_range: sym.selection_range
+	// Prefer a declaration in the primary (current module) directory, then widen
+	// to the full search set; never look outside the supplied dirs, so a
+	// same-named function in an unrelated indexed workspace root is not returned.
+	mut dir_passes := [][]string{}
+	if search_dirs.len > 1 {
+		dir_passes << [search_dirs[0]]
+	}
+	dir_passes << search_dirs
+	for dirs in dir_passes {
+		if uri, sym := app.find_indexed_fn(fn_name, include_tests, dirs) {
+			return CallHierarchyItem{
+				name:            sym.name
+				kind:            sym.kind
+				uri:             uri
+				range:           sym.range
+				selection_range: sym.selection_range
+			}
 		}
 	}
 	return CallHierarchyItem{}

--- a/call_hierarchy.v
+++ b/call_hierarchy.v
@@ -19,7 +19,7 @@ fn (mut app App) handle_prepare_call_hierarchy(request Request) Response {
 	uri := params.text_document.uri
 	content := app.open_files[uri] or { os.read_file(uri_to_path(uri)) or { '' } }
 	lines := content.split_into_lines()
-	if params.position.line >= lines.len {
+	if params.position.line < 0 || params.position.line >= lines.len {
 		return Response{
 			id:     request.id
 			result: 'null'
@@ -33,7 +33,7 @@ fn (mut app App) handle_prepare_call_hierarchy(request Request) Response {
 			result: 'null'
 		}
 	}
-	word := line_text[start..end]
+	word := substr_by_char_bounds(line_text, start, end)
 	if word == '' {
 		return Response{
 			id:     request.id

--- a/call_hierarchy.v
+++ b/call_hierarchy.v
@@ -216,35 +216,15 @@ fn find_fn_in_content(fn_name string, content string, uri string) CallHierarchyI
 // `search_dirs` for a function/method named `fn_name`. Polls for cancellation
 // between files so callers can return early when the request is cancelled.
 fn (mut app App) find_fn_declaration(fn_name string, search_dirs []string, request_id int) CallHierarchyItem {
-	for uri, fc in app.open_files {
-		if request_id in app.cancelled_requests {
-			return CallHierarchyItem{}
-		}
-		item := find_fn_in_content(fn_name, fc, uri)
-		if item.name != '' {
-			return item
-		}
-	}
-	for dir in search_dirs {
-		if dir == '' || dir == '/' || !os.is_dir(dir) {
-			continue
-		}
-		for f in os.walk_ext(dir, '.v') {
-			if request_id in app.cancelled_requests {
-				return CallHierarchyItem{}
-			}
-			if f.ends_with('_test.v') {
-				continue
-			}
-			uri := path_to_uri(f)
-			if uri in app.open_files {
-				continue
-			}
-			fc := os.read_file(f) or { continue }
-			item := find_fn_in_content(fn_name, fc, uri)
-			if item.name != '' {
-				return item
-			}
+	// Answer from the persistent symbol index instead of re-scanning every file.
+	app.ensure_dirs_indexed(search_dirs)
+	if uri, sym := app.find_indexed_fn(fn_name) {
+		return CallHierarchyItem{
+			name:            sym.name
+			kind:            sym.kind
+			uri:             uri
+			range:           sym.range
+			selection_range: sym.selection_range
 		}
 	}
 	return CallHierarchyItem{}

--- a/call_hierarchy.v
+++ b/call_hierarchy.v
@@ -26,14 +26,14 @@ fn (mut app App) handle_prepare_call_hierarchy(request Request) Response {
 		}
 	}
 	line_text := lines[params.position.line]
-	start, end := find_word_bounds_at_col(line_text, params.position.char)
+	start, end := find_word_bounds_at_col(line_text, params.position.char, app.position_encoding)
 	if start < 0 || end <= start {
 		return Response{
 			id:     request.id
 			result: 'null'
 		}
 	}
-	word := substr_by_char_bounds(line_text, start, end)
+	word := substr_by_char_bounds(line_text, start, end, app.position_encoding)
 	if word == '' {
 		return Response{
 			id:     request.id

--- a/call_hierarchy.v
+++ b/call_hierarchy.v
@@ -45,7 +45,7 @@ fn (mut app App) handle_prepare_call_hierarchy(request Request) Response {
 	if item.name == '' {
 		working_dir := os.dir(uri_to_path(uri))
 		search_dirs := app.workspace_search_dirs(working_dir)
-		item = app.find_fn_declaration(word, search_dirs, request.id)
+		item = app.find_fn_declaration(word, search_dirs, request.id, uri.ends_with('_test.v'))
 	}
 	if item.name == '' {
 		return Response{
@@ -163,7 +163,7 @@ fn (mut app App) handle_call_hierarchy_outgoing(request Request) Response {
 		if called_name == self_name {
 			continue // skip direct recursion
 		}
-		callee := app.find_fn_declaration(called_name, search_dirs, request.id)
+		callee := app.find_fn_declaration(called_name, search_dirs, request.id, uri.ends_with('_test.v'))
 		if callee.name == '' {
 			continue
 		}
@@ -216,10 +216,10 @@ fn find_fn_in_content(fn_name string, content string, uri string, enc PositionEn
 // find_fn_declaration searches open files and then on-disk files in
 // `search_dirs` for a function/method named `fn_name`. Polls for cancellation
 // between files so callers can return early when the request is cancelled.
-fn (mut app App) find_fn_declaration(fn_name string, search_dirs []string, request_id int) CallHierarchyItem {
+fn (mut app App) find_fn_declaration(fn_name string, search_dirs []string, request_id int, include_tests bool) CallHierarchyItem {
 	// Answer from the persistent symbol index instead of re-scanning every file.
 	app.ensure_dirs_indexed(search_dirs)
-	if uri, sym := app.find_indexed_fn(fn_name) {
+	if uri, sym := app.find_indexed_fn(fn_name, include_tests) {
 		return CallHierarchyItem{
 			name:            sym.name
 			kind:            sym.kind

--- a/compilation_test.v
+++ b/compilation_test.v
@@ -20,7 +20,7 @@ fn test_smoke_incremental_edit_is_lossless() {
 			line: 0
 			char: 1
 		}
-	}, 'X')
+	}, 'X', .utf16)
 	// The CRLF terminators must be preserved exactly.
 	assert updated == 'aX\r\nb\r\n'
 }

--- a/compilation_test.v
+++ b/compilation_test.v
@@ -1,6 +1,41 @@
 module main
 
-fn test_compilation() {
-	println('ok')
-	assert true
+// This file used to be a no-op (`assert true`). It now exercises a cross-section
+// of the server's pure logic so the suite fails loudly if a foundational
+// invariant regresses, instead of merely proving the code compiles.
+
+fn test_smoke_uri_roundtrip() {
+	original := '/home/user/my project/a#b.v'
+	assert uri_to_path(path_to_uri(original)) == original
+}
+
+fn test_smoke_incremental_edit_is_lossless() {
+	content := 'a\r\nb\r\n'
+	updated := apply_incremental_change(content, LSPRange{
+		start: Position{
+			line: 0
+			char: 1
+		}
+		end:   Position{
+			line: 0
+			char: 1
+		}
+	}, 'X')
+	// The CRLF terminators must be preserved exactly.
+	assert updated == 'aX\r\nb\r\n'
+}
+
+fn test_smoke_raw_id_extraction() {
+	id := extract_raw_id('{"jsonrpc":"2.0","id":"z-9","method":"initialize"}') or {
+		assert false, 'expected id'
+		return
+	}
+	assert id == '"z-9"'
+}
+
+fn test_smoke_argv_is_shell_free() {
+	// A malicious path stays a single literal argv element (no shell involved).
+	malicious := '/tmp/$(touch /tmp/pwned)/x.v'
+	args := build_v_check_args_single(malicious)
+	assert malicious in args
 }

--- a/document_highlight.v
+++ b/document_highlight.v
@@ -10,7 +10,8 @@ const doc_highlight_read = 2
 const doc_highlight_write = 3
 
 // Each semantic highlight candidate requires a serial compiler definition
-// lookup. Above this bound, highlighting falls back to lexical occurrences.
+// lookup. Above this bound, return no highlights rather than conflate symbols
+// with the same spelling from different scopes.
 const document_highlight_semantic_max_candidates = 48
 
 struct DocumentHighlightCandidate {
@@ -203,15 +204,6 @@ fn collect_document_highlight_candidates(lines []string, symbol string) []Docume
 	return candidates
 }
 
-// resolve_document_highlight_anchor avoids all compiler work when semantic
-// verification would exceed the per-request candidate bound.
-fn (mut app App) resolve_document_highlight_anchor(uri string, line int, ch int, candidate_count int) ?Location {
-	if candidate_count > document_highlight_semantic_max_candidates {
-		return none
-	}
-	return app.resolve_symbol_anchor(uri, line, ch)
-}
-
 // handle_document_highlight handles textDocument/documentHighlight.
 // It finds all occurrences of the identifier under the cursor within the current
 // document and returns them as a DocumentHighlight list.
@@ -254,8 +246,13 @@ fn (mut app App) handle_document_highlight(request Request) Response {
 		}
 	}
 	candidates := collect_document_highlight_candidates(lines, symbol)
-	anchor := app.resolve_document_highlight_anchor(uri, params.position.line, start,
-		candidates.len)
+	if candidates.len > document_highlight_semantic_max_candidates {
+		return Response{
+			id:     request.id
+			result: []DocumentHighlight{}
+		}
+	}
+	anchor := app.resolve_symbol_anchor(uri, params.position.line, start)
 	mut anchor_cache := map[string]?Location{}
 	if a := anchor {
 		// The initial lookup already resolved the selected occurrence.

--- a/document_highlight.v
+++ b/document_highlight.v
@@ -12,8 +12,8 @@ const doc_highlight_write = 3
 // classify_highlight_kind classifies an identifier occurrence ending at byte
 // offset `end_byte` on `line` as a Write (assignment target) or a Read, based on
 // the operator that immediately follows it. This is a syntactic heuristic
-// (P2-03): `name :=` / `name =` / `name op=` are writes; comparisons and
-// everything else are reads.
+// (P2-03): `name :=` / `name =` / `name op=` / `name++` / `name--` are writes;
+// comparisons and everything else are reads.
 fn classify_highlight_kind(line string, end_byte int) int {
 	mut i := end_byte
 	for i < line.len && (line[i] == ` ` || line[i] == `\t`) {
@@ -31,6 +31,9 @@ fn classify_highlight_kind(line string, end_byte int) int {
 		return doc_highlight_read
 	}
 	if rest.starts_with('=') {
+		return doc_highlight_write
+	}
+	if rest.starts_with('++') || rest.starts_with('--') {
 		return doc_highlight_write
 	}
 	// Compound assignment: += -= *= /= %= &= |= ^= (op followed by '=', not '==').

--- a/document_highlight.v
+++ b/document_highlight.v
@@ -2,14 +2,14 @@
 // Use of this source code is governed by a GPL license that can be found in the LICENSE file.
 module main
 
-import json
+import json2
 import os
 
 // handle_document_highlight handles textDocument/documentHighlight.
 // It finds all occurrences of the identifier under the cursor within the current
 // document and returns them as a DocumentHighlight list.
 fn (mut app App) handle_document_highlight(request Request) Response {
-	params := json.decode(DocumentHighlightParams, request.params) or {
+	params := json2.decode[DocumentHighlightParams](request.params) or {
 		$if debug { log('Failed to decode DocumentHighlightParams: ${err}') }
 		return Response{
 			id:     request.id

--- a/document_highlight.v
+++ b/document_highlight.v
@@ -25,7 +25,7 @@ fn (mut app App) handle_document_highlight(request Request) Response {
 		}
 	}
 	lines := content.split_into_lines()
-	if params.position.line >= lines.len {
+	if params.position.line < 0 || params.position.line >= lines.len {
 		return Response{
 			id:     request.id
 			result: []DocumentHighlight{}
@@ -39,7 +39,7 @@ fn (mut app App) handle_document_highlight(request Request) Response {
 			result: []DocumentHighlight{}
 		}
 	}
-	symbol := line_text[start..end]
+	symbol := substr_by_char_bounds(line_text, start, end)
 	if symbol == '' {
 		return Response{
 			id:     request.id

--- a/document_highlight.v
+++ b/document_highlight.v
@@ -9,6 +9,16 @@ import os
 const doc_highlight_read = 2
 const doc_highlight_write = 3
 
+// Each semantic highlight candidate requires a serial compiler definition
+// lookup. Above this bound, highlighting falls back to lexical occurrences.
+const document_highlight_semantic_max_candidates = 48
+
+struct DocumentHighlightCandidate {
+	line_idx   int
+	start_byte int
+	end_byte   int
+}
+
 // highlight_has_word reports whether `text` contains `word` at identifier
 // boundaries.
 fn highlight_has_word(text string, word string) bool {
@@ -141,6 +151,67 @@ fn classify_highlight_kind(line string, start_byte int, end_byte int) int {
 	return doc_highlight_read
 }
 
+// collect_document_highlight_candidates finds exact identifier occurrences
+// while excluding line comments and string literals.
+fn collect_document_highlight_candidates(lines []string, symbol string) []DocumentHighlightCandidate {
+	mut candidates := []DocumentHighlightCandidate{}
+	for line_idx, line in lines {
+		if !line.contains(symbol) {
+			continue
+		}
+		n := line.len
+		mut col := 0
+		for col < n {
+			c := line[col]
+			if col + 1 < n && c == `/` && line[col + 1] == `/` {
+				break
+			}
+			if c == `"` || c == `'` {
+				quote := c
+				col++
+				for col < n {
+					if line[col] == `\\` {
+						col += 2
+						continue
+					}
+					if line[col] == quote {
+						col++
+						break
+					}
+					col++
+				}
+				continue
+			}
+			if is_ident_char(c) {
+				start_byte := col
+				col++
+				for col < n && is_ident_char(line[col]) {
+					col++
+				}
+				if line[start_byte..col] == symbol {
+					candidates << DocumentHighlightCandidate{
+						line_idx:   line_idx
+						start_byte: start_byte
+						end_byte:   col
+					}
+				}
+				continue
+			}
+			col++
+		}
+	}
+	return candidates
+}
+
+// resolve_document_highlight_anchor avoids all compiler work when semantic
+// verification would exceed the per-request candidate bound.
+fn (mut app App) resolve_document_highlight_anchor(uri string, line int, ch int, candidate_count int) ?Location {
+	if candidate_count > document_highlight_semantic_max_candidates {
+		return none
+	}
+	return app.resolve_symbol_anchor(uri, line, ch)
+}
+
 // handle_document_highlight handles textDocument/documentHighlight.
 // It finds all occurrences of the identifier under the cursor within the current
 // document and returns them as a DocumentHighlight list.
@@ -182,90 +253,57 @@ fn (mut app App) handle_document_highlight(request Request) Response {
 			result: []DocumentHighlight{}
 		}
 	}
-	anchor := app.resolve_symbol_anchor(uri, params.position.line, start)
+	candidates := collect_document_highlight_candidates(lines, symbol)
+	anchor := app.resolve_document_highlight_anchor(uri, params.position.line, start,
+		candidates.len)
 	mut anchor_cache := map[string]?Location{}
-	mut highlights := []DocumentHighlight{}
-	for line_idx, line in lines {
-		if !line.contains(symbol) {
-			continue
+	if a := anchor {
+		// The initial lookup already resolved the selected occurrence.
+		anchor_cache[anchor_cache_key(uri, params.position.line, start)] = a
+	}
+	mut highlights := []DocumentHighlight{cap: candidates.len}
+	for candidate in candidates {
+		line := lines[candidate.line_idx]
+		start_char := byte_to_encoded_col(line, candidate.start_byte, app.position_encoding)
+		end_char := byte_to_encoded_col(line, candidate.end_byte, app.position_encoding)
+		if a := anchor {
+			if resolved := app.resolve_symbol_anchor_cached(uri, candidate.line_idx, start_char, mut
+				anchor_cache)
+			{
+				if !same_anchor_location(resolved, a) {
+					continue
+				}
+			} else {
+				continue
+			}
 		}
-		n := line.len
-		mut col := 0
-		for col < n {
-			c := line[col]
-			// Skip line comments.
-			if col + 1 < n && c == `/` && line[col + 1] == `/` {
-				break
-			}
-			// Skip string literals.
-			if c == `"` || c == `'` {
-				quote := c
-				col++
-				for col < n {
-					if line[col] == `\\` {
-						col += 2
-						continue
-					}
-					if line[col] == quote {
-						col++
-						break
-					}
-					col++
-				}
-				continue
-			}
-			if is_ident_char(c) {
-				start_byte := col
-				col++
-				for col < n && is_ident_char(line[col]) {
-					col++
-				}
-				if line[start_byte..col] == symbol {
-					start_char := byte_to_encoded_col(line, start_byte, app.position_encoding)
-					end_char := byte_to_encoded_col(line, col, app.position_encoding)
-					if a := anchor {
-						if resolved := app.resolve_symbol_anchor_cached(uri, line_idx, start_char, mut
-							anchor_cache)
-						{
-							if !same_anchor_location(resolved, a) {
-								continue
-							}
-						} else {
-							continue
-						}
-					}
-					mut kind := classify_highlight_kind(line, start_byte, col)
-					if a := anchor {
-						occurrence := Location{
-							uri:   uri
-							range: LSPRange{
-								start: Position{
-									line: line_idx
-									char: start_char
-								}
-							}
-						}
-						if same_anchor_location(occurrence, a) {
-							kind = doc_highlight_write
-						}
-					}
-					highlights << DocumentHighlight{
-						range: LSPRange{
-							start: Position{
-								line: line_idx
-								char: start_char
-							}
-							end:   Position{
-								line: line_idx
-								char: end_char
-							}
-						}
-						kind:  kind // Read/Write (P2-03)
+		mut kind := classify_highlight_kind(line, candidate.start_byte, candidate.end_byte)
+		if a := anchor {
+			occurrence := Location{
+				uri:   uri
+				range: LSPRange{
+					start: Position{
+						line: candidate.line_idx
+						char: start_char
 					}
 				}
-				continue
 			}
-			col++
+			if same_anchor_location(occurrence, a) {
+				kind = doc_highlight_write
+			}
+		}
+		highlights << DocumentHighlight{
+			range: LSPRange{
+				start: Position{
+					line: candidate.line_idx
+					char: start_char
+				}
+				end:   Position{
+					line: candidate.line_idx
+					char: end_char
+				}
+			}
+			kind:  kind // Read/Write (P2-03)
 		}
 	}
 	return Response{

--- a/document_highlight.v
+++ b/document_highlight.v
@@ -152,53 +152,22 @@ fn classify_highlight_kind(line string, start_byte int, end_byte int) int {
 	return doc_highlight_read
 }
 
-// collect_document_highlight_candidates finds exact identifier occurrences
-// while excluding line comments and string literals.
-fn collect_document_highlight_candidates(lines []string, symbol string) []DocumentHighlightCandidate {
-	mut candidates := []DocumentHighlightCandidate{}
-	for line_idx, line in lines {
-		if !line.contains(symbol) {
+// collect_document_highlight_candidates reuses the reference tokenizer so
+// comments, literal text, and executable string interpolations are treated
+// consistently by highlighting and rename.
+fn collect_document_highlight_candidates(content string, lines []string, symbol string, enc PositionEncoding) []DocumentHighlightCandidate {
+	occurrences := extract_identifier_occurrences(content, enc)
+	positions := occurrences[symbol] or { return []DocumentHighlightCandidate{} }
+	mut candidates := []DocumentHighlightCandidate{cap: positions.len}
+	for position in positions {
+		if position.line < 0 || position.line >= lines.len {
 			continue
 		}
-		n := line.len
-		mut col := 0
-		for col < n {
-			c := line[col]
-			if col + 1 < n && c == `/` && line[col + 1] == `/` {
-				break
-			}
-			if c == `"` || c == `'` {
-				quote := c
-				col++
-				for col < n {
-					if line[col] == `\\` {
-						col += 2
-						continue
-					}
-					if line[col] == quote {
-						col++
-						break
-					}
-					col++
-				}
-				continue
-			}
-			if is_ident_char(c) {
-				start_byte := col
-				col++
-				for col < n && is_ident_char(line[col]) {
-					col++
-				}
-				if line[start_byte..col] == symbol {
-					candidates << DocumentHighlightCandidate{
-						line_idx:   line_idx
-						start_byte: start_byte
-						end_byte:   col
-					}
-				}
-				continue
-			}
-			col++
+		line := lines[position.line]
+		candidates << DocumentHighlightCandidate{
+			line_idx:   position.line
+			start_byte: encoded_col_to_byte(line, position.start_char, enc)
+			end_byte:   encoded_col_to_byte(line, position.end_char, enc)
 		}
 	}
 	return candidates
@@ -245,7 +214,8 @@ fn (mut app App) handle_document_highlight(request Request) Response {
 			result: []DocumentHighlight{}
 		}
 	}
-	candidates := collect_document_highlight_candidates(lines, symbol)
+	candidates := collect_document_highlight_candidates(content, lines, symbol,
+		app.position_encoding)
 	if candidates.len > document_highlight_semantic_max_candidates {
 		return Response{
 			id:     request.id

--- a/document_highlight.v
+++ b/document_highlight.v
@@ -32,14 +32,14 @@ fn (mut app App) handle_document_highlight(request Request) Response {
 		}
 	}
 	line_text := lines[params.position.line]
-	start, end := find_word_bounds_at_col(line_text, params.position.char)
+	start, end := find_word_bounds_at_col(line_text, params.position.char, app.position_encoding)
 	if start < 0 || end <= start {
 		return Response{
 			id:     request.id
 			result: []DocumentHighlight{}
 		}
 	}
-	symbol := substr_by_char_bounds(line_text, start, end)
+	symbol := substr_by_char_bounds(line_text, start, end, app.position_encoding)
 	if symbol == '' {
 		return Response{
 			id:     request.id
@@ -85,8 +85,8 @@ fn (mut app App) handle_document_highlight(request Request) Response {
 					col++
 				}
 				if line[start_byte..col] == symbol {
-					start_char := utf8_byte_to_char_index(line, start_byte)
-					end_char := utf8_byte_to_char_index(line, col)
+					start_char := byte_to_encoded_col(line, start_byte, app.position_encoding)
+					end_char := byte_to_encoded_col(line, col, app.position_encoding)
 					if a := anchor {
 						if resolved := app.resolve_symbol_anchor_cached(uri, line_idx, start_char, mut
 							anchor_cache)

--- a/document_highlight.v
+++ b/document_highlight.v
@@ -5,6 +5,42 @@ module main
 import json2
 import os
 
+// DocumentHighlightKind values (LSP §3.17): 1 = Text, 2 = Read, 3 = Write.
+const doc_highlight_read = 2
+const doc_highlight_write = 3
+
+// classify_highlight_kind classifies an identifier occurrence ending at byte
+// offset `end_byte` on `line` as a Write (assignment target) or a Read, based on
+// the operator that immediately follows it. This is a syntactic heuristic
+// (P2-03): `name :=` / `name =` / `name op=` are writes; comparisons and
+// everything else are reads.
+fn classify_highlight_kind(line string, end_byte int) int {
+	mut i := end_byte
+	for i < line.len && (line[i] == ` ` || line[i] == `\t`) {
+		i++
+	}
+	if i >= line.len {
+		return doc_highlight_read
+	}
+	rest := line[i..]
+	if rest.starts_with(':=') {
+		return doc_highlight_write
+	}
+	// Distinguish assignment `=` from comparison `==`/`=>`.
+	if rest.starts_with('==') || rest.starts_with('=>') {
+		return doc_highlight_read
+	}
+	if rest.starts_with('=') {
+		return doc_highlight_write
+	}
+	// Compound assignment: += -= *= /= %= &= |= ^= (op followed by '=', not '==').
+	if rest.len >= 2 && rest[1] == `=` && (rest.len < 3 || rest[2] != `=`)
+		&& rest[0] in [`+`, `-`, `*`, `/`, `%`, `&`, `|`, `^`] {
+		return doc_highlight_write
+	}
+	return doc_highlight_read
+}
+
 // handle_document_highlight handles textDocument/documentHighlight.
 // It finds all occurrences of the identifier under the cursor within the current
 // document and returns them as a DocumentHighlight list.
@@ -109,7 +145,7 @@ fn (mut app App) handle_document_highlight(request Request) Response {
 								char: end_char
 							}
 						}
-						kind:  1 // Text
+						kind:  classify_highlight_kind(line, col) // Read/Write (P2-03)
 					}
 				}
 				continue

--- a/document_highlight.v
+++ b/document_highlight.v
@@ -9,12 +9,106 @@ import os
 const doc_highlight_read = 2
 const doc_highlight_write = 3
 
-// classify_highlight_kind classifies an identifier occurrence ending at byte
-// offset `end_byte` on `line` as a Write (assignment target) or a Read, based on
-// the operator that immediately follows it. This is a syntactic heuristic
-// (P2-03): declarations, assignments (including shifts), and `name++`/`name--`
-// are writes; comparisons and everything else are reads.
-fn classify_highlight_kind(line string, end_byte int) int {
+// highlight_has_word reports whether `text` contains `word` at identifier
+// boundaries.
+fn highlight_has_word(text string, word string) bool {
+	if word == '' || text.len < word.len {
+		return false
+	}
+	for i := 0; i + word.len <= text.len; i++ {
+		if text[i..i + word.len] != word {
+			continue
+		}
+		left_ok := i == 0 || !is_ident_char(text[i - 1])
+		right_ok := i + word.len == text.len || !is_ident_char(text[i + word.len])
+		if left_ok && right_ok {
+			return true
+		}
+	}
+	return false
+}
+
+// is_for_binding_highlight reports whether the occurrence is on the binding
+// side of `for name in values` (including `for key, value in map`).
+fn is_for_binding_highlight(line string, start_byte int, end_byte int) bool {
+	prefix := line[..start_byte]
+	mut for_byte := -1
+	for i := 0; i + 3 <= prefix.len; i++ {
+		if prefix[i..i + 3] != 'for' {
+			continue
+		}
+		left_ok := i == 0 || !is_ident_char(prefix[i - 1])
+		right_ok := i + 3 == prefix.len || !is_ident_char(prefix[i + 3])
+		if left_ok && right_ok {
+			for_byte = i
+		}
+	}
+	if for_byte < 0 {
+		return false
+	}
+	binding_prefix := prefix[for_byte + 3..]
+	if binding_prefix.contains('{') || binding_prefix.contains(';')
+		|| highlight_has_word(binding_prefix, 'in') {
+		return false
+	}
+	mut binding_suffix := line[end_byte..]
+	brace_byte := binding_suffix.index_any('{;')
+	if brace_byte >= 0 {
+		binding_suffix = binding_suffix[..brace_byte]
+	}
+	return highlight_has_word(binding_suffix, 'in')
+}
+
+// is_fn_parameter_highlight reports whether an occurrence is a receiver or
+// parameter name in a function signature and is followed by its type.
+fn is_fn_parameter_highlight(line string, start_byte int, end_byte int) bool {
+	mut type_byte := end_byte
+	for type_byte < line.len && (line[type_byte] == ` ` || line[type_byte] == `\t`) {
+		type_byte++
+	}
+	if type_byte == end_byte || type_byte >= line.len {
+		return false
+	}
+	type_start := line[type_byte]
+	if !is_ident_char(type_start) && type_start !in [`[`, `?`, `&`, `.`] {
+		return false
+	}
+
+	prefix := line[..start_byte]
+	mut fn_byte := -1
+	for i := 0; i + 2 <= prefix.len; i++ {
+		if prefix[i..i + 2] != 'fn' {
+			continue
+		}
+		left_ok := i == 0 || !is_ident_char(prefix[i - 1])
+		right_ok := i + 2 == prefix.len || !is_ident_char(prefix[i + 2])
+		if left_ok && right_ok {
+			fn_byte = i
+		}
+	}
+	if fn_byte < 0 {
+		return false
+	}
+	mut paren_depth := 0
+	for i := fn_byte + 2; i < prefix.len; i++ {
+		if prefix[i] == `(` {
+			paren_depth++
+		} else if prefix[i] == `)` {
+			paren_depth--
+		}
+	}
+	return paren_depth > 0
+}
+
+// classify_highlight_kind classifies an identifier occurrence between byte
+// offsets `start_byte` and `end_byte` on `line` as a Write or a Read. This is a
+// syntactic heuristic (P2-03): declarations, assignments (including shifts),
+// and `name++`/`name--` are writes; comparisons and other uses are reads.
+fn classify_highlight_kind(line string, start_byte int, end_byte int) int {
+	if is_for_binding_highlight(line, start_byte, end_byte)
+		|| is_fn_parameter_highlight(line, start_byte, end_byte) {
+		return doc_highlight_write
+	}
 	mut i := end_byte
 	for i < line.len && (line[i] == ` ` || line[i] == `\t`) {
 		i++
@@ -140,6 +234,21 @@ fn (mut app App) handle_document_highlight(request Request) Response {
 							continue
 						}
 					}
+					mut kind := classify_highlight_kind(line, start_byte, col)
+					if a := anchor {
+						occurrence := Location{
+							uri:   uri
+							range: LSPRange{
+								start: Position{
+									line: line_idx
+									char: start_char
+								}
+							}
+						}
+						if same_anchor_location(occurrence, a) {
+							kind = doc_highlight_write
+						}
+					}
 					highlights << DocumentHighlight{
 						range: LSPRange{
 							start: Position{
@@ -151,7 +260,7 @@ fn (mut app App) handle_document_highlight(request Request) Response {
 								char: end_char
 							}
 						}
-						kind:  classify_highlight_kind(line, col) // Read/Write (P2-03)
+						kind:  kind // Read/Write (P2-03)
 					}
 				}
 				continue

--- a/document_highlight.v
+++ b/document_highlight.v
@@ -12,8 +12,8 @@ const doc_highlight_write = 3
 // classify_highlight_kind classifies an identifier occurrence ending at byte
 // offset `end_byte` on `line` as a Write (assignment target) or a Read, based on
 // the operator that immediately follows it. This is a syntactic heuristic
-// (P2-03): `name :=` / `name =` / `name op=` / `name++` / `name--` are writes;
-// comparisons and everything else are reads.
+// (P2-03): declarations, assignments (including shifts), and `name++`/`name--`
+// are writes; comparisons and everything else are reads.
 fn classify_highlight_kind(line string, end_byte int) int {
 	mut i := end_byte
 	for i < line.len && (line[i] == ` ` || line[i] == `\t`) {
@@ -34,6 +34,9 @@ fn classify_highlight_kind(line string, end_byte int) int {
 		return doc_highlight_write
 	}
 	if rest.starts_with('++') || rest.starts_with('--') {
+		return doc_highlight_write
+	}
+	if rest.starts_with('<<=') || rest.starts_with('>>=') {
 		return doc_highlight_write
 	}
 	// Compound assignment: += -= *= /= %= &= |= ^= (op followed by '=', not '==').

--- a/folding_range.v
+++ b/folding_range.v
@@ -2,13 +2,13 @@
 // Use of this source code is governed by a GPL license that can be found in the LICENSE file.
 module main
 
-import json
+import json2
 import os
 
 // handle_folding_range handles the textDocument/foldingRange LSP request,
 // returning all collapsible regions for the document.
 fn (mut app App) handle_folding_range(request Request) Response {
-	params := json.decode(FoldingRangeParams, request.params) or {
+	params := json2.decode[FoldingRangeParams](request.params) or {
 		$if debug { log('Failed to decode FoldingRangeParams: ${err}') }
 		return Response{
 			id:     request.id

--- a/handlers.v
+++ b/handlers.v
@@ -2960,7 +2960,12 @@ fn (mut app App) on_cancel_request(request Request) {
 	// (P0-02/P0-03).
 	if raw := extract_raw_id(request.params) {
 		app.cancelled_raw_ids[raw] = true
-		app.cancelled_requests[raw_id_to_int(raw)] = true
+		// Only a numeric id belongs in the int map. A string id must NOT be
+		// collapsed to 0: that would spuriously cancel numeric id 0 and make every
+		// string id collide at 0 (P0-02). String ids are matched via the raw set.
+		if !raw.starts_with('"') {
+			app.cancelled_requests[raw.int()] = true
+		}
 		log('VLS: request ${raw} marked as cancelled')
 		return
 	}

--- a/handlers.v
+++ b/handlers.v
@@ -3,7 +3,7 @@
 module main
 
 import os
-import json
+import json2
 import time
 
 const v_keywords = ['asm', 'as', 'assert', 'atomic', 'break', 'const', 'continue', 'defer', 'dump',
@@ -17,7 +17,7 @@ const v_builtins = ['close', 'copy', 'eprintln', 'eprint', 'error', 'error_with_
 
 // operation_at_pos handles LSP requests at a given position (completion, hover, signature, definition).
 fn (mut app App) operation_at_pos(method Method, request Request) Response {
-	params := json.decode(TextDocumentPositionParams, request.params) or {
+	params := json2.decode[TextDocumentPositionParams](request.params) or {
 		$if debug { log('Failed to decode TextDocumentPositionParams: ${err}') }
 		return Response{
 			id:     request.id
@@ -368,7 +368,7 @@ fn parse_public_module_member_completions(content string) []Detail {
 
 // on_did_open handles the LSP didOpen notification, loading file content into the server state.
 fn (mut app App) on_did_open(request Request) {
-	params := json.decode(DidOpenTextDocumentParams, request.params) or {
+	params := json2.decode[DidOpenTextDocumentParams](request.params) or {
 		$if debug { log('Failed to decode DidOpenTextDocumentParams: ${err}') }
 		return
 	}
@@ -399,7 +399,7 @@ fn (mut app App) on_did_open(request Request) {
 // problems do not linger after close (P0-07). The dispatcher publishes an empty
 // diagnostic set to clear editor markers.
 fn (mut app App) on_did_close(request Request) {
-	params := json.decode(DidCloseTextDocumentParams, request.params) or {
+	params := json2.decode[DidCloseTextDocumentParams](request.params) or {
 		$if debug { log('Failed to decode DidCloseTextDocumentParams: ${err}') }
 		return
 	}
@@ -463,7 +463,7 @@ fn (mut app App) build_diagnostics_notification(uri string, content string) Noti
 
 // Returns instant red wavy errors
 fn (mut app App) on_did_change(request Request) ?Notification {
-	params := json.decode(DidChangeTextDocumentParams, request.params) or {
+	params := json2.decode[DidChangeTextDocumentParams](request.params) or {
 		$if debug { log('Failed to decode DidChangeTextDocumentParams: ${err}') }
 		return none
 	}
@@ -518,7 +518,7 @@ fn (mut app App) on_did_change(request Request) ?Notification {
 
 // on_did_save handles didSave by re-running diagnostics for the saved document.
 fn (mut app App) on_did_save(request Request) ?Notification {
-	params := json.decode(DidSaveTextDocumentParams, request.params) or {
+	params := json2.decode[DidSaveTextDocumentParams](request.params) or {
 		$if debug { log('Failed to decode DidSaveTextDocumentParams: ${err}') }
 		return none
 	}
@@ -558,7 +558,7 @@ fn (mut app App) on_did_save(request Request) ?Notification {
 // on_will_save_wait_until handles willSaveWaitUntil by formatting the document
 // before it is saved, returning the edits to apply atomically with the save.
 fn (mut app App) on_will_save_wait_until(request Request) Response {
-	params := json.decode(WillSaveTextDocumentParams, request.params) or {
+	params := json2.decode[WillSaveTextDocumentParams](request.params) or {
 		$if debug { log('Failed to decode WillSaveTextDocumentParams: ${err}') }
 		return Response{
 			id:     request.id
@@ -587,7 +587,7 @@ fn (mut app App) on_will_save_wait_until(request Request) Response {
 // and placeholder text for the identifier under the cursor, or an empty result
 // when the cursor is not on a renameable symbol.
 fn (mut app App) handle_prepare_rename(request Request) Response {
-	params := json.decode(TextDocumentPositionParams, request.params) or {
+	params := json2.decode[TextDocumentPositionParams](request.params) or {
 		$if debug { log('Failed to decode TextDocumentPositionParams for prepareRename: ${err}') }
 		return Response{
 			id:     request.id
@@ -719,7 +719,7 @@ fn find_word_bounds_at_col(line string, col int) (int, int) {
 // open project for symbols whose names contain the query string (case-insensitive)
 // and returns them as WorkspaceSymbol items.
 fn (mut app App) handle_workspace_symbol(request Request) Response {
-	params := json.decode(WorkspaceSymbolParams, request.params) or {
+	params := json2.decode[WorkspaceSymbolParams](request.params) or {
 		$if debug { log('Failed to decode WorkspaceSymbolParams: ${err}') }
 		return Response{
 			id:     request.id
@@ -905,7 +905,7 @@ fn apply_incremental_change(content string, range LSPRange, new_text string) str
 
 // find_references handles the LSP references request, returning all locations of a symbol.
 fn (mut app App) find_references(request Request) Response {
-	params := json.decode(ReferenceParams, request.params) or {
+	params := json2.decode[ReferenceParams](request.params) or {
 		$if debug { log('Failed to decode ReferenceParams: ${err}') }
 		return Response{
 			id:     request.id
@@ -964,7 +964,7 @@ fn (mut app App) find_references(request Request) Response {
 
 // handle_rename handles the LSP rename request, returning edits to rename a symbol.
 fn (mut app App) handle_rename(request Request) Response {
-	params := json.decode(RenameParams, request.params) or {
+	params := json2.decode[RenameParams](request.params) or {
 		$if debug { log('Failed to decode RenameParams: ${err}') }
 		return Response{
 			id:     request.id
@@ -1495,7 +1495,7 @@ fn (mut app App) format_content(uri string, content string) ([]TextEdit, string)
 
 // handle_formatting handles the LSP formatting request, returning edits to format the document.
 fn (mut app App) handle_formatting(request Request) Response {
-	params := json.decode(DocumentFormattingParams, request.params) or {
+	params := json2.decode[DocumentFormattingParams](request.params) or {
 		log('Failed to decode DocumentFormattingParams: ${err}')
 		return Response{
 			id:     request.id
@@ -1524,7 +1524,7 @@ fn (mut app App) handle_formatting(request Request) Response {
 
 // handle_document_symbols handles the LSP documentSymbol request, returning top-level symbols.
 fn (mut app App) handle_document_symbols(request Request) Response {
-	params := json.decode(DocumentSymbolParams, request.params) or {
+	params := json2.decode[DocumentSymbolParams](request.params) or {
 		log('Failed to decode DocumentSymbolParams: ${err}')
 		return Response{
 			id:     request.id
@@ -1548,7 +1548,7 @@ fn (mut app App) handle_inlay_hints(request Request) Response {
 			result: []InlayHint{}
 		}
 	}
-	params := json.decode(InlayHintParams, request.params) or {
+	params := json2.decode[InlayHintParams](request.params) or {
 		log('Failed to decode InlayHintParams: ${err}')
 		return Response{
 			id:     request.id
@@ -2315,7 +2315,7 @@ fn (mut app App) search_symbol_in_dirs_semantic(search_dirs []string, symbol str
 
 // handle_code_action handles the LSP codeAction request, returning quick fixes and organize imports.
 fn (mut app App) handle_code_action(request Request) Response {
-	params := json.decode(CodeActionParams, request.params) or {
+	params := json2.decode[CodeActionParams](request.params) or {
 		$if debug { log('Failed to decode CodeActionParams: ${err}') }
 		return Response{
 			id:     request.id
@@ -2624,7 +2624,7 @@ fn make_keyword_completions() []Detail {
 // handle_range_formatting handles textDocument/rangeFormatting.
 // It formats the whole file via `v fmt` and returns edits only for the requested range.
 fn (mut app App) handle_range_formatting(request Request) Response {
-	params := json.decode(DocumentRangeFormattingParams, request.params) or {
+	params := json2.decode[DocumentRangeFormattingParams](request.params) or {
 		log('Failed to decode DocumentRangeFormattingParams: ${err}')
 		return Response{
 			id:     request.id
@@ -2733,7 +2733,7 @@ fn (mut app App) handle_range_formatting(request Request) Response {
 // the identifier under the cursor as the inner range, and the enclosing line
 // as the outer (parent) range.  Clients expand the selection incrementally.
 fn (mut app App) handle_selection_range(request Request) Response {
-	params := json.decode(SelectionRangeParams, request.params) or {
+	params := json2.decode[SelectionRangeParams](request.params) or {
 		$if debug { log('Failed to decode SelectionRangeParams: ${err}') }
 		return Response{
 			id:     request.id
@@ -2830,7 +2830,7 @@ fn resolve_workspace_settings(params_json string) ResolvedWorkspaceSettings {
 	mut resolved := ResolvedWorkspaceSettings{}
 
 	// 1) Preferred shape: settings.vls.{inlayHints, diagnostics}
-	sectioned := json.decode(DidChangeConfigurationParams, params_json) or {
+	sectioned := json2.decode[DidChangeConfigurationParams](params_json) or {
 		DidChangeConfigurationParams{}
 	}
 	if enabled := sectioned.settings.vls.inlay_hints {
@@ -2843,7 +2843,7 @@ fn resolve_workspace_settings(params_json string) ResolvedWorkspaceSettings {
 	}
 
 	// 2) Direct shape: settings.{inlayHints, diagnostics}
-	direct := json.decode(DidChangeConfigurationDirectParams, params_json) or {
+	direct := json2.decode[DidChangeConfigurationDirectParams](params_json) or {
 		DidChangeConfigurationDirectParams{}
 	}
 	if !resolved.has_inlay_hints {
@@ -2860,7 +2860,7 @@ fn resolve_workspace_settings(params_json string) ResolvedWorkspaceSettings {
 	}
 
 	// 3) Nested compatibility shapes, used only when flat values are absent.
-	sectioned_nested := json.decode(DidChangeConfigurationParamsCompat, params_json) or {
+	sectioned_nested := json2.decode[DidChangeConfigurationParamsCompat](params_json) or {
 		DidChangeConfigurationParamsCompat{}
 	}
 	if !resolved.has_inlay_hints {
@@ -2870,7 +2870,7 @@ fn resolve_workspace_settings(params_json string) ResolvedWorkspaceSettings {
 		}
 	}
 
-	direct_nested := json.decode(DidChangeConfigurationDirectParamsCompat, params_json) or {
+	direct_nested := json2.decode[DidChangeConfigurationDirectParamsCompat](params_json) or {
 		DidChangeConfigurationDirectParamsCompat{}
 	}
 	if !resolved.has_inlay_hints {
@@ -2884,7 +2884,7 @@ fn resolve_workspace_settings(params_json string) ResolvedWorkspaceSettings {
 }
 
 fn (mut app App) on_initialize(request Request) ?string {
-	params := json.decode(InitializeParams, request.params) or {
+	params := json2.decode[InitializeParams](request.params) or {
 		msg := 'Invalid initialize params: ${err.msg()}'
 		$if debug { log(msg) }
 		return msg
@@ -2970,23 +2970,27 @@ fn normalize_workspace_root(path string) ?string {
 }
 
 fn (mut app App) on_cancel_request(request Request) {
-	params := json.decode(CancelRequestParams, request.params) or {
-		$if debug { log('Failed to decode CancelRequestParams: ${err}') }
-		return
-	}
-	app.cancelled_requests[params.id] = true
-	// Cancellation ids may be strings; capture the exact raw id so string-id
-	// requests can be cancelled too (P0-02/P0-03).
+	// Capture the exact raw id first: json2 aborts decoding CancelRequestParams
+	// when the id is a string, but string ids must still be cancellable
+	// (P0-02/P0-03).
 	if raw := extract_raw_id(request.params) {
 		app.cancelled_raw_ids[raw] = true
+		app.cancelled_requests[raw_id_to_int(raw)] = true
+		log('VLS: request ${raw} marked as cancelled')
+		return
 	}
-	log('VLS: request ${params.id} marked as cancelled')
+	if params := json2.decode[CancelRequestParams](request.params) {
+		app.cancelled_requests[params.id] = true
+		log('VLS: request ${params.id} marked as cancelled')
+	} else {
+		$if debug { log('Failed to decode CancelRequestParams') }
+	}
 }
 
 // on_did_change_workspace_folders handles workspace/didChangeWorkspaceFolders by
 // updating the server's list of workspace roots when the client adds or removes folders.
 fn (mut app App) on_did_change_workspace_folders(request Request) {
-	params := json.decode(DidChangeWorkspaceFoldersParams, request.params) or {
+	params := json2.decode[DidChangeWorkspaceFoldersParams](request.params) or {
 		$if debug { log('Failed to decode DidChangeWorkspaceFoldersParams: ${err}') }
 		return
 	}
@@ -3020,7 +3024,7 @@ fn (mut app App) on_did_change_workspace_folders(request Request) {
 // handle_code_lens handles textDocument/codeLens requests.
 // Returns run/test lens items for fn main() and fn test_* declarations.
 fn (mut app App) handle_code_lens(request Request) Response {
-	params := json.decode(CodeLensParams, request.params) or {
+	params := json2.decode[CodeLensParams](request.params) or {
 		$if debug { log('Failed to decode CodeLensParams: ${err}') }
 		return Response{
 			id:     request.id
@@ -3091,7 +3095,7 @@ fn (mut app App) handle_code_lens(request Request) Response {
 // handle_code_lens_resolve handles codeLens/resolve.
 // The lens is already fully resolved at creation time so this is a pass-through.
 fn (mut app App) handle_code_lens_resolve(request Request) Response {
-	lens := json.decode(CodeLens, request.params) or {
+	lens := json2.decode[CodeLens](request.params) or {
 		$if debug { log('Failed to decode CodeLens for resolve: ${err}') }
 		return Response{
 			id:     request.id
@@ -3107,7 +3111,7 @@ fn (mut app App) handle_code_lens_resolve(request Request) Response {
 // handle_execute_command handles workspace/executeCommand.
 // Currently supports vls.runFile and vls.runTests by echoing a log message.
 fn (mut app App) handle_execute_command(request Request) Response {
-	params := json.decode(ExecuteCommandParams, request.params) or {
+	params := json2.decode[ExecuteCommandParams](request.params) or {
 		$if debug { log('Failed to decode ExecuteCommandParams: ${err}') }
 		return Response{
 			id:     request.id
@@ -3139,7 +3143,7 @@ fn (mut app App) handle_execute_command(request Request) Response {
 // handle_inline_value handles textDocument/inlineValue.
 // Returns inline text values for simple variable := literal assignments in the range.
 fn (mut app App) handle_inline_value(request Request) Response {
-	params := json.decode(InlineValueParams, request.params) or {
+	params := json2.decode[InlineValueParams](request.params) or {
 		$if debug { log('Failed to decode InlineValueParams: ${err}') }
 		return Response{
 			id:     request.id
@@ -3194,7 +3198,7 @@ fn (mut app App) handle_inline_value(request Request) Response {
 // Returns ranges for all occurrences of the identifier under the cursor in the
 // same line (identifier and its declaration) for linked editing.
 fn (mut app App) handle_linked_editing_range(request Request) Response {
-	params := json.decode(TextDocumentPositionParams, request.params) or {
+	params := json2.decode[TextDocumentPositionParams](request.params) or {
 		$if debug {
 			log('Failed to decode TextDocumentPositionParams for linkedEditingRange: ${err}')
 		}

--- a/handlers.v
+++ b/handlers.v
@@ -2557,52 +2557,23 @@ fn build_safe_organize_imports_action(uri string, lines []string) ?CodeAction {
 	}
 }
 
-// collect_module_fn_completions collects free function completions from sibling files in the module.
-fn (app &App) collect_module_fn_completions(current_file_uri string, working_dir string) []Detail {
-	mut items := []Detail{}
-	mut searched_uris := map[string]bool{}
-	searched_uris[current_file_uri] = true
-
-	// Determine the current file's module so we only include same-module siblings.
+// collect_module_fn_completions collects free-function completions from sibling
+// files in the current module, via the persistent index. A V module lives in a
+// single directory, so we make sure the open buffers and the current file's
+// directory are indexed (cheap, shallow) and then read pre-parsed completion
+// items from the index instead of re-walking and re-parsing on every keystroke.
+fn (mut app App) collect_module_fn_completions(current_file_uri string, working_dir string) []Detail {
 	current_content := app.open_files[current_file_uri] or {
-		content := os.read_file(uri_to_path(current_file_uri)) or { '' }
-		content
+		os.read_file(uri_to_path(current_file_uri)) or { '' }
 	}
 	current_module := get_module_name(current_content)
-
-	// 1. Scan in-memory open files
-	for uri, content in app.open_files {
-		if uri in searched_uris {
-			continue
-		}
-		if uri.ends_with('_test.v') {
-			continue
-		}
-		searched_uris[uri] = true
-		if current_module != '' && get_module_name(content) != current_module {
-			continue
-		}
-		items << parse_module_fn_completions(content)
+	// Keep open buffers fresh, then ensure the current module's directory is
+	// indexed (covers loose files with no v.mod project root too).
+	for uri, _ in app.open_files {
+		app.reindex_uri(uri)
 	}
-
-	// 2. Scan on-disk .v files in the working directory not yet processed
-	for v_file in os.walk_ext(working_dir, '.v') {
-		if v_file.ends_with('_test.v') {
-			continue
-		}
-		uri := path_to_uri(v_file)
-		if uri in searched_uris {
-			continue
-		}
-		searched_uris[uri] = true
-		content := os.read_file(v_file) or { continue }
-		if current_module != '' && get_module_name(content) != current_module {
-			continue
-		}
-		items << parse_module_fn_completions(content)
-	}
-
-	return items
+	app.ensure_dir_shallow_indexed(working_dir)
+	return app.query_module_fn_completions(current_module, current_file_uri)
 }
 
 // parse_module_fn_completions extracts free-function declarations (`pub fn` and `fn`)

--- a/handlers.v
+++ b/handlers.v
@@ -936,10 +936,11 @@ fn (mut app App) find_references(request Request) Response {
 	}
 
 	// Resolve references from the project's reference-occurrence index.
+	scope := app.index_scope_for_uri(path)
 	anchor := app.resolve_symbol_anchor(path, line, col)
 	mut locations := if a := anchor {
 		// References may fall back to lexical occurrences past the candidate cap.
-		app.search_symbol_in_dirs_semantic(symbol, a, request.id, true)
+		app.search_symbol_in_dirs_semantic(symbol, a, scope, request.id, true)
 	} else {
 		app.search_symbol_in_dirs(symbol, request.id)
 	}
@@ -997,9 +998,9 @@ fn (mut app App) handle_rename(request Request) Response {
 	// A destructive rename is safe only when the bounded index covers every
 	// source in the project/module. Oversized, unreadable, or count-capped files
 	// may contain additional references that must not be left unchanged.
-	app.ensure_dirs_indexed(app.index_query_dirs())
-	app.ensure_loose_file_dirs_shallow_indexed()
-	if !app.index_is_complete() {
+	scope := app.index_scope_for_uri(path)
+	app.ensure_index_scope(scope)
+	if !app.index_is_complete_for_scope(scope) {
 		log('rename: source index is incomplete; refusing a partial workspace edit')
 		return Response{
 			id:     request.id
@@ -1022,7 +1023,7 @@ fn (mut app App) handle_rename(request Request) Response {
 	// Rename is destructive: never accept the scope-unsafe lexical fallback. Past
 	// the candidate cap search_symbol_in_dirs_semantic returns none, and an
 	// unresolved rename is refused below rather than editing unrelated symbols.
-	locations := app.search_symbol_in_dirs_semantic(symbol, anchor, request.id, false)
+	locations := app.search_symbol_in_dirs_semantic(symbol, anchor, scope, request.id, false)
 	if locations.len == 0 {
 		log('rename: no scope-safe occurrences for "${symbol}" (unresolved or above candidate cap); refusing')
 		return Response{
@@ -2369,27 +2370,15 @@ fn same_anchor_location(a Location, b Location) bool {
 // responsive, at the cost of scope precision for that one very common symbol.
 const reference_semantic_max_candidates = 48
 
-// search_symbol_in_dirs_semantic reads candidate occurrences of `symbol` from the
-// reference-occurrence index (no per-request workspace re-walk, P1-05) and keeps
-// only those whose compiler definition lookup resolves to the same declaration
-// anchor, so references stay scope-safe across same-name symbols (P1-04). The
-// per-candidate compiler lookup is cached within the request and the number of
-// compiler invocations is bounded (see reference_semantic_max_candidates). When
-// the candidate count exceeds the cap, `allow_lexical_fallback` decides the
-// outcome: references may take the unverified lexical occurrences (over-inclusive
-// but harmless highlights), whereas rename must NOT — it passes false so the
-// caller refuses rather than emit a destructive edit across unrelated scopes.
-fn (mut app App) search_symbol_in_dirs_semantic(symbol string, anchor Location, request_id int, allow_lexical_fallback bool) []Location {
-	started_ms := time.now().unix_milli()
-	app.ensure_dirs_indexed(app.index_query_dirs())
-	app.ensure_loose_file_dirs_shallow_indexed()
-
-	// Collect every lexical candidate first so the compiler-verification cost can
-	// be bounded up front rather than discovered candidate-by-candidate.
+// collect_semantic_candidates returns lexical occurrences inside `scope`.
+fn (mut app App) collect_semantic_candidates(symbol string, scope IndexScope) []Location {
 	mut candidates := []Location{}
 	mut uris := app.symbol_index.keys()
 	uris.sort()
 	for uri in uris {
+		if !uri_is_in_index_scope(uri, scope) {
+			continue
+		}
 		occ := app.occurrences_for(uri)
 		positions := occ[symbol] or { continue }
 		for p in positions {
@@ -2408,6 +2397,21 @@ fn (mut app App) search_symbol_in_dirs_semantic(symbol string, anchor Location, 
 			}
 		}
 	}
+	return candidates
+}
+
+// search_symbol_in_dirs_semantic reads scoped candidate occurrences of `symbol`
+// from the reference index and keeps only those whose compiler definition lookup
+// resolves to the same declaration anchor. Compiler work is capped after scope
+// filtering. References may use lexical fallback over the cap; rename may not.
+fn (mut app App) search_symbol_in_dirs_semantic(symbol string, anchor Location, scope IndexScope, request_id int, allow_lexical_fallback bool) []Location {
+	started_ms := time.now().unix_milli()
+	app.ensure_index_scope(scope)
+
+	// Filter lexical candidates to the source project/module before applying the
+	// cap, so same-named occurrences in unrelated workspace roots cannot make a
+	// safe rename appear too expensive.
+	candidates := app.collect_semantic_candidates(symbol, scope)
 
 	// Too many candidates to verify one-compile-per-token without freezing the
 	// loop. References fall back to the unverified lexical occurrences (bounded,

--- a/handlers.v
+++ b/handlers.v
@@ -887,6 +887,13 @@ fn incremental_change_is_valid(content string, range LSPRange, enc PositionEncod
 		return false
 	}
 	starts := line_start_offsets(content)
+	// Reject a range whose start or end line does not exist in the document. A
+	// desynced client can send lines past EOF; position_to_byte_offset clamps
+	// those to content.len, which would make an out-of-bounds edit look valid and
+	// get appended at EOF while the version advances, desyncing the buffer (P0-07).
+	if range.start.line >= starts.len || range.end.line >= starts.len {
+		return false
+	}
 	start_byte := position_to_byte_offset(content, starts, range.start.line, range.start.char, enc)
 	end_byte := position_to_byte_offset(content, starts, range.end.line, range.end.char, enc)
 	return start_byte <= end_byte && start_byte <= content.len && end_byte <= content.len
@@ -2356,10 +2363,25 @@ fn (mut app App) handle_code_action(request Request) Response {
 				line_nr := diag.range.start.line
 				if line_nr >= 0 && line_nr < lines.len
 					&& lines[line_nr].trim_space().starts_with('import ') {
-					// Remove the whole line including its trailing newline by
-					// deleting the range [line_nr,0)..[line_nr+1,0). Ending the
-					// range at the previous line length would leave a blank line
-					// behind (P0-09).
+					// Remove the whole import line. When the line has a trailing
+					// terminator (a following line-start exists) delete it too by
+					// ending at [line_nr+1,0), so no blank line is left behind. When
+					// the import is the final line with no newline, [line_nr+1,0) is
+					// out of bounds and clients may reject the whole edit, so end at
+					// the final line's encoded length instead (P0-09).
+					starts := line_start_offsets(content)
+					end_pos := if line_nr + 1 < starts.len {
+						Position{
+							line: line_nr + 1
+							char: 0
+						}
+					} else {
+						Position{
+							line: line_nr
+							char: byte_to_encoded_col(lines[line_nr], lines[line_nr].len,
+								app.position_encoding)
+						}
+					}
 					edit := WorkspaceEdit{
 						changes: {
 							uri: [
@@ -2369,10 +2391,7 @@ fn (mut app App) handle_code_action(request Request) Response {
 											line: line_nr
 											char: 0
 										}
-										end:   Position{
-											line: line_nr + 1
-											char: 0
-										}
+										end:   end_pos
 									}
 									new_text: ''
 								},

--- a/handlers.v
+++ b/handlers.v
@@ -1502,13 +1502,16 @@ fn get_import_completions(line string, work_dir string) []Detail {
 //  3. all .v files in the project working directory
 //  4. vlib/builtin/ (always, for built-in functions like println)
 //  5. vlib/<module>/ for each module imported in the current file
-fn (mut app App) find_doc_comment_for_symbol(symbol string, current_lines []string, current_file_uri string) string {
-	// 1. Current file
-	decl_line := find_declaration_line(current_lines, symbol)
-	if decl_line >= 0 {
-		doc := extract_doc_comment(current_lines, decl_line)
-		if doc != '' {
-			return doc
+fn (mut app App) find_doc_comment_for_symbol(symbol string, current_lines []string, current_file_uri string, imported_module string) string {
+	// 1. Current file, but only for an unqualified symbol. A qualified
+	// `module.symbol` must never inherit a same-named local declaration's docs.
+	if imported_module == '' {
+		decl_line := find_declaration_line(current_lines, symbol)
+		if decl_line >= 0 {
+			doc := extract_doc_comment(current_lines, decl_line)
+			if doc != '' {
+				return doc
+			}
 		}
 	}
 
@@ -1519,9 +1522,28 @@ fn (mut app App) find_doc_comment_for_symbol(symbol string, current_lines []stri
 	app.ensure_dirs_indexed(app.index_query_dirs())
 	cur_dir := os.dir(uri_to_path(current_file_uri))
 	scope_root := find_project_root(cur_dir)
-	indexed_doc := app.find_indexed_doc_in_scope(symbol, cur_dir, scope_root)
-	if indexed_doc != '' {
-		return indexed_doc
+	if imported_module != '' {
+		rel := imported_module.replace('.', os.path_separator)
+		base_dir := if scope_root != '' { scope_root } else { cur_dir }
+		preferred_dir := os.join_path(base_dir, rel)
+		if os.is_dir(preferred_dir) {
+			indexed_doc := app.find_indexed_doc_in_scope(symbol, cur_dir, scope_root, preferred_dir)
+			if indexed_doc != '' {
+				return indexed_doc
+			}
+		}
+		// A qualified stdlib symbol is likewise constrained to its imported
+		// module. Do not fall through to builtin or another imported module.
+		module_dir := os.join_path(v_dir, 'vlib', rel)
+		if os.is_dir(module_dir) {
+			return search_doc_in_vlib_dir(module_dir, symbol)
+		}
+		return ''
+	} else {
+		indexed_doc := app.find_indexed_doc_in_scope(symbol, cur_dir, scope_root, '')
+		if indexed_doc != '' {
+			return indexed_doc
+		}
 	}
 
 	// 4. vlib/builtin/ — always search for built-in symbols
@@ -1549,6 +1571,20 @@ fn (mut app App) find_doc_comment_for_symbol(symbol string, current_lines []stri
 	}
 
 	return ''
+}
+
+// imported_module_at_symbol returns the imported module path qualifying the
+// symbol at byte column `col`, or '' for an unqualified symbol.
+fn imported_module_at_symbol(line string, col int, content string) string {
+	start, _ := find_word_bounds_at_col(line, col, .utf8)
+	if start <= 0 || line[start - 1] != `.` {
+		return ''
+	}
+	alias := get_word_before_dot(line, start - 1, .utf8)
+	if alias == '' {
+		return ''
+	}
+	return parse_import_aliases(content)[alias] or { '' }
 }
 
 // search_doc_in_vlib_dir searches all non-test .v files in `dir` for a
@@ -3091,12 +3127,8 @@ fn (mut app App) on_cancel_request(request Request) {
 	// (P0-02/P0-03).
 	if raw := extract_raw_id(request.params) {
 		app.cancelled_raw_ids[raw] = true
-		// Only a numeric id belongs in the int map. A string id must NOT be
-		// collapsed to 0: that would spuriously cancel numeric id 0 and make every
-		// string id collide at 0 (P0-02). String ids are matched via the raw set.
-		if !raw.starts_with('"') {
-			app.cancelled_requests[raw.int()] = true
-		}
+		// Match every valid id by its exact raw token. Narrowing a fractional or
+		// out-of-range numeric id to int can collide with a different request.
 		log('VLS: request ${raw} marked as cancelled')
 		return
 	}

--- a/handlers.v
+++ b/handlers.v
@@ -889,17 +889,15 @@ fn (mut app App) find_references(request Request) Response {
 		}
 	}
 
-	// Search all .v files in working directory
-	working_dir := os.dir(real_path)
-	search_dirs := app.workspace_search_dirs(working_dir)
+	// Resolve references from the project's reference-occurrence index.
 	anchor := app.resolve_symbol_anchor(path, line, col)
 	mut locations := if a := anchor {
-		app.search_symbol_in_dirs_semantic(search_dirs, symbol, a, request.id)
+		app.search_symbol_in_dirs_semantic(symbol, a, request.id)
 	} else {
-		app.search_symbol_in_dirs(search_dirs, symbol, request.id)
+		app.search_symbol_in_dirs(symbol, request.id)
 	}
 	if locations.len == 0 {
-		locations = app.search_symbol_in_dirs(search_dirs, symbol, request.id)
+		locations = app.search_symbol_in_dirs(symbol, request.id)
 	}
 	if !params.context.include_declaration {
 		if a := anchor {
@@ -954,8 +952,6 @@ fn (mut app App) handle_rename(request Request) Response {
 	// definition anchor, we refuse rather than fall back to lexical same-name
 	// matching, which would rename unrelated symbols in other scopes/modules
 	// (P1-04).
-	working_dir := os.dir(real_path)
-	search_dirs := app.workspace_search_dirs(working_dir)
 	anchor := app.resolve_symbol_anchor(path, line, col) or {
 		log('rename: could not resolve a semantic anchor for "${symbol}"; refusing lexical rename (P1-04)')
 		return Response{
@@ -963,7 +959,7 @@ fn (mut app App) handle_rename(request Request) Response {
 			result: 'null'
 		}
 	}
-	locations := app.search_symbol_in_dirs_semantic(search_dirs, symbol, anchor, request.id)
+	locations := app.search_symbol_in_dirs_semantic(symbol, anchor, request.id)
 	if locations.len == 0 {
 		return Response{
 			id:     request.id
@@ -2157,86 +2153,32 @@ fn (app &App) workspace_search_dirs(primary_dir string) []string {
 	return dirs
 }
 
-fn (mut app App) search_symbol_in_project(working_dir string, symbol string, request_id int) []Location {
-	return app.search_symbol_in_dirs([working_dir], symbol, request_id)
-}
-
-fn (mut app App) search_symbol_in_dirs(search_dirs []string, symbol string, request_id int) []Location {
+// search_symbol_in_dirs returns every lexical occurrence of `symbol` across the
+// indexed project, read from the reference-occurrence index rather than by
+// re-walking and re-tokenizing the workspace on each request (P1-05).
+fn (mut app App) search_symbol_in_dirs(symbol string, request_id int) []Location {
+	app.ensure_dirs_indexed(app.index_query_dirs())
 	mut locations := []Location{}
-	mut seen_files := map[string]bool{}
-	for dir in search_dirs {
-		if dir == '' || dir == '/' || !os.is_dir(dir) {
-			continue
+	mut uris := app.symbol_index.keys()
+	uris.sort()
+	for uri in uris {
+		if request_id in app.cancelled_requests {
+			return locations
 		}
-		v_files := os.walk_ext(dir, '.v')
-
-		for v_file in v_files {
-			if request_id in app.cancelled_requests {
-				return locations
-			}
-			if seen_files[v_file] {
-				continue
-			}
-			seen_files[v_file] = true
-			content := app.open_files[path_to_uri(v_file)] or {
-				os.read_file(v_file) or { continue }
-			}
-			lines := content.split_into_lines()
-
-			for line_idx, line_text in lines {
-				n := line_text.len
-				mut col := 0
-				for col < n {
-					c := line_text[col]
-					// Skip line comments.
-					if col + 1 < n && c == `/` && line_text[col + 1] == `/` {
-						break
+		occ := app.occurrences_for(uri)
+		positions := occ[symbol] or { continue }
+		for p in positions {
+			locations << Location{
+				uri:   uri
+				range: LSPRange{
+					start: Position{
+						line: p.line
+						char: p.start_char
 					}
-					// Skip string literals.
-					if c == `"` || c == `'` {
-						quote := c
-						col++
-						for col < n {
-							if line_text[col] == `\\` {
-								col += 2
-								continue
-							}
-							if line_text[col] == quote {
-								col++
-								break
-							}
-							col++
-						}
-						continue
+					end:   Position{
+						line: p.line
+						char: p.end_char
 					}
-					// Extract full identifier token at this position.
-					if is_ident_char(c) {
-						start := col
-						col++
-						for col < n && is_ident_char(line_text[col]) {
-							col++
-						}
-						if line_text[start..col] == symbol {
-							start_char := byte_to_encoded_col(line_text, start,
-								app.position_encoding)
-							end_char := byte_to_encoded_col(line_text, col, app.position_encoding)
-							locations << Location{
-								uri:   path_to_uri(v_file)
-								range: LSPRange{
-									start: Position{
-										line: line_idx
-										char: start_char
-									}
-									end:   Position{
-										line: line_idx
-										char: end_char
-									}
-								}
-							}
-						}
-						continue
-					}
-					col++
 				}
 			}
 		}
@@ -2245,10 +2187,12 @@ fn (mut app App) search_symbol_in_dirs(search_dirs []string, symbol string, requ
 }
 
 // resolve_symbol_anchor resolves the canonical definition location for a symbol
-// usage via compiler gd^ lookup. Returns none when the definition cannot be
-// resolved, allowing callers to fall back to lexical matching.
+// usage via compiler gd^ lookup. `ch` is a column in the client's negotiated
+// encoding; it is converted to the byte column the compiler expects (P0-01).
+// Returns none when the definition cannot be resolved.
 fn (mut app App) resolve_symbol_anchor(uri string, line int, ch int) ?Location {
-	line_info := '${line + 1}:gd^${ch}'
+	byte_col := app.client_col_to_byte_col(uri, line, ch)
+	line_info := '${line + 1}:gd^${byte_col}'
 	result := app.run_v_line_info(.definition, uri, line_info)
 	if result is Location {
 		loc := result as Location
@@ -2291,107 +2235,53 @@ fn same_anchor_location(a Location, b Location) bool {
 	return delta == 0 || delta == 1 || delta == -1
 }
 
-// search_symbol_in_dirs_semantic performs a lexical candidate scan and validates
-// each candidate with a compiler definition lookup, keeping only occurrences that
-// resolve to the same declaration anchor. Polls for cancellation after each file
-// so that expensive compiler lookups are skipped when the request is cancelled.
-fn (mut app App) search_symbol_in_dirs_semantic(search_dirs []string, symbol string, anchor Location, request_id int) []Location {
+// search_symbol_in_dirs_semantic reads candidate occurrences of `symbol` from the
+// reference-occurrence index (no per-request workspace re-walk, P1-05) and keeps
+// only those whose compiler definition lookup resolves to the same declaration
+// anchor, so references stay scope-safe across same-name symbols (P1-04). The
+// per-candidate compiler lookup is cached within the request. Polls for
+// cancellation so a long scan can bail out.
+fn (mut app App) search_symbol_in_dirs_semantic(symbol string, anchor Location, request_id int) []Location {
 	started_ms := time.now().unix_milli()
+	app.ensure_dirs_indexed(app.index_query_dirs())
 	mut locations := []Location{}
-	mut seen_files := map[string]bool{}
 	mut anchor_cache := map[string]?Location{}
-	mut files_scanned := 0
-	mut anchor_lookups := 0
 	mut candidate_tokens := 0
-	for dir in search_dirs {
-		if dir == '' || dir == '/' || !os.is_dir(dir) {
-			continue
+	mut uris := app.symbol_index.keys()
+	uris.sort()
+	for uri in uris {
+		if request_id in app.cancelled_requests {
+			return locations
 		}
-		v_files := os.walk_ext(dir, '.v')
-		for v_file in v_files {
+		occ := app.occurrences_for(uri)
+		positions := occ[symbol] or { continue }
+		for p in positions {
 			if request_id in app.cancelled_requests {
 				return locations
 			}
-			if seen_files[v_file] {
+			candidate_tokens++
+			resolved := app.resolve_symbol_anchor_cached(uri, p.line, p.start_char, mut
+				anchor_cache) or { continue }
+			if !same_anchor_location(resolved, anchor) {
 				continue
 			}
-			seen_files[v_file] = true
-			uri := path_to_uri(v_file)
-			content := app.open_files[uri] or { os.read_file(v_file) or { continue } }
-			if !content.contains(symbol) {
-				continue
-			}
-			files_scanned++
-			lines := content.split_into_lines()
-			for line_idx, line_text in lines {
-				if !line_text.contains(symbol) {
-					continue
-				}
-				n := line_text.len
-				mut col := 0
-				for col < n {
-					c := line_text[col]
-					if col + 1 < n && c == `/` && line_text[col + 1] == `/` {
-						break
+			locations << Location{
+				uri:   uri
+				range: LSPRange{
+					start: Position{
+						line: p.line
+						char: p.start_char
 					}
-					if c == `"` || c == `'` {
-						quote := c
-						col++
-						for col < n {
-							if line_text[col] == `\\` {
-								col += 2
-								continue
-							}
-							if line_text[col] == quote {
-								col++
-								break
-							}
-							col++
-						}
-						continue
+					end:   Position{
+						line: p.line
+						char: p.end_char
 					}
-					if is_ident_char(c) {
-						start := col
-						col++
-						for col < n && is_ident_char(line_text[col]) {
-							col++
-						}
-						if line_text[start..col] != symbol {
-							continue
-						}
-						candidate_tokens++
-						start_char := byte_to_encoded_col(line_text, start, app.position_encoding)
-						anchor_lookups++
-						if resolved := app.resolve_symbol_anchor_cached(uri, line_idx, start_char, mut
-							anchor_cache)
-						{
-							if !same_anchor_location(resolved, anchor) {
-								continue
-							}
-							end_char := byte_to_encoded_col(line_text, col, app.position_encoding)
-							locations << Location{
-								uri:   uri
-								range: LSPRange{
-									start: Position{
-										line: line_idx
-										char: start_char
-									}
-									end:   Position{
-										line: line_idx
-										char: end_char
-									}
-								}
-							}
-						}
-						continue
-					}
-					col++
 				}
 			}
 		}
 	}
 	elapsed_ms := time.now().unix_milli() - started_ms
-	app.send_log_message('semantic-scan symbol=${symbol} files=${files_scanned} candidates=${candidate_tokens} lookups=${anchor_lookups} matches=${locations.len} elapsed_ms=${elapsed_ms}',
+	app.send_log_message('semantic-scan symbol=${symbol} candidates=${candidate_tokens} matches=${locations.len} elapsed_ms=${elapsed_ms}',
 		4)
 	return locations
 }

--- a/handlers.v
+++ b/handlers.v
@@ -578,23 +578,23 @@ fn (mut app App) on_did_save(request Request) ?Notification {
 			app.open_files[uri] = text
 			app.text = text
 			app.bump_generation(uri)
+			app.invalidate_index_uri(uri)
 		}
-	} else if text := params.text {
-		content = text
-		app.open_files[uri] = text
-		app.text = text
-		app.bump_generation(uri)
 	} else {
-		real_path := uri_to_path(uri)
-		content = os.read_file(real_path) or {
-			$if debug { log('on_did_save: failed to read file ${real_path}: ${err}') }
-			return none
+		// didSave for a document that is NOT open. Do not insert it into
+		// open_files — that would leave it logically open (and editor-owned)
+		// forever. Just compute diagnostics from the saved text or, failing that,
+		// the on-disk content.
+		if text := params.text {
+			content = text
+		} else {
+			real_path := uri_to_path(uri)
+			content = os.read_file(real_path) or {
+				$if debug { log('on_did_save: failed to read file ${real_path}: ${err}') }
+				return none
+			}
 		}
-		app.open_files[uri] = content
-		app.text = content
-		app.bump_generation(uri)
 	}
-	app.invalidate_index_uri(uri)
 	notification := app.build_diagnostics_notification(uri, content)
 	return notification
 }

--- a/handlers.v
+++ b/handlers.v
@@ -394,6 +394,7 @@ fn (mut app App) on_did_open(request Request) {
 		app.open_files_versions[uri] = version
 	}
 	app.bump_generation(uri)
+	app.invalidate_index_uri(uri) // re-parse from the buffer on next query
 	app.text = content
 	$if debug { log('STORED CONTENT for uri=${uri}, FILE COUNT: ${app.open_files.len}') }
 }
@@ -418,6 +419,9 @@ fn (mut app App) on_did_close(request Request) {
 	if uri in app.diag_cache {
 		app.diag_cache.delete(uri)
 	}
+	// The buffer is gone; re-index from disk so the file's symbols remain
+	// discoverable with their on-disk content.
+	app.reindex_uri(uri)
 }
 
 fn (mut app App) build_diagnostics_notification(uri string, content string) Notification {
@@ -518,6 +522,7 @@ fn (mut app App) on_did_change(request Request) ?Notification {
 		app.open_files_versions[uri] = version
 	}
 	app.bump_generation(uri)
+	app.invalidate_index_uri(uri) // symbols re-parsed lazily on next query
 	notification := app.build_diagnostics_notification(uri, content)
 	$if debug { log('returning notification: ${notification}') }
 	return notification
@@ -589,6 +594,7 @@ fn (mut app App) on_did_save(request Request) ?Notification {
 		app.text = content
 		app.bump_generation(uri)
 	}
+	app.invalidate_index_uri(uri)
 	notification := app.build_diagnostics_notification(uri, content)
 	return notification
 }
@@ -764,95 +770,14 @@ fn (mut app App) handle_workspace_symbol(request Request) Response {
 			result: []WorkspaceSymbol{}
 		}
 	}
-	query := params.query.to_lower()
-	mut results := []WorkspaceSymbol{}
-	mut searched_uris := map[string]bool{}
-	mut seen_symbols := map[string]bool{}
-
+	query := params.query
 	token := app.begin_progress('Searching workspace symbols…')
-
-	// Determine working dirs from open files
-	mut working_dirs := map[string]bool{}
-	for uri, _ in app.open_files {
-		dir := os.dir(uri_to_path(uri))
-		if dir != '' && dir != '/' {
-			working_dirs[dir] = true
-		}
-	}
-	for root in app.workspace_roots {
-		if root != '' && root != '/' {
-			working_dirs[root] = true
-		}
-	}
-	mut sorted_open_uris := app.open_files.keys()
-	sorted_open_uris.sort()
-	mut sorted_working_dirs := working_dirs.keys()
-	sorted_working_dirs.sort()
-
-	// Search open files first (in-memory)
-	for uri in sorted_open_uris {
-		if request.id in app.cancelled_requests {
-			app.end_progress(token, '')
-			return Response{
-				id:     request.id
-				result: results
-			}
-		}
-		content := app.open_files[uri]
-		searched_uris[uri] = true
-		syms := parse_document_symbols(content)
-		for sym in syms {
-			if query == '' || sym.name.to_lower().contains(query) {
-				add_workspace_symbol(mut results, mut seen_symbols, sym.name, sym.kind, uri,
-					sym.selection_range)
-			}
-			// Also include children (struct fields and enum members)
-			for child in sym.children {
-				if query == '' || child.name.to_lower().contains(query) {
-					add_workspace_symbol(mut results, mut seen_symbols,
-						'${sym.name}.${child.name}', child.kind, uri, child.selection_range)
-				}
-			}
-		}
-	}
-
-	// Search on-disk .v files not already tracked
-	for dir in sorted_working_dirs {
-		for v_file in os.walk_ext(dir, '.v') {
-			if request.id in app.cancelled_requests {
-				app.end_progress(token, '')
-				return Response{
-					id:     request.id
-					result: results
-				}
-			}
-			if v_file.ends_with('_test.v') {
-				continue
-			}
-			uri := path_to_uri(v_file)
-			if uri in searched_uris {
-				continue
-			}
-			searched_uris[uri] = true
-			content := os.read_file(v_file) or { continue }
-			syms := parse_document_symbols(content)
-			for sym in syms {
-				if query == '' || sym.name.to_lower().contains(query) {
-					add_workspace_symbol(mut results, mut seen_symbols, sym.name, sym.kind, uri,
-						sym.selection_range)
-				}
-				for child in sym.children {
-					if query == '' || child.name.to_lower().contains(query) {
-						add_workspace_symbol(mut results, mut seen_symbols,
-							'${sym.name}.${child.name}', child.kind, uri, child.selection_range)
-					}
-				}
-			}
-		}
-	}
-
+	// Populate/refresh the persistent index once, then answer from it. Tests are
+	// included so test functions/types are discoverable (P2-11). Subsequent
+	// queries reuse the index instead of re-reading and re-parsing the workspace.
+	app.ensure_dirs_indexed(app.index_query_dirs())
+	results := app.query_workspace_symbols(query)
 	app.end_progress(token, '')
-
 	return Response{
 		id:     request.id
 		result: results
@@ -1517,7 +1442,7 @@ fn get_import_completions(line string, work_dir string) []Detail {
 //  3. all .v files in the project working directory
 //  4. vlib/builtin/ (always, for built-in functions like println)
 //  5. vlib/<module>/ for each module imported in the current file
-fn (app &App) find_doc_comment_for_symbol(symbol string, current_lines []string, current_file_uri string) string {
+fn (mut app App) find_doc_comment_for_symbol(symbol string, current_lines []string, current_file_uri string) string {
 	// 1. Current file
 	decl_line := find_declaration_line(current_lines, symbol)
 	if decl_line >= 0 {
@@ -1527,43 +1452,12 @@ fn (app &App) find_doc_comment_for_symbol(symbol string, current_lines []string,
 		}
 	}
 
-	// 2 & 3. Other open files then all project .v files
-	working_dir := os.dir(uri_to_path(current_file_uri))
-	mut searched_uris := map[string]bool{}
-	searched_uris[current_file_uri] = true
-
-	// Search open files first (in memory, no disk I/O)
-	for uri, content in app.open_files {
-		if uri in searched_uris {
-			continue
-		}
-		searched_uris[uri] = true
-		lines := content.split_into_lines()
-		dl := find_declaration_line(lines, symbol)
-		if dl >= 0 {
-			doc := extract_doc_comment(lines, dl)
-			if doc != '' {
-				return doc
-			}
-		}
-	}
-
-	// Search remaining .v files on disk in the working directory
-	for v_file in os.walk_ext(working_dir, '.v') {
-		uri := path_to_uri(v_file)
-		if uri in searched_uris {
-			continue
-		}
-		searched_uris[uri] = true
-		content := os.read_file(v_file) or { continue }
-		lines := content.split_into_lines()
-		dl := find_declaration_line(lines, symbol)
-		if dl >= 0 {
-			doc := extract_doc_comment(lines, dl)
-			if doc != '' {
-				return doc
-			}
-		}
+	// 2 & 3. Other open files and project .v files, via the persistent index
+	// (avoids re-reading and re-parsing the whole project on every hover, P1-08).
+	app.ensure_dirs_indexed(app.index_query_dirs())
+	indexed_doc := app.find_indexed_doc(symbol)
+	if indexed_doc != '' {
+		return indexed_doc
 	}
 
 	// 4. vlib/builtin/ — always search for built-in symbols
@@ -1711,11 +1605,19 @@ fn (mut app App) handle_document_symbols(request Request) Response {
 		}
 	}
 	uri := params.text_document.uri
+	// Serve from the persistent index, refreshing this one document first so it
+	// reflects the latest buffer content.
+	app.reindex_uri(uri)
+	if entry := app.symbol_index[uri] {
+		return Response{
+			id:     request.id
+			result: entry.doc_symbols
+		}
+	}
 	content := app.open_files[uri] or { '' }
-	symbols := parse_document_symbols(content)
 	return Response{
 		id:     request.id
-		result: symbols
+		result: parse_document_symbols(content)
 	}
 }
 

--- a/handlers.v
+++ b/handlers.v
@@ -937,7 +937,8 @@ fn (mut app App) find_references(request Request) Response {
 	// Resolve references from the project's reference-occurrence index.
 	anchor := app.resolve_symbol_anchor(path, line, col)
 	mut locations := if a := anchor {
-		app.search_symbol_in_dirs_semantic(symbol, a, request.id)
+		// References may fall back to lexical occurrences past the candidate cap.
+		app.search_symbol_in_dirs_semantic(symbol, a, request.id, true)
 	} else {
 		app.search_symbol_in_dirs(symbol, request.id)
 	}
@@ -1004,8 +1005,12 @@ fn (mut app App) handle_rename(request Request) Response {
 			result: 'null'
 		}
 	}
-	locations := app.search_symbol_in_dirs_semantic(symbol, anchor, request.id)
+	// Rename is destructive: never accept the scope-unsafe lexical fallback. Past
+	// the candidate cap search_symbol_in_dirs_semantic returns none, and an
+	// unresolved rename is refused below rather than editing unrelated symbols.
+	locations := app.search_symbol_in_dirs_semantic(symbol, anchor, request.id, false)
 	if locations.len == 0 {
+		log('rename: no scope-safe occurrences for "${symbol}" (unresolved or above candidate cap); refusing')
 		return Response{
 			id:     request.id
 			result: 'null'
@@ -2319,8 +2324,12 @@ const reference_semantic_max_candidates = 48
 // only those whose compiler definition lookup resolves to the same declaration
 // anchor, so references stay scope-safe across same-name symbols (P1-04). The
 // per-candidate compiler lookup is cached within the request and the number of
-// compiler invocations is bounded (see reference_semantic_max_candidates).
-fn (mut app App) search_symbol_in_dirs_semantic(symbol string, anchor Location, request_id int) []Location {
+// compiler invocations is bounded (see reference_semantic_max_candidates). When
+// the candidate count exceeds the cap, `allow_lexical_fallback` decides the
+// outcome: references may take the unverified lexical occurrences (over-inclusive
+// but harmless highlights), whereas rename must NOT — it passes false so the
+// caller refuses rather than emit a destructive edit across unrelated scopes.
+fn (mut app App) search_symbol_in_dirs_semantic(symbol string, anchor Location, request_id int, allow_lexical_fallback bool) []Location {
 	started_ms := time.now().unix_milli()
 	app.ensure_dirs_indexed(app.index_query_dirs())
 	app.ensure_loose_file_dirs_shallow_indexed()
@@ -2351,8 +2360,15 @@ fn (mut app App) search_symbol_in_dirs_semantic(symbol string, anchor Location, 
 	}
 
 	// Too many candidates to verify one-compile-per-token without freezing the
-	// loop: return the lexical occurrences unverified (scope-unsafe but bounded).
+	// loop. References fall back to the unverified lexical occurrences (bounded,
+	// scope-unsafe but harmless); rename refuses (returns none) so it never edits
+	// unrelated same-named symbols in other scopes.
 	if candidates.len > reference_semantic_max_candidates {
+		if !allow_lexical_fallback {
+			app.send_log_message('semantic-scan symbol=${symbol} candidates=${candidates.len} exceeds cap ${reference_semantic_max_candidates}; refusing scope-unsafe resolution',
+				2)
+			return []Location{}
+		}
 		app.send_log_message('semantic-scan symbol=${symbol} candidates=${candidates.len} exceeds cap ${reference_semantic_max_candidates}; returning lexical occurrences',
 			3)
 		return candidates

--- a/handlers.v
+++ b/handlers.v
@@ -3178,7 +3178,19 @@ fn normalize_workspace_root(path string) ?string {
 	return normalized
 }
 
+// max_cancelled_ids bounds the cancellation maps so a client that sends
+// $/cancelRequest for ids that never correspond to an in-flight request cannot
+// grow them without limit (P0-04). Cancellation is best-effort, so dropping the
+// oldest tracked ids when the bound is exceeded is safe.
+const max_cancelled_ids = 4096
+
 fn (mut app App) on_cancel_request(request Request) {
+	if app.cancelled_raw_ids.len >= max_cancelled_ids {
+		app.cancelled_raw_ids.clear()
+	}
+	if app.cancelled_requests.len >= max_cancelled_ids {
+		app.cancelled_requests.clear()
+	}
 	// Capture the exact raw id first: json2 aborts decoding CancelRequestParams
 	// when the id is a string, but string ids must still be cancellable
 	// (P0-02/P0-03).

--- a/handlers.v
+++ b/handlers.v
@@ -894,6 +894,18 @@ fn incremental_change_is_valid(content string, range LSPRange, enc PositionEncod
 	if range.start.line >= starts.len || range.end.line >= starts.len {
 		return false
 	}
+	// Reject a character offset past its line's encoded length. On an existing
+	// line, position_to_byte_offset clamps a too-large character to the line end,
+	// which would likewise make an invalid range look valid and get applied at EOL
+	// while the version advances — the same desync in the character dimension.
+	start_line_text := line_text_without_terminator(content, starts, range.start.line)
+	if range.start.char > byte_to_encoded_col(start_line_text, start_line_text.len, enc) {
+		return false
+	}
+	end_line_text := line_text_without_terminator(content, starts, range.end.line)
+	if range.end.char > byte_to_encoded_col(end_line_text, end_line_text.len, enc) {
+		return false
+	}
 	start_byte := position_to_byte_offset(content, starts, range.start.line, range.start.char, enc)
 	end_byte := position_to_byte_offset(content, starts, range.end.line, range.end.char, enc)
 	return start_byte <= end_byte && start_byte <= content.len && end_byte <= content.len
@@ -1483,8 +1495,12 @@ fn (mut app App) find_doc_comment_for_symbol(symbol string, current_lines []stri
 
 	// 2 & 3. Other open files and project .v files, via the persistent index
 	// (avoids re-reading and re-parsing the whole project on every hover, P1-08).
+	// Scope the lookup to the current module directory, then the current project,
+	// so a same-named symbol from an unrelated project/module is never used.
 	app.ensure_dirs_indexed(app.index_query_dirs())
-	indexed_doc := app.find_indexed_doc(symbol)
+	cur_dir := os.dir(uri_to_path(current_file_uri))
+	scope_root := find_project_root(cur_dir)
+	indexed_doc := app.find_indexed_doc_in_scope(symbol, cur_dir, scope_root)
 	if indexed_doc != '' {
 		return indexed_doc
 	}

--- a/handlers.v
+++ b/handlers.v
@@ -31,6 +31,14 @@ fn (mut app App) operation_at_pos(method Method, request Request) Response {
 			result: 'null'
 		}
 	}
+	// LSP positions are non-negative; reject malformed negative positions rather
+	// than indexing arrays with negative values (P1-09).
+	if params.position.line < 0 || params.position.char < 0 {
+		return Response{
+			id:     request.id
+			result: 'null'
+		}
+	}
 	line_nr := params.position.line + 1
 	col := params.position.char
 	path := params.text_document.uri
@@ -381,12 +389,15 @@ fn (mut app App) on_did_open(request Request) {
 	if version := params.text_document.version {
 		app.open_files_versions[uri] = version
 	}
-	app.open_files_generation++
+	app.bump_generation(uri)
 	app.text = content
 	$if debug { log('STORED CONTENT for uri=${uri}, FILE COUNT: ${app.open_files.len}') }
 }
 
-// on_did_close handles the LSP didClose notification by removing the file from tracked state.
+// on_did_close handles the LSP didClose notification by removing the file from
+// tracked state. It also clears the diagnostic cache for the document so stale
+// problems do not linger after close (P0-07). The dispatcher publishes an empty
+// diagnostic set to clear editor markers.
 fn (mut app App) on_did_close(request Request) {
 	params := json.decode(DidCloseTextDocumentParams, request.params) or {
 		$if debug { log('Failed to decode DidCloseTextDocumentParams: ${err}') }
@@ -395,10 +406,13 @@ fn (mut app App) on_did_close(request Request) {
 	uri := params.text_document.uri
 	if uri in app.open_files {
 		app.open_files.delete(uri)
-		app.open_files_generation++
+		app.bump_generation(uri)
 	}
 	if uri in app.open_files_versions {
 		app.open_files_versions.delete(uri)
+	}
+	if uri in app.diag_cache {
+		app.diag_cache.delete(uri)
 	}
 }
 
@@ -422,7 +436,10 @@ fn (mut app App) build_diagnostics_notification(uri string, content string) Noti
 	mut diagnostics := []LSPDiagnostic{}
 	mut seen_positions := map[string]bool{}
 	for v_err in v_errors {
-		pos_key := '${v_err.line_nr}:${v_err.col}'
+		// Include the message and length in the dedup key so two genuinely
+		// different diagnostics at the same line/column are both retained
+		// (P1-06). Only exact duplicates are dropped.
+		pos_key := '${v_err.line_nr}:${v_err.col}:${v_err.len}:${v_err.level}:${v_err.message}'
 		if pos_key in seen_positions {
 			continue
 		}
@@ -456,10 +473,27 @@ fn (mut app App) on_did_change(request Request) ?Notification {
 		return none
 	}
 	uri := params.text_document.uri
+	// Enforce monotonic versions: reject stale or out-of-order changes so an
+	// old buffer state can never overwrite newer text (P0-07).
+	if new_version := params.text_document.version {
+		if old_version := app.open_files_versions[uri] {
+			if new_version <= old_version {
+				log('on_did_change: ignoring stale version ${new_version} <= ${old_version} for ${uri}')
+				return none
+			}
+		}
+	}
+	is_open := uri in app.open_files
 	mut content := app.open_files[uri] or { '' }
 	for change in params.content_changes {
 		if change.range != none {
-			// Incremental change
+			// Incremental change. If the document was never opened we have no
+			// base text to apply the edit against; applying it against '' would
+			// silently corrupt state, so require a full-text sync instead.
+			if !is_open {
+				log('on_did_change: incremental change for unopened document ${uri}; ignoring (client should re-sync)')
+				return none
+			}
 			rng := change.range or {
 				$if debug { log('Skipping malformed incremental change with missing range') }
 				continue
@@ -467,7 +501,7 @@ fn (mut app App) on_did_change(request Request) ?Notification {
 
 			content = apply_incremental_change(content, rng, change.text)
 		} else {
-			// Full text replacement
+			// Full text replacement.
 			content = change.text
 		}
 	}
@@ -476,7 +510,7 @@ fn (mut app App) on_did_change(request Request) ?Notification {
 	if version := params.text_document.version {
 		app.open_files_versions[uri] = version
 	}
-	app.open_files_generation++
+	app.bump_generation(uri)
 	notification := app.build_diagnostics_notification(uri, content)
 	$if debug { log('returning notification: ${notification}') }
 	return notification
@@ -489,23 +523,33 @@ fn (mut app App) on_did_save(request Request) ?Notification {
 		return none
 	}
 	uri := params.text_document.uri
-	mut content := app.open_files[uri] or { '' }
-	if content == '' {
+	// A valid empty open buffer ('') must not be confused with an absent
+	// document. Only fall back to didSave text / disk when the document is not
+	// tracked as open (P0-07 item 6). When the client includes save text and
+	// the document is open, prefer the client's text as the new source of truth.
+	mut content := ''
+	if existing := app.open_files[uri] {
+		content = existing
 		if text := params.text {
 			content = text
 			app.open_files[uri] = text
 			app.text = text
-			app.open_files_generation++
-		} else {
-			real_path := uri_to_path(uri)
-			content = os.read_file(real_path) or {
-				$if debug { log('on_did_save: failed to read file ${real_path}: ${err}') }
-				return none
-			}
-			app.open_files[uri] = content
-			app.text = content
-			app.open_files_generation++
+			app.bump_generation(uri)
 		}
+	} else if text := params.text {
+		content = text
+		app.open_files[uri] = text
+		app.text = text
+		app.bump_generation(uri)
+	} else {
+		real_path := uri_to_path(uri)
+		content = os.read_file(real_path) or {
+			$if debug { log('on_did_save: failed to read file ${real_path}: ${err}') }
+			return none
+		}
+		app.open_files[uri] = content
+		app.text = content
+		app.bump_generation(uri)
 	}
 	notification := app.build_diagnostics_notification(uri, content)
 	return notification
@@ -528,12 +572,11 @@ fn (mut app App) on_will_save_wait_until(request Request) Response {
 			result: []TextEdit{}
 		}
 	}
-	edits, formatted := app.format_content(uri, content)
-	if formatted != '' {
-		app.open_files[uri] = formatted
-		app.text = formatted
-		app.open_files_generation++
-	}
+	// Return the edits only. We must NOT mutate the server's document state here:
+	// the client may cancel, reject, or transform the edit, and it will send the
+	// authoritative new content via a subsequent didChange/didSave. Mutating now
+	// would desynchronize the server from the editor (P0-07 item 7).
+	edits, _ := app.format_content(uri, content)
 	return Response{
 		id:     request.id
 		result: edits
@@ -554,7 +597,7 @@ fn (mut app App) handle_prepare_rename(request Request) Response {
 	real_path := uri_to_path(params.text_document.uri)
 	content := app.open_files[params.text_document.uri] or { os.read_file(real_path) or { '' } }
 	lines := content.split_into_lines()
-	if params.position.line >= lines.len {
+	if params.position.line < 0 || params.position.line >= lines.len {
 		return Response{
 			id:     request.id
 			result: 'null'
@@ -568,7 +611,7 @@ fn (mut app App) handle_prepare_rename(request Request) Response {
 			result: 'null'
 		}
 	}
-	symbol := line_text[start..end]
+	symbol := substr_by_char_bounds(line_text, start, end)
 	if symbol == '' {
 		return Response{
 			id:     request.id
@@ -625,8 +668,24 @@ fn add_workspace_symbol(mut results []WorkspaceSymbol, mut seen_symbols map[stri
 	}
 }
 
-// find_word_bounds_at_col returns [start, end) bounds for the identifier at `col`.
-// If `col` is just after an identifier, it still resolves that identifier.
+// substr_by_char_bounds returns the substring of `line` between the given
+// character (code point) boundaries. It converts the character offsets to byte
+// offsets first, so the slice can never land in the middle of a multi-byte
+// UTF-8 sequence. Callers that receive character offsets (e.g. from
+// find_word_bounds_at_col) must use this instead of raw byte slicing (P0-01).
+fn substr_by_char_bounds(line string, char_start int, char_end int) string {
+	bs := utf8_char_to_byte_index(line, char_start)
+	be := utf8_char_to_byte_index(line, char_end)
+	if bs > be || be > line.len {
+		return ''
+	}
+	return line[bs..be]
+}
+
+// find_word_bounds_at_col returns [start, end) character bounds for the
+// identifier at `col`. If `col` is just after an identifier, it still resolves
+// that identifier. The returned bounds are character (code point) offsets;
+// slice the line via substr_by_char_bounds, never raw byte indexing.
 fn find_word_bounds_at_col(line string, col int) (int, int) {
 	if line == '' {
 		return -1, -1
@@ -763,42 +822,85 @@ fn (mut app App) handle_workspace_symbol(request Request) Response {
 }
 
 // Helper to apply an incremental change to the document content
+// line_start_offsets returns the byte offset at which each line begins,
+// treating \n, \r\n, and \r as line terminators (LSP §3 treats all three as
+// valid). The returned slice always has at least one entry (offset 0).
+fn line_start_offsets(content string) []int {
+	mut offsets := [0]
+	mut i := 0
+	for i < content.len {
+		c := content[i]
+		if c == `\n` {
+			offsets << i + 1
+			i++
+		} else if c == `\r` {
+			if i + 1 < content.len && content[i + 1] == `\n` {
+				offsets << i + 2
+				i += 2
+			} else {
+				offsets << i + 1
+				i++
+			}
+		} else {
+			i++
+		}
+	}
+	return offsets
+}
+
+// line_text_without_terminator returns the text of `line` with any trailing
+// \n, \r\n, or \r stripped, so character offsets map onto line content only.
+fn line_text_without_terminator(content string, starts []int, line int) string {
+	line_start := starts[line]
+	seg_end := if line + 1 < starts.len { starts[line + 1] } else { content.len }
+	mut e := seg_end
+	if e > line_start && content[e - 1] == `\n` {
+		e--
+		if e > line_start && content[e - 1] == `\r` {
+			e--
+		}
+	} else if e > line_start && content[e - 1] == `\r` {
+		e--
+	}
+	return content[line_start..e]
+}
+
+// position_to_byte_offset maps an LSP (line, character) position to a byte
+// offset within `content`. Positions past the end of a line clamp to the line's
+// content end (before its terminator); positions past the last line clamp to
+// the content length.
+fn position_to_byte_offset(content string, starts []int, line int, character int) int {
+	if line < 0 {
+		return 0
+	}
+	if line >= starts.len {
+		return content.len
+	}
+	lt := line_text_without_terminator(content, starts, line)
+	byte_in_line := utf8_char_to_byte_index(lt, character)
+	return starts[line] + byte_in_line
+}
+
+// apply_incremental_change applies one incremental edit against `content`,
+// splicing the raw string by byte offset so that existing line terminators
+// (CRLF, CR, LF, and a final-newline distinction) are preserved exactly
+// (P0-07). Returns the original content unchanged for an invalid/reversed
+// range rather than corrupting the buffer.
 fn apply_incremental_change(content string, range LSPRange, new_text string) string {
-	lines := content.split_into_lines()
-	if lines.len == 0 {
-		return new_text
-	}
-	start := range.start
-	mut end_line := range.end.line
-	mut end_char := range.end.char
-	if start.line < 0 || end_line < 0 || start.line >= lines.len {
+	if range.start.line < 0 || range.start.char < 0 || range.end.line < 0 || range.end.char < 0 {
 		return content
 	}
-	if end_line >= lines.len {
-		end_line = lines.len - 1
-		end_char = utf8_byte_to_char_index(lines[end_line], lines[end_line].len)
-	}
-	start_byte := utf8_char_to_byte_index(lines[start.line], start.char)
-	end_byte := utf8_char_to_byte_index(lines[end_line], end_char)
-	if end_line < start.line || (end_line == start.line && end_byte < start_byte) {
+	if range.end.line < range.start.line
+		|| (range.end.line == range.start.line && range.end.char < range.start.char) {
 		return content
 	}
-	mut before := []string{}
-	mut after := []string{}
-	if start.line > 0 {
-		before = lines[..start.line].clone()
+	starts := line_start_offsets(content)
+	start_byte := position_to_byte_offset(content, starts, range.start.line, range.start.char)
+	end_byte := position_to_byte_offset(content, starts, range.end.line, range.end.char)
+	if start_byte > end_byte || start_byte > content.len || end_byte > content.len {
+		return content
 	}
-	if end_line + 1 < lines.len {
-		after = lines[end_line + 1..].clone()
-	}
-	prefix := lines[start.line][..start_byte]
-	suffix := lines[end_line][end_byte..]
-	replacement := prefix + new_text + suffix
-	mut result_lines := []string{}
-	result_lines << before
-	result_lines << replacement.split('\n')
-	result_lines << after
-	return result_lines.join('\n')
+	return content[..start_byte] + new_text + content[end_byte..]
 }
 
 // find_references handles the LSP references request, returning all locations of a symbol.
@@ -884,18 +986,21 @@ fn (mut app App) handle_rename(request Request) Response {
 		}
 	}
 
-	// Find all references
+	// Rename is destructive, so it must be driven by a stable semantic symbol
+	// identity. If we cannot resolve the symbol under the cursor to a compiler
+	// definition anchor, we refuse rather than fall back to lexical same-name
+	// matching, which would rename unrelated symbols in other scopes/modules
+	// (P1-04).
 	working_dir := os.dir(real_path)
 	search_dirs := app.workspace_search_dirs(working_dir)
-	anchor := app.resolve_symbol_anchor(path, line, col)
-	mut locations := if a := anchor {
-		app.search_symbol_in_dirs_semantic(search_dirs, symbol, a, request.id)
-	} else {
-		app.search_symbol_in_dirs(search_dirs, symbol, request.id)
+	anchor := app.resolve_symbol_anchor(path, line, col) or {
+		log('rename: could not resolve a semantic anchor for "${symbol}"; refusing lexical rename (P1-04)')
+		return Response{
+			id:     request.id
+			result: 'null'
+		}
 	}
-	if locations.len == 0 {
-		locations = app.search_symbol_in_dirs(search_dirs, symbol, request.id)
-	}
+	locations := app.search_symbol_in_dirs_semantic(search_dirs, symbol, anchor, request.id)
 	if locations.len == 0 {
 		return Response{
 			id:     request.id
@@ -958,7 +1063,7 @@ fn (app &App) get_word_at_position(file_path string, line int, col int) string {
 		os.read_file(file_path) or { return '' }
 	}
 	lines := content.split_into_lines()
-	if line >= lines.len {
+	if line < 0 || line >= lines.len {
 		return ''
 	}
 
@@ -1342,7 +1447,7 @@ fn search_doc_in_vlib_dir(dir string, symbol string) string {
 fn (mut app App) format_content(uri string, content string) ([]TextEdit, string) {
 	real_path := uri_to_path(uri)
 
-	temp_file := os.join_path(os.temp_dir(), 'vls_fmt_${os.getpid()}_${os.file_name(real_path)}')
+	temp_file := make_unique_temp_path('vls_fmt', real_path)
 	os.write_file(temp_file, content) or {
 		log('Failed to write temp file for formatting: ${err}')
 		return []TextEdit{}, ''
@@ -1351,7 +1456,7 @@ fn (mut app App) format_content(uri string, content string) ([]TextEdit, string)
 	// With -w flag, v fmt writes the formatted content back to the temp file.
 	// Read from there instead of relying on stdout capture, which is
 	// unreliable on Windows MSYS2.
-	result := os.execute(ensure_stderr_captured(build_v_fmt_cmd(temp_file)))
+	result := run_v_argv(build_v_fmt_args(temp_file), '')
 
 	mut formatted := os.read_file(temp_file) or { result.output }
 
@@ -2221,125 +2326,151 @@ fn (mut app App) handle_code_action(request Request) Response {
 	content := app.open_files[uri] or { '' }
 	lines := content.split_into_lines()
 	diagnostics := params.context.diagnostics
-
-	$if debug {
-		log('handle_code_action called for uri: ${uri}')
-		log('diagnostics count: ${diagnostics.len}')
-		for i, diag in diagnostics {
-			log('diagnostics[${i}]: message=${diag.message}, range=${diag.range}')
-		}
-	}
+	only := params.context.only or { []string{} }
 
 	mut actions := []CodeAction{}
 
-	$if debug { log('Top-level types in handlers.v: App, ...') }
-	// 1. Quick fixes for diagnostics
-	for diag in diagnostics {
-		$if debug {
-			log('Checking diagnostic: message=' + diag.message + ', range.start.line=' +
-				diag.range.start.line.str())
-		}
-		if diag.message.contains('unknown module') {
-			line_nr := diag.range.start.line
-			$if debug {
-				log('unknown module diagnostic at line_nr=' + line_nr.str())
-				if line_nr < lines.len {
-					log('line content: ' + lines[line_nr])
-				}
-			}
-			if line_nr < lines.len && lines[line_nr].trim_space().starts_with('import ') {
-				$if debug { log('Matched import line for quickfix') }
-				edit := WorkspaceEdit{
-					changes: {
-						uri: [
-							TextEdit{
-								range:    LSPRange{
-									start: Position{
-										line: line_nr
-										char: 0
+	// 1. Quick fixes for diagnostics.
+	if code_action_kind_wanted(only, code_action_kind_quickfix) {
+		for diag in diagnostics {
+			if diag.message.contains('unknown module') {
+				line_nr := diag.range.start.line
+				if line_nr >= 0 && line_nr < lines.len
+					&& lines[line_nr].trim_space().starts_with('import ') {
+					// Remove the whole line including its trailing newline by
+					// deleting the range [line_nr,0)..[line_nr+1,0). Ending the
+					// range at the previous line length would leave a blank line
+					// behind (P0-09).
+					edit := WorkspaceEdit{
+						changes: {
+							uri: [
+								TextEdit{
+									range:    LSPRange{
+										start: Position{
+											line: line_nr
+											char: 0
+										}
+										end:   Position{
+											line: line_nr + 1
+											char: 0
+										}
 									}
-									end:   Position{
-										line: line_nr
-										char: lines[line_nr].len
-									}
-								}
-								new_text: ''
-							},
-						]
+									new_text: ''
+								},
+							]
+						}
+					}
+					actions << CodeAction{
+						title:        'Remove unknown import'
+						kind:         code_action_kind_quickfix
+						is_preferred: true
+						edit:         edit
+						diagnostics:  [diag]
 					}
 				}
-				actions << CodeAction{
-					title:        'Remove unknown import'
-					kind:         code_action_kind_quickfix
-					is_preferred: true
-					edit:         edit
-					diagnostics:  [diag]
-				}
-				$if debug { log('Added quickfix action for line_nr=' + line_nr.str()) }
 			}
 		}
 	}
 
-	// 2. Organize Imports (sort and deduplicate)
-	mut import_lines := []int{}
-	for i, line in lines {
-		if line.trim_space().starts_with('import ') {
-			import_lines << i
-		}
-	}
-	if import_lines.len > 0 {
-		mut imports := []string{}
-		for i in import_lines {
-			imports << lines[i].trim_space()
-		}
-		// Deduplicate and sort
-		mut seen := map[string]bool{}
-		mut unique_imports := []string{}
-		for imp in imports {
-			if !seen[imp] {
-				unique_imports << imp
-				seen[imp] = true
-			}
-		}
-		unique_imports.sort()
-		if unique_imports.len > 0 {
-			edit := WorkspaceEdit{
-				changes: {
-					uri: [
-						TextEdit{
-							range:    LSPRange{
-								start: Position{
-									line: import_lines.first()
-									char: 0
-								}
-								end:   Position{
-									line: import_lines.last()
-									char: lines[import_lines.last()].len
-								}
-							}
-							new_text: unique_imports.join('\n')
-						},
-					]
-				}
-			}
-			actions << CodeAction{
-				title: 'Organize Imports'
-				kind:  code_action_kind_source_organize_imports
-				edit:  edit
-			}
-		}
-	}
-
-	$if debug {
-		log('actions count before return: ' + actions.len.str())
-		for i, act in actions {
-			log('actions[' + i.str() + ']: title=' + act.title + ', kind=' + act.kind)
+	// 2. Organize Imports — only safe when every import line forms a single
+	// contiguous block. If imports are separated by any other code or comments
+	// we refuse the action rather than delete the intervening text (P0-09).
+	if code_action_kind_wanted(only, code_action_kind_source_organize_imports) {
+		if action := build_safe_organize_imports_action(uri, lines) {
+			actions << action
 		}
 	}
 
 	return Response{
 		id:     request.id
 		result: actions
+	}
+}
+
+// code_action_kind_wanted reports whether an action of `kind` should be offered
+// given the client's requested `only` filter. An empty filter means "any".
+// A requested kind matches if it equals or is a prefix of the action kind
+// (LSP treats kinds hierarchically, e.g. 'source' covers 'source.organizeImports').
+fn code_action_kind_wanted(only []string, kind string) bool {
+	if only.len == 0 {
+		return true
+	}
+	for want in only {
+		if want == kind || kind.starts_with(want + '.') || kind == want {
+			return true
+		}
+		if kind.starts_with(want) && (want.ends_with('.') || kind.len == want.len) {
+			return true
+		}
+	}
+	return false
+}
+
+// build_safe_organize_imports_action returns an Organize Imports action that is
+// guaranteed to leave all non-import text byte-for-byte unchanged, or none when
+// the imports are not a single contiguous block.
+fn build_safe_organize_imports_action(uri string, lines []string) ?CodeAction {
+	mut import_lines := []int{}
+	for i, line in lines {
+		if line.trim_space().starts_with('import ') {
+			import_lines << i
+		}
+	}
+	if import_lines.len == 0 {
+		return none
+	}
+	first := import_lines.first()
+	last := import_lines.last()
+	// Contiguity check: the imports must occupy every line in [first, last].
+	if last - first + 1 != import_lines.len {
+		log('organize imports: imports are non-contiguous; refusing to edit to avoid deleting intervening code (P0-09)')
+		return none
+	}
+	// Sort + dedup the (trimmed) import lines.
+	mut seen := map[string]bool{}
+	mut unique_imports := []string{}
+	for i in import_lines {
+		imp := lines[i].trim_space()
+		if !seen[imp] {
+			unique_imports << imp
+			seen[imp] = true
+		}
+	}
+	unique_imports.sort()
+	new_text := unique_imports.join('\n')
+	// If nothing would change, don't offer a no-op edit.
+	mut original := []string{}
+	for i in first .. last + 1 {
+		original << lines[i]
+	}
+	if original.join('\n') == new_text {
+		return none
+	}
+	// Postcondition guard: the replaced block contains only import lines, so no
+	// other text can be affected. Replace [first,0)..[last,eol_of_last).
+	edit := WorkspaceEdit{
+		changes: {
+			uri: [
+				TextEdit{
+					range:    LSPRange{
+						start: Position{
+							line: first
+							char: 0
+						}
+						end:   Position{
+							line: last
+							char: utf8_byte_to_char_index(lines[last], lines[last].len)
+						}
+					}
+					new_text: new_text
+				},
+			]
+		}
+	}
+	return CodeAction{
+		title: 'Organize Imports'
+		kind:  code_action_kind_source_organize_imports
+		edit:  edit
 	}
 }
 
@@ -2511,7 +2642,11 @@ fn (mut app App) handle_range_formatting(request Request) Response {
 			}
 		}
 	}
-	temp_file := os.join_path(os.temp_dir(), 'vls_rfmt_${os.getpid()}_${os.file_name(real_path)}')
+	// v fmt formats whole files, so we format the full document, then compute the
+	// minimal changed line hunk (common prefix/suffix). We only emit an edit when
+	// that hunk is fully contained inside the requested range; otherwise we return
+	// no edits rather than risk touching text outside the requested range.
+	temp_file := make_unique_temp_path('vls_rfmt', real_path)
 	os.write_file(temp_file, content) or {
 		log('Failed to write temp file for range formatting: ${err}')
 		return Response{
@@ -2519,51 +2654,73 @@ fn (mut app App) handle_range_formatting(request Request) Response {
 			result: []TextEdit{}
 		}
 	}
-	result := os.execute(ensure_stderr_captured(build_v_fmt_cmd(temp_file)))
+	// With -w, v fmt rewrites the temp file in place; read the file, not stdout.
+	result := run_v_argv(build_v_fmt_args(temp_file), '')
+	formatted := os.read_file(temp_file) or {
+		os.rm(temp_file) or {}
+		return Response{
+			id:     request.id
+			result: []TextEdit{}
+		}
+	}
 	os.rm(temp_file) or {
 		$if debug { log('Failed to remove temp file for range formatting: ${err}') }
 	}
-	if result.exit_code != 0 || result.output == content {
+	if result.exit_code != 0 || formatted == '' || formatted == content {
 		return Response{
 			id:     request.id
 			result: []TextEdit{}
 		}
 	}
 	original_lines := content.split_into_lines()
-	formatted_lines := result.output.split_into_lines()
-	start_line := params.range.start.line
-	mut end_line := params.range.end.line
-	if end_line >= original_lines.len {
-		end_line = original_lines.len - 1
+	formatted_lines := formatted.split_into_lines()
+	req_start := if params.range.start.line < 0 { 0 } else { params.range.start.line }
+	mut req_end := params.range.end.line
+	if req_end >= original_lines.len {
+		req_end = original_lines.len - 1
 	}
-	if start_line >= original_lines.len || start_line >= formatted_lines.len {
+	if req_start >= original_lines.len || req_start > req_end {
 		return Response{
 			id:     request.id
 			result: []TextEdit{}
 		}
 	}
-	safe_end := if end_line < formatted_lines.len { end_line } else { formatted_lines.len - 1 }
-	formatted_slice := formatted_lines[start_line..safe_end + 1].join('\n')
-	original_slice := original_lines[start_line..end_line + 1].join('\n')
-	if formatted_slice == original_slice {
+	// Common prefix length (number of identical leading lines).
+	mut pre := 0
+	for pre < original_lines.len && pre < formatted_lines.len
+		&& original_lines[pre] == formatted_lines[pre] {
+		pre++
+	}
+	// Common suffix length, not overlapping the prefix.
+	mut suf := 0
+	for suf < original_lines.len - pre && suf < formatted_lines.len - pre
+		&& original_lines[original_lines.len - 1 - suf] == formatted_lines[formatted_lines.len - 1 - suf] {
+		suf++
+	}
+	orig_hunk_start := pre
+	orig_hunk_end := original_lines.len - suf // exclusive
+	// The changed hunk must lie fully within the requested line range.
+	if orig_hunk_start < req_start || orig_hunk_end - 1 > req_end {
+		log('range formatting: changed hunk [${orig_hunk_start}..${orig_hunk_end}) outside requested range [${req_start}..${req_end}]; returning no edits')
 		return Response{
 			id:     request.id
 			result: []TextEdit{}
 		}
 	}
-	last_char := original_lines[end_line].len
+	fmt_hunk_end := formatted_lines.len - suf // exclusive
+	new_text := formatted_lines[orig_hunk_start..fmt_hunk_end].join('\n') + '\n'
 	edit := TextEdit{
 		range:    LSPRange{
 			start: Position{
-				line: start_line
+				line: orig_hunk_start
 				char: 0
 			}
 			end:   Position{
-				line: end_line
-				char: last_char
+				line: orig_hunk_end
+				char: 0
 			}
 		}
-		new_text: formatted_slice
+		new_text: new_text
 	}
 	return Response{
 		id:     request.id
@@ -2588,7 +2745,7 @@ fn (mut app App) handle_selection_range(request Request) Response {
 	lines := content.split_into_lines()
 	mut results := []SelectionRange{}
 	for pos in params.positions {
-		if pos.line >= lines.len {
+		if pos.line < 0 || pos.char < 0 || pos.line >= lines.len {
 			results << SelectionRange{
 				range: LSPRange{
 					start: pos
@@ -2818,6 +2975,11 @@ fn (mut app App) on_cancel_request(request Request) {
 		return
 	}
 	app.cancelled_requests[params.id] = true
+	// Cancellation ids may be strings; capture the exact raw id so string-id
+	// requests can be cancelled too (P0-02/P0-03).
+	if raw := extract_raw_id(request.params) {
+		app.cancelled_raw_ids[raw] = true
+	}
 	log('VLS: request ${params.id} marked as cancelled')
 }
 
@@ -3044,7 +3206,7 @@ fn (mut app App) handle_linked_editing_range(request Request) Response {
 	uri := params.text_document.uri
 	content := app.open_files[uri] or { os.read_file(uri_to_path(uri)) or { '' } }
 	lines := content.split_into_lines()
-	if params.position.line >= lines.len {
+	if params.position.line < 0 || params.position.line >= lines.len {
 		return Response{
 			id:     request.id
 			result: 'null'
@@ -3058,7 +3220,7 @@ fn (mut app App) handle_linked_editing_range(request Request) Response {
 			result: 'null'
 		}
 	}
-	symbol := line_text[start..end]
+	symbol := substr_by_char_bounds(line_text, start, end)
 	// Collect all occurrences of the symbol on this line.
 	mut ranges := []LSPRange{}
 	mut col := 0

--- a/handlers.v
+++ b/handlers.v
@@ -3024,6 +3024,8 @@ fn (mut app App) on_did_change_workspace_folders(request Request) {
 			}
 		}
 		app.workspace_roots = new_roots
+		// Drop now-stale index entries that belonged to the removed folder.
+		app.drop_index_under(path)
 	}
 	// Add newly opened folders.
 	for folder in params.event.added {

--- a/handlers.v
+++ b/handlers.v
@@ -1536,15 +1536,16 @@ fn (mut app App) format_content(uri string, content string) ([]TextEdit, string)
 		return []TextEdit{}, ''
 	}
 
-	lines := content.split_into_lines()
-	last_line := lines.len - 1
-	// The end position's character must be in the client's encoding, not raw
-	// bytes, for a correct full-document replace range (P0-01).
-	last_char := if lines.len > 0 {
-		byte_to_encoded_col(lines[last_line], lines[last_line].len, app.position_encoding)
-	} else {
-		0
-	}
+	// Compute the document's true end position from line-start byte offsets, not
+	// split_into_lines(): the latter drops the empty line after a trailing
+	// newline, which would leave the final terminator outside the replacement and
+	// let `v fmt` append an extra one (P0-08). `starts.len - 1` is the number of
+	// line terminators; the final segment is the text after the last terminator
+	// (empty when the file ends in a newline).
+	starts := line_start_offsets(content)
+	end_line := starts.len - 1
+	final_segment := content[starts[end_line]..]
+	end_char := byte_to_encoded_col(final_segment, final_segment.len, app.position_encoding)
 
 	edit := TextEdit{
 		range:    LSPRange{
@@ -1553,8 +1554,8 @@ fn (mut app App) format_content(uri string, content string) ([]TextEdit, string)
 				char: 0
 			}
 			end:   Position{
-				line: last_line
-				char: last_char
+				line: end_line
+				char: end_char
 			}
 		}
 		new_text: formatted

--- a/handlers.v
+++ b/handlers.v
@@ -922,12 +922,11 @@ fn (mut app App) find_references(request Request) Response {
 		}
 	}
 	path := params.text_document.uri
-	real_path := uri_to_path(path)
 	line := params.position.line
 	col := params.position.char
 
 	// Get symbol name at cursor
-	symbol := app.get_word_at_position(real_path, line, col)
+	symbol := app.get_word_at_position(path, line, col)
 	if symbol == '' {
 		return Response{
 			id:     request.id
@@ -981,13 +980,12 @@ fn (mut app App) handle_rename(request Request) Response {
 		}
 	}
 	path := params.text_document.uri
-	real_path := uri_to_path(path)
 	line := params.position.line
 	col := params.position.char
 	new_name := params.new_name
 
 	// Get symbol name at cursor
-	symbol := app.get_word_at_position(real_path, line, col)
+	symbol := app.get_word_at_position(path, line, col)
 	if symbol == '' {
 		return Response{
 			id:     request.id
@@ -1107,10 +1105,8 @@ fn (app &App) byte_col_to_client_col(uri string, line int, byte_col int) int {
 	return byte_to_encoded_col(lines[line], byte_col, app.position_encoding)
 }
 
-fn (app &App) get_word_at_position(file_path string, line int, col int) string {
-	content := app.open_files[path_to_uri(file_path)] or {
-		os.read_file(file_path) or { return '' }
-	}
+fn (app &App) get_word_at_position(uri string, line int, col int) string {
+	content := app.open_files[uri] or { os.read_file(uri_to_path(uri)) or { return '' } }
 	lines := content.split_into_lines()
 	if line < 0 || line >= lines.len {
 		return ''

--- a/handlers.v
+++ b/handlers.v
@@ -3171,13 +3171,24 @@ fn (mut app App) on_did_change_workspace_folders(request Request) {
 		if path == '' || path == '/' {
 			continue
 		}
+		path_key := normalized_index_path(path)
 		mut new_roots := []string{}
 		for r in app.workspace_roots {
-			if r != path {
+			if normalized_index_path(r) != path_key {
 				new_roots << r
 			}
 		}
 		app.workspace_roots = new_roots
+		mut already_removed := false
+		for removed in app.removed_workspace_roots {
+			if normalized_index_path(removed) == path_key {
+				already_removed = true
+				break
+			}
+		}
+		if !already_removed {
+			app.removed_workspace_roots << path
+		}
 		// Drop now-stale index entries that belonged to the removed folder.
 		app.drop_index_under(path)
 	}
@@ -3187,7 +3198,22 @@ fn (mut app App) on_did_change_workspace_folders(request Request) {
 		if path == '' || path == '/' {
 			continue
 		}
-		if path !in app.workspace_roots {
+		path_key := normalized_index_path(path)
+		mut remaining_removed := []string{}
+		for removed in app.removed_workspace_roots {
+			if normalized_index_path(removed) != path_key {
+				remaining_removed << removed
+			}
+		}
+		app.removed_workspace_roots = remaining_removed
+		mut already_active := false
+		for root in app.workspace_roots {
+			if normalized_index_path(root) == path_key {
+				already_active = true
+				break
+			}
+		}
+		if !already_active {
 			app.workspace_roots << path
 		}
 	}

--- a/handlers.v
+++ b/handlers.v
@@ -2211,6 +2211,7 @@ fn (app &App) workspace_search_dirs(primary_dir string) []string {
 // re-walking and re-tokenizing the workspace on each request (P1-05).
 fn (mut app App) search_symbol_in_dirs(symbol string, request_id int) []Location {
 	app.ensure_dirs_indexed(app.index_query_dirs())
+	app.ensure_loose_file_dirs_shallow_indexed()
 	mut locations := []Location{}
 	mut uris := app.symbol_index.keys()
 	uris.sort()
@@ -2297,6 +2298,7 @@ fn same_anchor_location(a Location, b Location) bool {
 fn (mut app App) search_symbol_in_dirs_semantic(symbol string, anchor Location, request_id int) []Location {
 	started_ms := time.now().unix_milli()
 	app.ensure_dirs_indexed(app.index_query_dirs())
+	app.ensure_loose_file_dirs_shallow_indexed()
 	mut locations := []Location{}
 	mut anchor_cache := map[string]?Location{}
 	mut candidate_tokens := 0
@@ -2528,7 +2530,7 @@ fn (mut app App) collect_module_fn_completions(current_file_uri string, working_
 		app.reindex_uri(uri)
 	}
 	app.ensure_dir_shallow_indexed(working_dir)
-	return app.query_module_fn_completions(current_module, current_file_uri)
+	return app.query_module_fn_completions(current_module, current_file_uri, working_dir)
 }
 
 // parse_module_fn_completions extracts free-function declarations (`pub fn` and `fn`)

--- a/handlers.v
+++ b/handlers.v
@@ -1682,6 +1682,7 @@ fn (mut app App) handle_inlay_hints(request Request) Response {
 	// Only scan project directory if working_dir is a real, accessible directory.
 	// Guard against fake URIs (e.g. tests using file:///test.v) which resolve
 	// working_dir to '/' and would cause a full filesystem walk.
+	mut imported_mods := []string{}
 	if working_dir != '' && working_dir != '/' && os.is_dir(working_dir) {
 		project_files := os.walk_ext(working_dir, '.v')
 		for pf in project_files {
@@ -1689,24 +1690,16 @@ fn (mut app App) handle_inlay_hints(request Request) Response {
 				index_files << pf
 			}
 		}
-
-		// Add vlib modules imported by this file
-		imported_mods := parse_imports(content)
-		for mod in imported_mods {
-			mod_path := mod.replace('.', '/')
-			vlib_mod_dir := os.join_path(v_dir, 'vlib', mod_path)
-			if os.is_dir(vlib_mod_dir) {
-				vlib_files := os.walk_ext(vlib_mod_dir, '.v')
-				for vf in vlib_files {
-					if !vf.ends_with('_test.v') {
-						index_files << vf
-					}
-				}
-			}
-		}
+		imported_mods = parse_imports(content)
 	}
 
+	// Project/open files are re-read live (they may change mid-session). vlib
+	// module indexes are merged from a session cache below — walking and parsing
+	// vlib on every inlayHint request was the dominant, needlessly repeated cost.
 	mut fn_index := build_fn_index(index_files)
+	for mod in imported_mods {
+		app.merge_vlib_module_fns(mod, mut fn_index)
+	}
 	// Also index functions defined in the current file (in-memory content).
 	parse_fn_signatures_into(content, '', mut fn_index)
 
@@ -1947,6 +1940,31 @@ fn build_fn_index(files []string) map[string]string {
 		parse_fn_signatures_into(content, mod_name, mut index)
 	}
 	return index
+}
+
+// merge_vlib_module_fns merges the fn→return-type index for a vlib module into
+// `index`, building and caching it on first use. vlib source does not change
+// during a session, so the walk+read+parse is done once per module rather than
+// on every inlayHint request.
+fn (mut app App) merge_vlib_module_fns(mod string, mut index map[string]string) {
+	if mod !in app.vlib_fn_cache {
+		mut built := map[string]string{}
+		mod_path := mod.replace('.', '/')
+		vlib_mod_dir := os.join_path(v_dir, 'vlib', mod_path)
+		if os.is_dir(vlib_mod_dir) {
+			mut vfiles := []string{}
+			for vf in os.walk_ext(vlib_mod_dir, '.v') {
+				if !vf.ends_with('_test.v') {
+					vfiles << vf
+				}
+			}
+			built = build_fn_index(vfiles)
+		}
+		app.vlib_fn_cache[mod] = built.move()
+	}
+	for name, ret in app.vlib_fn_cache[mod] {
+		index[name] = ret
+	}
 }
 
 // lookup_fn_return_type looks up the return type of a function call RHS in the

--- a/handlers.v
+++ b/handlers.v
@@ -437,6 +437,7 @@ fn (mut app App) build_diagnostics_notification(uri string, content string) Noti
 	}
 	v_errors := app.run_v_check(uri, content)
 	log('run_v_check errors:${v_errors}')
+	lines := content.split_into_lines()
 	mut diagnostics := []LSPDiagnostic{}
 	mut seen_positions := map[string]bool{}
 	for v_err in v_errors {
@@ -448,7 +449,9 @@ fn (mut app App) build_diagnostics_notification(uri string, content string) Noti
 			continue
 		}
 		seen_positions[pos_key] = true
-		diagnostics << v_error_to_lsp_diagnostic(v_err)
+		// The compiler reports byte columns; re-encode the diagnostic range in
+		// the client's negotiated encoding (P0-01).
+		diagnostics << app.encode_diagnostic_range(v_error_to_lsp_diagnostic(v_err), lines)
 	}
 	pd_params := PublishDiagnosticsParams{
 		uri:         uri
@@ -518,6 +521,37 @@ fn (mut app App) on_did_change(request Request) ?Notification {
 	notification := app.build_diagnostics_notification(uri, content)
 	$if debug { log('returning notification: ${notification}') }
 	return notification
+}
+
+// encode_diagnostic_range re-encodes a diagnostic's byte-based character
+// offsets (as produced from compiler output) into the client's negotiated
+// position encoding, using the document `lines`.
+fn (app &App) encode_diagnostic_range(diag LSPDiagnostic, lines []string) LSPDiagnostic {
+	start_line := diag.range.start.line
+	end_line := diag.range.end.line
+	start_char := if start_line >= 0 && start_line < lines.len {
+		byte_to_encoded_col(lines[start_line], diag.range.start.char, app.position_encoding)
+	} else {
+		diag.range.start.char
+	}
+	end_char := if end_line >= 0 && end_line < lines.len {
+		byte_to_encoded_col(lines[end_line], diag.range.end.char, app.position_encoding)
+	} else {
+		diag.range.end.char
+	}
+	return LSPDiagnostic{
+		...diag
+		range: LSPRange{
+			start: Position{
+				line: start_line
+				char: start_char
+			}
+			end:   Position{
+				line: end_line
+				char: end_char
+			}
+		}
+	}
 }
 
 // on_did_save handles didSave by re-running diagnostics for the saved document.
@@ -1614,7 +1648,13 @@ fn (mut app App) format_content(uri string, content string) ([]TextEdit, string)
 
 	lines := content.split_into_lines()
 	last_line := lines.len - 1
-	last_char := if lines.len > 0 { lines[last_line].len } else { 0 }
+	// The end position's character must be in the client's encoding, not raw
+	// bytes, for a correct full-document replace range (P0-01).
+	last_char := if lines.len > 0 {
+		byte_to_encoded_col(lines[last_line], lines[last_line].len, app.position_encoding)
+	} else {
+		0
+	}
 
 	edit := TextEdit{
 		range:    LSPRange{
@@ -1820,12 +1860,13 @@ fn (mut app App) handle_inlay_hints(request Request) Response {
 			continue
 		}
 
-		// Position the hint right after the variable name in the raw line
+		// Position the hint right after the variable name in the raw line. The
+		// byte offset is re-encoded into the client's encoding (P0-01/P2-07).
 		name_col := raw.index(var_name) or { continue }
 		hints << InlayHint{
 			position:     Position{
 				line: line_idx
-				char: name_col + var_name.len
+				char: byte_to_encoded_col(raw, name_col + var_name.len, app.position_encoding)
 			}
 			label:        ': ${inferred}'
 			kind:         inlay_hint_kind_type
@@ -2895,7 +2936,8 @@ fn (mut app App) handle_selection_range(request Request) Response {
 			continue
 		}
 		line_text := lines[pos.line]
-		// Outermost: full line range.
+		// Outermost: full line range. The end char is the line length in the
+		// client's encoding, not raw bytes (P0-01/P2-09).
 		line_range := LSPRange{
 			start: Position{
 				line: pos.line
@@ -2903,7 +2945,7 @@ fn (mut app App) handle_selection_range(request Request) Response {
 			}
 			end:   Position{
 				line: pos.line
-				char: line_text.len
+				char: byte_to_encoded_col(line_text, line_text.len, app.position_encoding)
 			}
 		}
 		start, end := find_word_bounds_at_col(line_text, pos.char, app.position_encoding)

--- a/handlers.v
+++ b/handlers.v
@@ -2517,7 +2517,7 @@ fn (mut app App) handle_code_action(request Request) Response {
 	// contiguous block. If imports are separated by any other code or comments
 	// we refuse the action rather than delete the intervening text (P0-09).
 	if code_action_kind_wanted(only, code_action_kind_source_organize_imports) {
-		if action := build_safe_organize_imports_action(uri, lines, app.position_encoding) {
+		if action := build_safe_organize_imports_action(uri, content, lines, app.position_encoding) {
 			actions << action
 		}
 	}
@@ -2550,7 +2550,7 @@ fn code_action_kind_wanted(only []string, kind string) bool {
 // build_safe_organize_imports_action returns an Organize Imports action that is
 // guaranteed to leave all non-import text byte-for-byte unchanged, or none when
 // the imports are not a single contiguous block.
-fn build_safe_organize_imports_action(uri string, lines []string, enc PositionEncoding) ?CodeAction {
+fn build_safe_organize_imports_action(uri string, content string, lines []string, enc PositionEncoding) ?CodeAction {
 	mut import_lines := []int{}
 	for i, line in lines {
 		if line.trim_space().starts_with('import ') {
@@ -2578,13 +2578,14 @@ fn build_safe_organize_imports_action(uri string, lines []string, enc PositionEn
 		}
 	}
 	unique_imports.sort()
-	new_text := unique_imports.join('\n')
+	line_ending := line_ending_after_line(content, first)
+	new_text := unique_imports.join(line_ending)
 	// If nothing would change, don't offer a no-op edit.
 	mut original := []string{}
 	for i in first .. last + 1 {
 		original << lines[i]
 	}
-	if original.join('\n') == new_text {
+	if original.join(line_ending) == new_text {
 		return none
 	}
 	// Postcondition guard: the replaced block contains only import lines, so no
@@ -2613,6 +2614,23 @@ fn build_safe_organize_imports_action(uri string, lines []string, enc PositionEn
 		kind:  code_action_kind_source_organize_imports
 		edit:  edit
 	}
+}
+
+// line_ending_after_line returns the terminator following `line`. Falling back
+// to LF covers a final unterminated line and empty content.
+fn line_ending_after_line(content string, line int) string {
+	starts := line_start_offsets(content)
+	if line < 0 || line + 1 >= starts.len {
+		return '\n'
+	}
+	next_start := starts[line + 1]
+	if next_start >= 2 && content[next_start - 2] == `\r` && content[next_start - 1] == `\n` {
+		return '\r\n'
+	}
+	if next_start >= 1 && content[next_start - 1] == `\r` {
+		return '\r'
+	}
+	return '\n'
 }
 
 // collect_module_fn_completions collects free-function completions from sibling

--- a/handlers.v
+++ b/handlers.v
@@ -420,8 +420,13 @@ fn (mut app App) on_did_close(request Request) {
 		app.diag_cache.delete(uri)
 	}
 	// The buffer is gone; re-index from disk so the file's symbols remain
-	// discoverable with their on-disk content.
-	app.reindex_uri(uri)
+	// discoverable with their on-disk content. Remove the client URI alias and
+	// retain one stable key so a later canonical watcher event cannot create a
+	// duplicate entry for the same physical file.
+	disk_path := uri_to_path(uri)
+	disk_uri := index_uri_for_path(disk_path, app.open_index_uris_by_path())
+	app.drop_index_aliases_for_path(disk_path, disk_uri)
+	app.reindex_uri(disk_uri)
 }
 
 fn (mut app App) build_diagnostics_notification(uri string, content string) Notification {

--- a/handlers.v
+++ b/handlers.v
@@ -510,6 +510,13 @@ fn (mut app App) on_did_change(request Request) ?Notification {
 				continue
 			}
 
+			// An invalid range must not be silently dropped while the version is
+			// advanced (that desynchronizes the buffer). Refuse the whole change
+			// and keep the last-good content and version (P0-07).
+			if !incremental_change_is_valid(content, rng, app.position_encoding) {
+				log('on_did_change: invalid incremental range for ${uri}; refusing change without advancing version')
+				return none
+			}
 			content = apply_incremental_change(content, rng, change.text, app.position_encoding)
 		} else {
 			// Full text replacement.
@@ -864,6 +871,25 @@ fn apply_incremental_change(content string, range LSPRange, new_text string, enc
 		return content
 	}
 	return content[..start_byte] + new_text + content[end_byte..]
+}
+
+// incremental_change_is_valid reports whether `range` maps to an applicable byte
+// span in `content` (non-negative, non-reversed, in bounds). on_did_change uses
+// this to detect an edit it cannot apply, so it can refuse the change WITHOUT
+// advancing the document version — dropping the edit while bumping the version
+// would silently desynchronize the buffer (P0-07).
+fn incremental_change_is_valid(content string, range LSPRange, enc PositionEncoding) bool {
+	if range.start.line < 0 || range.start.char < 0 || range.end.line < 0 || range.end.char < 0 {
+		return false
+	}
+	if range.end.line < range.start.line
+		|| (range.end.line == range.start.line && range.end.char < range.start.char) {
+		return false
+	}
+	starts := line_start_offsets(content)
+	start_byte := position_to_byte_offset(content, starts, range.start.line, range.start.char, enc)
+	end_byte := position_to_byte_offset(content, starts, range.end.line, range.end.char, enc)
+	return start_byte <= end_byte && start_byte <= content.len && end_byte <= content.len
 }
 
 // find_references handles the LSP references request, returning all locations of a symbol.

--- a/handlers.v
+++ b/handlers.v
@@ -783,6 +783,7 @@ fn (mut app App) handle_workspace_symbol(request Request) Response {
 	// included so test functions/types are discoverable (P2-11). Subsequent
 	// queries reuse the index instead of re-reading and re-parsing the workspace.
 	app.ensure_dirs_indexed(app.index_query_dirs())
+	app.ensure_loose_file_dirs_shallow_indexed()
 	results := app.query_workspace_symbols(query)
 	app.end_progress(token, '')
 	return Response{
@@ -987,6 +988,19 @@ fn (mut app App) handle_rename(request Request) Response {
 	// Get symbol name at cursor
 	symbol := app.get_word_at_position(real_path, line, col)
 	if symbol == '' {
+		return Response{
+			id:     request.id
+			result: 'null'
+		}
+	}
+
+	// A destructive rename is safe only when the bounded index covers every
+	// source in the project/module. Oversized, unreadable, or count-capped files
+	// may contain additional references that must not be left unchanged.
+	app.ensure_dirs_indexed(app.index_query_dirs())
+	app.ensure_loose_file_dirs_shallow_indexed()
+	if !app.index_is_complete() {
+		log('rename: source index is incomplete; refusing a partial workspace edit')
 		return Response{
 			id:     request.id
 			result: 'null'

--- a/handlers.v
+++ b/handlers.v
@@ -42,6 +42,10 @@ fn (mut app App) operation_at_pos(method Method, request Request) Response {
 	line_nr := params.position.line + 1
 	col := params.position.char
 	path := params.text_document.uri
+	// The V compiler consumes byte columns, so convert the client's character
+	// offset (in the negotiated encoding) to a byte offset within the cursor line
+	// before building the -line-info string (P0-01).
+	byte_col := app.client_col_to_byte_col(path, params.position.line, col)
 
 	// Intercept completion on import lines
 	if method == .completion {
@@ -68,16 +72,16 @@ fn (mut app App) operation_at_pos(method Method, request Request) Response {
 
 	line_info := match method {
 		.completion {
-			'${line_nr}:${col}'
+			'${line_nr}:${byte_col}'
 		}
 		.hover {
-			'${line_nr}:hv^${col}'
+			'${line_nr}:hv^${byte_col}'
 		}
 		.signature_help {
-			'${line_nr}:fn^${col}'
+			'${line_nr}:fn^${byte_col}'
 		}
 		.definition, .declaration, .type_definition, .implementation {
-			'${line_nr}:gd^${col}'
+			'${line_nr}:gd^${byte_col}'
 		}
 		else {
 			''
@@ -94,9 +98,9 @@ fn (mut app App) operation_at_pos(method Method, request Request) Response {
 		lines := content.split_into_lines()
 		trigger_char := if cursor_line < lines.len && col > 0 {
 			line := lines[cursor_line]
-			byte_col := utf8_char_to_byte_index(line, col - 1)
-			if byte_col < line.len {
-				line[byte_col].ascii_str()
+			trigger_byte_col := encoded_col_to_byte(line, col - 1, app.position_encoding)
+			if trigger_byte_col < line.len {
+				line[trigger_byte_col].ascii_str()
 			} else {
 				''
 			}
@@ -151,7 +155,7 @@ fn (mut app App) operation_at_pos(method Method, request Request) Response {
 		}
 		if cursor_line < lines.len && col > 0 {
 			line := lines[cursor_line]
-			module_alias := get_word_before_dot(line, col - 1)
+			module_alias := get_word_before_dot(line, col - 1, app.position_encoding)
 			if module_alias != '' {
 				module_aliases := parse_import_aliases(content)
 				if module_path := module_aliases[module_alias] {
@@ -192,12 +196,12 @@ struct ImportedModuleBinding {
 }
 
 // get_word_before_dot returns the identifier immediately before a '.' character.
-// `dot_col` is the character index of the dot itself.
-fn get_word_before_dot(line string, dot_col int) string {
+// `dot_col` is the character index of the dot itself (in `enc` units).
+fn get_word_before_dot(line string, dot_col int, enc PositionEncoding) string {
 	if line == '' || dot_col < 0 {
 		return ''
 	}
-	dot_byte := utf8_char_to_byte_index(line, dot_col)
+	dot_byte := encoded_col_to_byte(line, dot_col, enc)
 	if dot_byte >= line.len || line[dot_byte] != `.` {
 		return ''
 	}
@@ -499,7 +503,7 @@ fn (mut app App) on_did_change(request Request) ?Notification {
 				continue
 			}
 
-			content = apply_incremental_change(content, rng, change.text)
+			content = apply_incremental_change(content, rng, change.text, app.position_encoding)
 		} else {
 			// Full text replacement.
 			content = change.text
@@ -604,14 +608,14 @@ fn (mut app App) handle_prepare_rename(request Request) Response {
 		}
 	}
 	line_text := lines[params.position.line]
-	start, end := find_word_bounds_at_col(line_text, params.position.char)
+	start, end := find_word_bounds_at_col(line_text, params.position.char, app.position_encoding)
 	if start < 0 || end <= start {
 		return Response{
 			id:     request.id
 			result: 'null'
 		}
 	}
-	symbol := substr_by_char_bounds(line_text, start, end)
+	symbol := substr_by_char_bounds(line_text, start, end, app.position_encoding)
 	if symbol == '' {
 		return Response{
 			id:     request.id
@@ -673,24 +677,24 @@ fn add_workspace_symbol(mut results []WorkspaceSymbol, mut seen_symbols map[stri
 // offsets first, so the slice can never land in the middle of a multi-byte
 // UTF-8 sequence. Callers that receive character offsets (e.g. from
 // find_word_bounds_at_col) must use this instead of raw byte slicing (P0-01).
-fn substr_by_char_bounds(line string, char_start int, char_end int) string {
-	bs := utf8_char_to_byte_index(line, char_start)
-	be := utf8_char_to_byte_index(line, char_end)
+fn substr_by_char_bounds(line string, char_start int, char_end int, enc PositionEncoding) string {
+	bs := encoded_col_to_byte(line, char_start, enc)
+	be := encoded_col_to_byte(line, char_end, enc)
 	if bs > be || be > line.len {
 		return ''
 	}
 	return line[bs..be]
 }
 
-// find_word_bounds_at_col returns [start, end) character bounds for the
-// identifier at `col`. If `col` is just after an identifier, it still resolves
-// that identifier. The returned bounds are character (code point) offsets;
-// slice the line via substr_by_char_bounds, never raw byte indexing.
-fn find_word_bounds_at_col(line string, col int) (int, int) {
+// find_word_bounds_at_col returns [start, end) character bounds (in the client's
+// `enc` units) for the identifier at `col`. If `col` is just after an
+// identifier, it still resolves that identifier. Slice the line via
+// substr_by_char_bounds, never raw byte indexing (P0-01).
+fn find_word_bounds_at_col(line string, col int, enc PositionEncoding) (int, int) {
 	if line == '' {
 		return -1, -1
 	}
-	mut c := utf8_char_to_byte_index(line, col)
+	mut c := encoded_col_to_byte(line, col, enc)
 	if c >= line.len {
 		c = line.len - 1
 	}
@@ -712,7 +716,7 @@ fn find_word_bounds_at_col(line string, col int) (int, int) {
 	for end < line.len && is_ident_char(line[end]) {
 		end++
 	}
-	return utf8_byte_to_char_index(line, start), utf8_byte_to_char_index(line, end)
+	return byte_to_encoded_col(line, start, enc), byte_to_encoded_col(line, end, enc)
 }
 
 // handle_workspace_symbol searches all tracked and on-disk .v files in the
@@ -869,7 +873,7 @@ fn line_text_without_terminator(content string, starts []int, line int) string {
 // offset within `content`. Positions past the end of a line clamp to the line's
 // content end (before its terminator); positions past the last line clamp to
 // the content length.
-fn position_to_byte_offset(content string, starts []int, line int, character int) int {
+fn position_to_byte_offset(content string, starts []int, line int, character int, enc PositionEncoding) int {
 	if line < 0 {
 		return 0
 	}
@@ -877,7 +881,7 @@ fn position_to_byte_offset(content string, starts []int, line int, character int
 		return content.len
 	}
 	lt := line_text_without_terminator(content, starts, line)
-	byte_in_line := utf8_char_to_byte_index(lt, character)
+	byte_in_line := encoded_col_to_byte(lt, character, enc)
 	return starts[line] + byte_in_line
 }
 
@@ -886,7 +890,7 @@ fn position_to_byte_offset(content string, starts []int, line int, character int
 // (CRLF, CR, LF, and a final-newline distinction) are preserved exactly
 // (P0-07). Returns the original content unchanged for an invalid/reversed
 // range rather than corrupting the buffer.
-fn apply_incremental_change(content string, range LSPRange, new_text string) string {
+fn apply_incremental_change(content string, range LSPRange, new_text string, enc PositionEncoding) string {
 	if range.start.line < 0 || range.start.char < 0 || range.end.line < 0 || range.end.char < 0 {
 		return content
 	}
@@ -895,8 +899,8 @@ fn apply_incremental_change(content string, range LSPRange, new_text string) str
 		return content
 	}
 	starts := line_start_offsets(content)
-	start_byte := position_to_byte_offset(content, starts, range.start.line, range.start.char)
-	end_byte := position_to_byte_offset(content, starts, range.end.line, range.end.char)
+	start_byte := position_to_byte_offset(content, starts, range.start.line, range.start.char, enc)
+	end_byte := position_to_byte_offset(content, starts, range.end.line, range.end.char, enc)
 	if start_byte > end_byte || start_byte > content.len || end_byte > content.len {
 		return content
 	}
@@ -1015,7 +1019,7 @@ fn (mut app App) handle_rename(request Request) Response {
 		end_char := if loc.range.end.char > loc.range.start.char {
 			loc.range.end.char
 		} else {
-			loc.range.start.char + utf8_byte_to_char_index(symbol, symbol.len)
+			loc.range.start.char + byte_to_encoded_col(symbol, symbol.len, app.position_encoding)
 		}
 		edit := TextEdit{
 			range:    LSPRange{
@@ -1058,6 +1062,31 @@ fn (mut app App) handle_rename(request Request) Response {
 	}
 }
 
+// client_col_to_byte_col converts a client `character` offset (in the negotiated
+// encoding) on `line` of the document at `uri` to a byte column, which is the
+// unit the V compiler's -line-info expects. Falls back to the raw column when
+// the document/line is unavailable.
+fn (app &App) client_col_to_byte_col(uri string, line int, col int) int {
+	content := app.open_files[uri] or { os.read_file(uri_to_path(uri)) or { return col } }
+	lines := content.split_into_lines()
+	if line < 0 || line >= lines.len {
+		return col
+	}
+	return encoded_col_to_byte(lines[line], col, app.position_encoding)
+}
+
+// byte_col_to_client_col converts a byte column reported by the compiler (for
+// the document at `uri`, on 0-based `line`) back to the client's negotiated
+// encoding. Falls back to the raw column when the document/line is unavailable.
+fn (app &App) byte_col_to_client_col(uri string, line int, byte_col int) int {
+	content := app.open_files[uri] or { os.read_file(uri_to_path(uri)) or { return byte_col } }
+	lines := content.split_into_lines()
+	if line < 0 || line >= lines.len {
+		return byte_col
+	}
+	return byte_to_encoded_col(lines[line], byte_col, app.position_encoding)
+}
+
 fn (app &App) get_word_at_position(file_path string, line int, col int) string {
 	content := app.open_files[path_to_uri(file_path)] or {
 		os.read_file(file_path) or { return '' }
@@ -1068,7 +1097,7 @@ fn (app &App) get_word_at_position(file_path string, line int, col int) string {
 	}
 
 	text := lines[line]
-	byte_col := utf8_char_to_byte_index(text, col)
+	byte_col := encoded_col_to_byte(text, col, app.position_encoding)
 	if byte_col >= text.len {
 		return ''
 	}
@@ -1091,6 +1120,115 @@ fn (app &App) get_word_at_position(file_path string, line int, col int) string {
 
 fn is_ident_char(c u8) bool {
 	return (c >= `a` && c <= `z`) || (c >= `A` && c <= `Z`) || (c >= `0` && c <= `9`) || c == `_`
+}
+
+// PositionEncoding is the unit the client uses for LSP `character` offsets.
+// LSP defaults to utf16; utf8 (byte offsets) and utf32 (code points) are only
+// used when negotiated via the client's `general.positionEncodings`.
+enum PositionEncoding {
+	utf16
+	utf8
+	utf32
+}
+
+// parse_position_encoding maps an LSP encoding string to a PositionEncoding.
+fn parse_position_encoding(s string) ?PositionEncoding {
+	return match s {
+		'utf-16' { PositionEncoding.utf16 }
+		'utf-8' { PositionEncoding.utf8 }
+		'utf-32' { PositionEncoding.utf32 }
+		else { none }
+	}
+}
+
+// position_encoding_string is the LSP wire string for a PositionEncoding.
+fn position_encoding_string(e PositionEncoding) string {
+	return match e {
+		.utf16 { 'utf-16' }
+		.utf8 { 'utf-8' }
+		.utf32 { 'utf-32' }
+	}
+}
+
+// utf8_seq_len returns the number of bytes in the UTF-8 sequence whose lead
+// byte is `b` (1 for invalid lead bytes, so we always make progress).
+@[inline]
+fn utf8_seq_len(b u8) int {
+	return if (b & 0x80) == 0 {
+		1
+	} else if (b & 0xe0) == 0xc0 {
+		2
+	} else if (b & 0xf0) == 0xe0 {
+		3
+	} else if (b & 0xf8) == 0xf0 {
+		4
+	} else {
+		1
+	}
+}
+
+// encoded_col_to_byte converts an LSP `character` offset expressed in `enc`
+// units into a byte offset within `line`. This is the inbound half of the
+// PositionCodec: every client-supplied character position must pass through it
+// before indexing bytes (P0-01). Non-BMP characters count as two UTF-16 units.
+fn encoded_col_to_byte(line string, col int, enc PositionEncoding) int {
+	if col <= 0 {
+		return 0
+	}
+	match enc {
+		.utf8 {
+			return if col >= line.len { line.len } else { col }
+		}
+		.utf32 {
+			return utf8_char_to_byte_index(line, col)
+		}
+		.utf16 {
+			mut units := 0
+			mut i := 0
+			for i < line.len {
+				if units >= col {
+					return i
+				}
+				size := utf8_seq_len(line[i])
+				u := if size == 4 { 2 } else { 1 }
+				if units + u > col {
+					// col lands in the middle of a surrogate pair; clamp to the
+					// start of this character.
+					return i
+				}
+				units += u
+				i += size
+			}
+			return line.len
+		}
+	}
+}
+
+// byte_to_encoded_col converts a byte offset within `line` into an LSP
+// `character` offset in `enc` units. This is the outbound half of the codec:
+// every character position returned to the client must pass through it.
+fn byte_to_encoded_col(line string, byte_idx int, enc PositionEncoding) int {
+	if byte_idx <= 0 {
+		return 0
+	}
+	match enc {
+		.utf8 {
+			return if byte_idx >= line.len { line.len } else { byte_idx }
+		}
+		.utf32 {
+			return utf8_byte_to_char_index(line, byte_idx)
+		}
+		.utf16 {
+			mut units := 0
+			mut i := 0
+			for i < line.len && i < byte_idx {
+				size := utf8_seq_len(line[i])
+				units += if size == 4 { 2 } else { 1 }
+				i += size
+			}
+			return units
+		}
+	}
 }
 
 fn utf8_char_to_byte_index(s string, char_idx int) int {
@@ -1144,10 +1282,11 @@ fn utf8_byte_to_char_index(s string, byte_idx int) int {
 	return char_count
 }
 
-// get_word_at_col extracts the identifier at column `col` within a single line.
-// Returns '' if the character at `col` is not an identifier character.
-fn get_word_at_col(line string, col int) string {
-	byte_col := utf8_char_to_byte_index(line, col)
+// get_word_at_col extracts the identifier at column `col` (in `enc` units)
+// within a single line. Returns '' if the character at `col` is not an
+// identifier character.
+fn get_word_at_col(line string, col int, enc PositionEncoding) string {
+	byte_col := encoded_col_to_byte(line, col, enc)
 	if byte_col >= line.len {
 		return ''
 	}
@@ -2135,8 +2274,9 @@ fn (mut app App) search_symbol_in_dirs(search_dirs []string, symbol string, requ
 							col++
 						}
 						if line_text[start..col] == symbol {
-							start_char := utf8_byte_to_char_index(line_text, start)
-							end_char := utf8_byte_to_char_index(line_text, col)
+							start_char := byte_to_encoded_col(line_text, start,
+								app.position_encoding)
+							end_char := byte_to_encoded_col(line_text, col, app.position_encoding)
 							locations << Location{
 								uri:   path_to_uri(v_file)
 								range: LSPRange{
@@ -2277,7 +2417,7 @@ fn (mut app App) search_symbol_in_dirs_semantic(search_dirs []string, symbol str
 							continue
 						}
 						candidate_tokens++
-						start_char := utf8_byte_to_char_index(line_text, start)
+						start_char := byte_to_encoded_col(line_text, start, app.position_encoding)
 						anchor_lookups++
 						if resolved := app.resolve_symbol_anchor_cached(uri, line_idx, start_char, mut
 							anchor_cache)
@@ -2285,7 +2425,7 @@ fn (mut app App) search_symbol_in_dirs_semantic(search_dirs []string, symbol str
 							if !same_anchor_location(resolved, anchor) {
 								continue
 							}
-							end_char := utf8_byte_to_char_index(line_text, col)
+							end_char := byte_to_encoded_col(line_text, col, app.position_encoding)
 							locations << Location{
 								uri:   uri
 								range: LSPRange{
@@ -2766,7 +2906,7 @@ fn (mut app App) handle_selection_range(request Request) Response {
 				char: line_text.len
 			}
 		}
-		start, end := find_word_bounds_at_col(line_text, pos.char)
+		start, end := find_word_bounds_at_col(line_text, pos.char, app.position_encoding)
 		if start < 0 || end <= start {
 			results << SelectionRange{
 				range: line_range
@@ -2903,15 +3043,42 @@ fn (mut app App) on_initialize(request Request) ?string {
 	if app.supports_work_done_progress {
 		log('VLS: client supports workDoneProgress')
 	}
-	// Log client-advertised position encodings for diagnostics.
+	// Negotiate the position encoding (P0-01). LSP defaults to UTF-16, which we
+	// always support. If the client advertises UTF-8 we prefer it, because the V
+	// compiler works in byte offsets, so UTF-8 needs no per-line conversion.
+	// UTF-32 (code points) is chosen only if it is the client's sole option.
+	app.position_encoding = negotiate_position_encoding(params)
+	log('VLS: negotiated positionEncoding=${position_encoding_string(app.position_encoding)}')
+	return none
+}
+
+// negotiate_position_encoding selects the server's position encoding from the
+// client's advertised `general.positionEncodings`, preferring UTF-8, then the
+// mandatory UTF-16, then UTF-32.
+fn negotiate_position_encoding(params InitializeParams) PositionEncoding {
 	if caps := params.capabilities {
 		if general := caps.general {
 			if encodings := general.position_encodings {
-				log('VLS: client positionEncodings=${encodings}')
+				mut has_utf16 := false
+				mut has_utf32 := false
+				for e in encodings {
+					match e {
+						'utf-8' { return PositionEncoding.utf8 }
+						'utf-16' { has_utf16 = true }
+						'utf-32' { has_utf32 = true }
+						else {}
+					}
+				}
+				if has_utf16 {
+					return PositionEncoding.utf16
+				}
+				if has_utf32 {
+					return PositionEncoding.utf32
+				}
 			}
 		}
 	}
-	return none
+	return PositionEncoding.utf16
 }
 
 fn client_supports_dynamic_watched_files_registration(params InitializeParams) bool {
@@ -3217,14 +3384,14 @@ fn (mut app App) handle_linked_editing_range(request Request) Response {
 		}
 	}
 	line_text := lines[params.position.line]
-	start, end := find_word_bounds_at_col(line_text, params.position.char)
+	start, end := find_word_bounds_at_col(line_text, params.position.char, app.position_encoding)
 	if start < 0 || end <= start {
 		return Response{
 			id:     request.id
 			result: 'null'
 		}
 	}
-	symbol := substr_by_char_bounds(line_text, start, end)
+	symbol := substr_by_char_bounds(line_text, start, end, app.position_encoding)
 	// Collect all occurrences of the symbol on this line.
 	mut ranges := []LSPRange{}
 	mut col := 0
@@ -3234,8 +3401,8 @@ fn (mut app App) handle_linked_editing_range(request Request) Response {
 		before_ok := abs == 0 || !is_ident_char(line_text[abs - 1])
 		after_ok := abs + symbol.len >= line_text.len || !is_ident_char(line_text[abs + symbol.len])
 		if before_ok && after_ok {
-			sc := utf8_byte_to_char_index(line_text, abs)
-			ec := utf8_byte_to_char_index(line_text, abs + symbol.len)
+			sc := byte_to_encoded_col(line_text, abs, app.position_encoding)
+			ec := byte_to_encoded_col(line_text, abs + symbol.len, app.position_encoding)
 			ranges << LSPRange{
 				start: Position{
 					line: params.position.line

--- a/handlers.v
+++ b/handlers.v
@@ -1613,7 +1613,8 @@ fn (mut app App) handle_document_symbols(request Request) Response {
 	content := app.open_files[uri] or { '' }
 	return Response{
 		id:     request.id
-		result: parse_document_symbols(content)
+		result: encode_document_symbols(parse_document_symbols(content),
+			content.split_into_lines(), app.position_encoding)
 	}
 }
 
@@ -2349,7 +2350,7 @@ fn (mut app App) handle_code_action(request Request) Response {
 	// contiguous block. If imports are separated by any other code or comments
 	// we refuse the action rather than delete the intervening text (P0-09).
 	if code_action_kind_wanted(only, code_action_kind_source_organize_imports) {
-		if action := build_safe_organize_imports_action(uri, lines) {
+		if action := build_safe_organize_imports_action(uri, lines, app.position_encoding) {
 			actions << action
 		}
 	}
@@ -2382,7 +2383,7 @@ fn code_action_kind_wanted(only []string, kind string) bool {
 // build_safe_organize_imports_action returns an Organize Imports action that is
 // guaranteed to leave all non-import text byte-for-byte unchanged, or none when
 // the imports are not a single contiguous block.
-fn build_safe_organize_imports_action(uri string, lines []string) ?CodeAction {
+fn build_safe_organize_imports_action(uri string, lines []string, enc PositionEncoding) ?CodeAction {
 	mut import_lines := []int{}
 	for i, line in lines {
 		if line.trim_space().starts_with('import ') {
@@ -2432,7 +2433,7 @@ fn build_safe_organize_imports_action(uri string, lines []string) ?CodeAction {
 						}
 						end:   Position{
 							line: last
-							char: utf8_byte_to_char_index(lines[last], lines[last].len)
+							char: byte_to_encoded_col(lines[last], lines[last].len, enc)
 						}
 					}
 					new_text: new_text

--- a/handlers.v
+++ b/handlers.v
@@ -2305,38 +2305,36 @@ fn same_anchor_location(a Location, b Location) bool {
 	return delta == 0 || delta == 1 || delta == -1
 }
 
+// reference_semantic_max_candidates bounds how many occurrences a references or
+// rename request will verify with the compiler. Each verification launches a
+// serial `run_v_line_info` (gd^) process, and the request loop cannot process a
+// cancellation mid-scan, so an unbounded scan of a very common symbol could fire
+// hundreds of serial compiles each up to compiler_timeout_ms (P1-04/P0-04). Past
+// this cap the scan falls back to the unverified lexical occurrences: bounded and
+// responsive, at the cost of scope precision for that one very common symbol.
+const reference_semantic_max_candidates = 48
+
 // search_symbol_in_dirs_semantic reads candidate occurrences of `symbol` from the
 // reference-occurrence index (no per-request workspace re-walk, P1-05) and keeps
 // only those whose compiler definition lookup resolves to the same declaration
 // anchor, so references stay scope-safe across same-name symbols (P1-04). The
-// per-candidate compiler lookup is cached within the request. Polls for
-// cancellation so a long scan can bail out.
+// per-candidate compiler lookup is cached within the request and the number of
+// compiler invocations is bounded (see reference_semantic_max_candidates).
 fn (mut app App) search_symbol_in_dirs_semantic(symbol string, anchor Location, request_id int) []Location {
 	started_ms := time.now().unix_milli()
 	app.ensure_dirs_indexed(app.index_query_dirs())
 	app.ensure_loose_file_dirs_shallow_indexed()
-	mut locations := []Location{}
-	mut anchor_cache := map[string]?Location{}
-	mut candidate_tokens := 0
+
+	// Collect every lexical candidate first so the compiler-verification cost can
+	// be bounded up front rather than discovered candidate-by-candidate.
+	mut candidates := []Location{}
 	mut uris := app.symbol_index.keys()
 	uris.sort()
 	for uri in uris {
-		if request_id in app.cancelled_requests {
-			return locations
-		}
 		occ := app.occurrences_for(uri)
 		positions := occ[symbol] or { continue }
 		for p in positions {
-			if request_id in app.cancelled_requests {
-				return locations
-			}
-			candidate_tokens++
-			resolved := app.resolve_symbol_anchor_cached(uri, p.line, p.start_char, mut
-				anchor_cache) or { continue }
-			if !same_anchor_location(resolved, anchor) {
-				continue
-			}
-			locations << Location{
+			candidates << Location{
 				uri:   uri
 				range: LSPRange{
 					start: Position{
@@ -2351,8 +2349,29 @@ fn (mut app App) search_symbol_in_dirs_semantic(symbol string, anchor Location, 
 			}
 		}
 	}
+
+	// Too many candidates to verify one-compile-per-token without freezing the
+	// loop: return the lexical occurrences unverified (scope-unsafe but bounded).
+	if candidates.len > reference_semantic_max_candidates {
+		app.send_log_message('semantic-scan symbol=${symbol} candidates=${candidates.len} exceeds cap ${reference_semantic_max_candidates}; returning lexical occurrences',
+			3)
+		return candidates
+	}
+
+	mut locations := []Location{}
+	mut anchor_cache := map[string]?Location{}
+	for cand in candidates {
+		if request_id in app.cancelled_requests {
+			return locations
+		}
+		resolved := app.resolve_symbol_anchor_cached(cand.uri, cand.range.start.line,
+			cand.range.start.char, mut anchor_cache) or { continue }
+		if same_anchor_location(resolved, anchor) {
+			locations << cand
+		}
+	}
 	elapsed_ms := time.now().unix_milli() - started_ms
-	app.send_log_message('semantic-scan symbol=${symbol} candidates=${candidate_tokens} matches=${locations.len} elapsed_ms=${elapsed_ms}',
+	app.send_log_message('semantic-scan symbol=${symbol} candidates=${candidates.len} matches=${locations.len} elapsed_ms=${elapsed_ms}',
 		4)
 	return locations
 }

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -4016,3 +4016,14 @@ fn test_negotiate_position_encoding_defaults_utf16() {
 	}
 	assert negotiate_position_encoding(params) == .utf32
 }
+
+fn test_classify_highlight_kind_read_write() {
+	// Assignments and declarations are writes.
+	assert classify_highlight_kind('x := 1', 1) == doc_highlight_write
+	assert classify_highlight_kind('x = 1', 1) == doc_highlight_write
+	assert classify_highlight_kind('x += 1', 1) == doc_highlight_write
+	// Comparisons and uses are reads.
+	assert classify_highlight_kind('x == 1', 1) == doc_highlight_read
+	assert classify_highlight_kind('foo(x)', 3) == doc_highlight_read
+	assert classify_highlight_kind('return x', 8) == doc_highlight_read
+}

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -634,6 +634,29 @@ fn test_incremental_change_is_valid_rejects_lines_past_eof() {
 	assert incremental_change_is_valid(content, ok, .utf16)
 }
 
+fn test_semantic_reference_scan_caps_candidates() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	app.capture_output = true // don't write log notifications to stdout during the test
+	// A directory that does not exist on disk, so no real files are scanned.
+	uri := 'file:///nonexistent_vls_reftest/a.v'
+	mut content := 'module main\n'
+	for _ in 0 .. reference_semantic_max_candidates + 5 {
+		content += 'fn line() { foo() }\n'
+	}
+	app.open_files[uri] = content
+
+	dummy_anchor := Location{
+		uri: uri
+	}
+	locs := app.search_symbol_in_dirs_semantic('foo', dummy_anchor, 0)
+	// Over the cap, every lexical occurrence is returned unverified (no compiler
+	// process is launched), bounding the worst-case cost.
+	assert locs.len == reference_semantic_max_candidates + 5
+}
+
 fn test_incremental_change_is_valid_rejects_char_past_line() {
 	// Line 0 "abc" has length 3. A character offset past the line end is invalid
 	// even though the line exists: position_to_byte_offset would clamp it to EOL

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -512,7 +512,43 @@ fn test_apply_incremental_change_handles_utf8_columns() {
 		}
 	}
 	updated := apply_incremental_change(content, range, 'X')
-	assert updated == 'aXz'
+	// The trailing newline must be preserved: incremental edits are lossless and
+	// must not normalize line endings (P0-07 item 4).
+	assert updated == 'aXz\n'
+}
+
+fn test_apply_incremental_change_preserves_crlf() {
+	// CRLF line endings outside the edited span must be preserved exactly.
+	content := 'abc\r\ndef\r\nghi\r\n'
+	range := LSPRange{
+		start: Position{
+			line: 1
+			char: 0
+		}
+		end:   Position{
+			line: 1
+			char: 3
+		}
+	}
+	updated := apply_incremental_change(content, range, 'XYZ')
+	assert updated == 'abc\r\nXYZ\r\nghi\r\n'
+}
+
+fn test_apply_incremental_change_rejects_reversed_range() {
+	content := 'abcdef'
+	range := LSPRange{
+		start: Position{
+			line: 0
+			char: 4
+		}
+		end:   Position{
+			line: 0
+			char: 2
+		}
+	}
+	// A reversed range is invalid; the content must be returned unchanged.
+	updated := apply_incremental_change(content, range, 'X')
+	assert updated == content
 }
 
 fn test_apply_incremental_change_handles_multiline_ranges() {
@@ -3656,4 +3692,75 @@ fn test_call_hierarchy_incoming_returns_callers() {
 	assert resp.result is []CallHierarchyIncomingCall
 	calls := resp.result as []CallHierarchyIncomingCall
 	assert calls.any(it.from.name == 'main')
+}
+
+// --- P0-09: Organize Imports must never delete non-import code ---
+
+fn test_organize_imports_refuses_non_contiguous_block() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	uri := 'file:///tmp/oi_noncontig.v'
+	// Imports separated by a function: organizing must NOT delete `helper`.
+	app.open_files[uri] = 'import os\n\nfn helper() {}\n\nimport time\n'
+	params := CodeActionParams{
+		text_document: TextDocumentIdentifier{
+			uri: uri
+		}
+		range:         LSPRange{}
+		context:       CodeActionContext{}
+	}
+	resp := app.handle_code_action(Request{
+		id:     1
+		params: json.encode(params)
+	})
+	assert resp.result is []CodeAction
+	actions := resp.result as []CodeAction
+	for a in actions {
+		assert a.kind != code_action_kind_source_organize_imports, 'organize imports must not be offered for non-contiguous imports'
+	}
+}
+
+fn test_organize_imports_sorts_contiguous_block() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	uri := 'file:///tmp/oi_contig.v'
+	app.open_files[uri] = 'import time\nimport os\nimport os\n'
+	params := CodeActionParams{
+		text_document: TextDocumentIdentifier{
+			uri: uri
+		}
+		range:         LSPRange{}
+		context:       CodeActionContext{}
+	}
+	resp := app.handle_code_action(Request{
+		id:     2
+		params: json.encode(params)
+	})
+	assert resp.result is []CodeAction
+	actions := resp.result as []CodeAction
+	mut found := false
+	for a in actions {
+		if a.kind == code_action_kind_source_organize_imports {
+			found = true
+			edit := a.edit or { continue }
+			edits := edit.changes[uri]
+			assert edits.len == 1
+			// Sorted + deduplicated.
+			assert edits[0].new_text == 'import os\nimport time'
+		}
+	}
+	assert found, 'organize imports should be offered for a contiguous import block'
+}
+
+fn test_code_action_kind_wanted_respects_only_filter() {
+	assert code_action_kind_wanted([], 'quickfix')
+	assert code_action_kind_wanted(['quickfix'], 'quickfix')
+	assert code_action_kind_wanted(['source'], 'source.organizeImports')
+	assert code_action_kind_wanted(['source.organizeImports'], 'source.organizeImports')
+	assert !code_action_kind_wanted(['quickfix'], 'source.organizeImports')
+	assert !code_action_kind_wanted(['source.organizeImports'], 'quickfix')
 }

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -4442,19 +4442,26 @@ fn test_negotiate_position_encoding_defaults_utf16() {
 
 fn test_classify_highlight_kind_read_write() {
 	// Assignments and declarations are writes.
-	assert classify_highlight_kind('x := 1', 1) == doc_highlight_write
-	assert classify_highlight_kind('x = 1', 1) == doc_highlight_write
-	assert classify_highlight_kind('x += 1', 1) == doc_highlight_write
-	assert classify_highlight_kind('x++', 1) == doc_highlight_write
-	assert classify_highlight_kind('x--', 1) == doc_highlight_write
-	assert classify_highlight_kind('bits <<= 1', 4) == doc_highlight_write
-	assert classify_highlight_kind('bits >>= 1', 4) == doc_highlight_write
+	assert classify_highlight_kind('x := 1', 0, 1) == doc_highlight_write
+	assert classify_highlight_kind('x = 1', 0, 1) == doc_highlight_write
+	assert classify_highlight_kind('x += 1', 0, 1) == doc_highlight_write
+	assert classify_highlight_kind('x++', 0, 1) == doc_highlight_write
+	assert classify_highlight_kind('x--', 0, 1) == doc_highlight_write
+	assert classify_highlight_kind('bits <<= 1', 0, 4) == doc_highlight_write
+	assert classify_highlight_kind('bits >>= 1', 0, 4) == doc_highlight_write
+	assert classify_highlight_kind('fn f(item Type) {}', 5, 9) == doc_highlight_write
+	assert classify_highlight_kind('fn (app App) run() {}', 4, 7) == doc_highlight_write
+	assert classify_highlight_kind('for item in items {}', 4, 8) == doc_highlight_write
+	assert classify_highlight_kind('for key, value in items {}', 4, 7) == doc_highlight_write
+	assert classify_highlight_kind('for key, value in items {}', 9, 14) == doc_highlight_write
 	// Comparisons and uses are reads.
-	assert classify_highlight_kind('x == 1', 1) == doc_highlight_read
-	assert classify_highlight_kind('bits << 1', 4) == doc_highlight_read
-	assert classify_highlight_kind('bits >> 1', 4) == doc_highlight_read
-	assert classify_highlight_kind('foo(x)', 3) == doc_highlight_read
-	assert classify_highlight_kind('return x', 8) == doc_highlight_read
+	assert classify_highlight_kind('x == 1', 0, 1) == doc_highlight_read
+	assert classify_highlight_kind('bits << 1', 0, 4) == doc_highlight_read
+	assert classify_highlight_kind('bits >> 1', 0, 4) == doc_highlight_read
+	assert classify_highlight_kind('foo(x)', 0, 3) == doc_highlight_read
+	assert classify_highlight_kind('return x', 7, 8) == doc_highlight_read
+	assert classify_highlight_kind('fn f(item Type) {}', 10, 14) == doc_highlight_read
+	assert classify_highlight_kind('for item in items {}', 12, 17) == doc_highlight_read
 }
 
 fn test_on_did_change_invalid_range_does_not_advance_version() {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -1668,6 +1668,43 @@ fn test_handle_rename_returns_null_when_no_symbol_at_position() {
 	assert (resp.result as string) == 'null'
 }
 
+fn test_handle_rename_refuses_incomplete_oversized_sibling_index() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+
+	test_dir := os.join_path(app.temp_dir, 'loose_rename')
+	must_mkdir_all(test_dir)
+	test_file := os.join_path(test_dir, 'main.v')
+	content := 'module main\n\nfn target() {\n\ttarget()\n}\n'
+	must_write_file(test_file, content)
+	must_write_file(os.join_path(test_dir, 'oversized.v'), 'x'.repeat(index_max_file_bytes + 1))
+	uri := path_to_uri(test_file)
+	app.open_files[uri] = content
+
+	resp := app.handle_rename(Request{
+		id:     903
+		method: 'textDocument/rename'
+		params: json2.encode(RenameParams{
+			text_document: TextDocumentIdentifier{
+				uri: uri
+			}
+			position:      Position{
+				line: 2
+				char: 4
+			}
+			new_name:      'renamed'
+		},
+			escape_unicode: true
+		)
+	})
+
+	assert !app.index_is_complete()
+	assert resp.result is string
+	assert (resp.result as string) == 'null'
+}
+
 fn test_parse_document_symbols_empty_content() {
 	syms := parse_document_symbols('')
 	assert syms.len == 0
@@ -3483,7 +3520,8 @@ fn test_semantic_tokens_range_filters_by_character() {
 			}
 		}
 	},
-		escape_unicode: true)
+		escape_unicode: true
+	)
 	full := app.handle_semantic_tokens_range(Request{
 		id:     1
 		params: full_params
@@ -3512,7 +3550,8 @@ fn test_semantic_tokens_range_filters_by_character() {
 			}
 		}
 	},
-		escape_unicode: true)
+		escape_unicode: true
+	)
 	narrow := app.handle_semantic_tokens_range(Request{
 		id:     2
 		params: narrow_params

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -4027,3 +4027,43 @@ fn test_classify_highlight_kind_read_write() {
 	assert classify_highlight_kind('foo(x)', 3) == doc_highlight_read
 	assert classify_highlight_kind('return x', 8) == doc_highlight_read
 }
+
+fn test_on_did_change_invalid_range_does_not_advance_version() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	uri := 'file:///tmp/inv.v'
+	app.open_files[uri] = 'module main\n'
+	app.open_files_versions[uri] = 1
+	// A reversed range is invalid: the change must be refused and the version
+	// must NOT advance (P0-07).
+	app.on_did_change(Request{
+		params: json2.encode(DidChangeTextDocumentParams{
+			text_document:   VersionedTextDocumentIdentifier{
+				uri:     uri
+				version: 2
+			}
+			content_changes: [
+				ContentChange{
+					text:  'X'
+					range: LSPRange{
+						start: Position{
+							line: 0
+							char: 5
+						}
+						end:   Position{
+							line: 0
+							char: 2
+						}
+					}
+				},
+			]
+		},
+			escape_unicode: true
+		)
+	}) or {}
+	// Content unchanged, version still 1.
+	assert app.open_files[uri] == 'module main\n'
+	assert app.open_files_versions[uri] == 1
+}

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -679,6 +679,12 @@ fn test_operation_at_pos_definition_line_info() {
 
 	response := app.operation_at_pos(.definition, request)
 	assert response.id == 2
+	// Regression guard: definition must actually resolve through the compiler
+	// interop path (which silently broke once when compiler stderr was dropped),
+	// not return null. It must point at the `fn helper()` declaration on line 2.
+	assert response.result is Location
+	loc := response.result as Location
+	assert loc.range.start.line == 2
 }
 
 fn test_operation_at_pos_signature_help_line_info() {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -4150,6 +4150,44 @@ fn test_organize_imports_sorts_contiguous_block() {
 	assert found, 'organize imports should be offered for a contiguous import block'
 }
 
+fn test_organize_imports_preserves_crlf_line_endings() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	uri := 'file:///tmp/oi_crlf.v'
+	app.open_files[uri] = 'module main\r\n\r\nimport time\r\nimport os\r\n\r\nfn main() {}\r\n'
+	resp := app.handle_code_action(Request{
+		id:     3
+		params: json2.encode(CodeActionParams{
+			text_document: TextDocumentIdentifier{
+				uri: uri
+			}
+			range:         LSPRange{}
+			context:       CodeActionContext{}
+		},
+			escape_unicode: true
+		)
+	})
+	assert resp.result is []CodeAction
+	actions := resp.result as []CodeAction
+	for action in actions {
+		if action.kind != code_action_kind_source_organize_imports {
+			continue
+		}
+		edit := action.edit or {
+			assert false, 'organize imports action must contain an edit'
+			return
+		}
+
+		edits := edit.changes[uri]
+		assert edits.len == 1
+		assert edits[0].new_text == 'import os\r\nimport time'
+		return
+	}
+	assert false, 'organize imports should be offered for an unsorted CRLF block'
+}
+
 fn test_remove_unknown_import_range_at_eof_without_newline() {
 	mut app := create_test_app()
 	defer {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -4464,6 +4464,41 @@ fn test_classify_highlight_kind_read_write() {
 	assert classify_highlight_kind('for item in items {}', 12, 17) == doc_highlight_read
 }
 
+fn test_document_highlight_falls_back_to_lexical_results_over_semantic_cap() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	uri := 'file:///nonexistent_vls_highlight/main.v'
+	mut content := 'module main\n\nfn main() {\n\tmut item := 0\n'
+	for _ in 0 .. document_highlight_semantic_max_candidates {
+		content += '\titem++\n'
+	}
+	content += '}\n'
+	app.open_files[uri] = content
+
+	response := app.handle_document_highlight(Request{
+		id:     900
+		method: 'textDocument/documentHighlight'
+		params: json2.encode(DocumentHighlightParams{
+			text_document: TextDocumentIdentifier{
+				uri: uri
+			}
+			position:      Position{
+				line: 3
+				char: 5
+			}
+		},
+			escape_unicode: true
+		)
+	})
+
+	assert response.result is []DocumentHighlight
+	highlights := response.result as []DocumentHighlight
+	assert highlights.len == document_highlight_semantic_max_candidates + 1
+	assert highlights[0].kind == doc_highlight_write
+}
+
 fn test_on_did_change_invalid_range_does_not_advance_version() {
 	mut app := create_test_app()
 	defer {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -3,7 +3,7 @@
 module main
 
 import os
-import json
+import json2
 
 fn must_mkdir_all(path string) {
 	os.mkdir_all(path) or {
@@ -58,11 +58,13 @@ fn test_on_did_open_tracks_file() {
 		id:      1
 		method:  'textDocument/didOpen'
 		jsonrpc: '2.0'
-		params:  json.encode(Params{
+		params:  json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	}
 
 	app.on_did_open(request)
@@ -95,18 +97,22 @@ fn test_on_did_open_multiple_files() {
 	uri2 := path_to_uri(test_file2)
 
 	app.on_did_open(Request{
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri1
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	})
 	app.on_did_open(Request{
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri2
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	})
 
 	assert app.open_files.len == 2
@@ -136,21 +142,25 @@ fn test_on_did_open_updates_current_text() {
 
 	// Open first file
 	app.on_did_open(Request{
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri1
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	})
 	assert app.text == content1
 
 	// Open second file - app.text should update to second file's content
 	app.on_did_open(Request{
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri2
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	})
 	assert app.text == content2
 }
@@ -166,11 +176,13 @@ fn test_on_did_open_nonexistent_file() {
 	uri := path_to_uri(nonexistent)
 
 	app.on_did_open(Request{
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	})
 
 	// File should not be tracked if it doesn't exist
@@ -186,12 +198,14 @@ fn test_on_did_open_uses_text_document_payload() {
 	uri := path_to_uri(os.join_path(app.temp_dir, 'unsaved.v'))
 	content := 'module main\n\nfn main() {\n\tprintln("from_payload")\n}'
 	app.on_did_open(Request{
-		params: json.encode(DidOpenTextDocumentParams{
+		params: json2.encode(DidOpenTextDocumentParams{
 			text_document: DidOpenTextDocumentItem{
 				uri:  uri
 				text: content
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	})
 
 	assert uri in app.open_files
@@ -207,12 +221,14 @@ fn test_on_did_open_uses_empty_text_payload_without_disk_fallback() {
 
 	uri := path_to_uri(os.join_path(app.temp_dir, 'unsaved_empty.v'))
 	app.on_did_open(Request{
-		params: json.encode(DidOpenTextDocumentParams{
+		params: json2.encode(DidOpenTextDocumentParams{
 			text_document: DidOpenTextDocumentItem{
 				uri:  uri
 				text: ''
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	})
 
 	assert uri in app.open_files
@@ -233,11 +249,13 @@ fn test_on_did_open_empty_file() {
 
 	uri := path_to_uri(test_file)
 	app.on_did_open(Request{
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	})
 
 	assert uri in app.open_files
@@ -261,11 +279,13 @@ fn test_on_did_open_reopen_same_file() {
 
 	uri := path_to_uri(test_file)
 	app.on_did_open(Request{
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	})
 	assert app.open_files[uri] == content1
 
@@ -275,11 +295,13 @@ fn test_on_did_open_reopen_same_file() {
 
 	// Reopen the file - should get new content
 	app.on_did_open(Request{
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	})
 	assert app.open_files[uri] == content2
 }
@@ -300,11 +322,13 @@ fn test_on_did_change_updates_content() {
 
 	// First open the file
 	app.on_did_open(Request{
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	})
 
 	// Then change it
@@ -313,14 +337,16 @@ fn test_on_did_change_updates_content() {
 		id:      2
 		method:  'textDocument/didChange'
 		jsonrpc: '2.0'
-		params:  json.encode(Params{
+		params:  json2.encode(Params{
 			text_document:   TextDocumentIdentifier{
 				uri: uri
 			}
 			content_changes: [ContentChange{
 				text: new_content
 			}]
-		})
+		},
+			escape_unicode: true
+		)
 	}
 
 	app.on_did_change(request)
@@ -337,9 +363,11 @@ fn test_on_did_change_empty_changes() {
 
 	// Request with empty content changes should return none
 	request := Request{
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			content_changes: []
-		})
+		},
+			escape_unicode: true
+		)
 	}
 
 	result := app.on_did_change(request)
@@ -354,11 +382,13 @@ fn test_on_did_change_empty_text() {
 
 	// Request with empty text (deletion) should be processed and return diagnostics
 	request := Request{
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			content_changes: [ContentChange{
 				text: ''
 			}]
-		})
+		},
+			escape_unicode: true
+		)
 	}
 
 	result := app.on_did_change(request)
@@ -385,22 +415,26 @@ fn test_on_did_change_returns_notification() {
 
 	uri := path_to_uri(test_file)
 	app.on_did_open(Request{
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	})
 
 	request := Request{
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document:   TextDocumentIdentifier{
 				uri: uri
 			}
 			content_changes: [ContentChange{
 				text: content
 			}]
-		})
+		},
+			escape_unicode: true
+		)
 	}
 
 	result := app.on_did_change(request)
@@ -425,11 +459,13 @@ fn test_on_did_change_multiple_changes() {
 
 	uri := path_to_uri(test_file)
 	app.on_did_open(Request{
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	})
 
 	// Simulate multiple sequential changes
@@ -441,14 +477,16 @@ fn test_on_did_change_multiple_changes() {
 
 	for change in changes {
 		request := Request{
-			params: json.encode(Params{
+			params: json2.encode(Params{
 				text_document:   TextDocumentIdentifier{
 					uri: uri
 				}
 				content_changes: [ContentChange{
 					text: change
 				}]
-			})
+			},
+				escape_unicode: true
+			)
 		}
 		app.on_did_change(request)
 		assert app.text == change
@@ -471,11 +509,13 @@ fn test_on_did_change_updates_tracked_file() {
 
 	// Open file
 	app.on_did_open(Request{
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	})
 
 	// Verify initial state
@@ -484,14 +524,16 @@ fn test_on_did_change_updates_tracked_file() {
 	// Change file
 	new_content := 'modified content'
 	app.on_did_change(Request{
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document:   TextDocumentIdentifier{
 				uri: uri
 			}
 			content_changes: [ContentChange{
 				text: new_content
 			}]
-		})
+		},
+			escape_unicode: true
+		)
 	})
 
 	// Verify both app.text and open_files are updated
@@ -586,7 +628,7 @@ fn test_operation_at_pos_completion_line_info() {
 	request := Request{
 		id:     1
 		method: 'textDocument/completion'
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
@@ -594,7 +636,9 @@ fn test_operation_at_pos_completion_line_info() {
 				line: 3
 				char: 4
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	}
 
 	response := app.operation_at_pos(.completion, request)
@@ -620,7 +664,7 @@ fn test_operation_at_pos_definition_line_info() {
 	request := Request{
 		id:     2
 		method: 'textDocument/definition'
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
@@ -628,7 +672,9 @@ fn test_operation_at_pos_definition_line_info() {
 				line: 5
 				char: 2
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	}
 
 	response := app.operation_at_pos(.definition, request)
@@ -654,7 +700,7 @@ fn test_operation_at_pos_signature_help_line_info() {
 	request := Request{
 		id:     3
 		method: 'textDocument/signatureHelp'
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
@@ -662,7 +708,9 @@ fn test_operation_at_pos_signature_help_line_info() {
 				line: 5
 				char: 7
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	}
 
 	response := app.operation_at_pos(.signature_help, request)
@@ -690,7 +738,7 @@ fn test_operation_at_pos_preserves_request_id() {
 	for id in test_ids {
 		request := Request{
 			id:     id
-			params: json.encode(Params{
+			params: json2.encode(Params{
 				text_document: TextDocumentIdentifier{
 					uri: uri
 				}
@@ -698,7 +746,9 @@ fn test_operation_at_pos_preserves_request_id() {
 					line: 2
 					char: 0
 				}
-			})
+			},
+				escape_unicode: true
+			)
 		}
 		response := app.operation_at_pos(.completion, request)
 		assert response.id == id
@@ -710,7 +760,7 @@ fn test_json_encode_response() {
 		id:     1
 		result: 'null'
 	}
-	encoded := json.encode(response)
+	encoded := json2.encode(response, escape_unicode: true)
 	assert encoded.contains('"id":1')
 	assert encoded.contains('"jsonrpc":"2.0"')
 }
@@ -734,7 +784,7 @@ fn test_json_encode_capabilities_response() {
 			}
 		}
 	}
-	encoded := json.encode(response)
+	encoded := json2.encode(response, escape_unicode: true)
 	assert encoded.contains('"definitionProvider":true')
 	assert encoded.contains('"completionProvider"')
 	assert encoded.contains('"signatureHelpProvider"')
@@ -759,7 +809,7 @@ fn test_json_encode_completion_response() {
 		id:     2
 		result: details
 	}
-	encoded := json.encode(response)
+	encoded := json2.encode(response, escape_unicode: true)
 	assert encoded.contains('"label":"println"')
 	assert encoded.contains('"label":"print"')
 }
@@ -781,7 +831,7 @@ fn test_json_encode_location_response() {
 			}
 		}
 	}
-	encoded := json.encode(response)
+	encoded := json2.encode(response, escape_unicode: true)
 	assert encoded.contains('"uri":"file:///test/main.v"')
 	assert encoded.contains('"line":10')
 }
@@ -807,7 +857,7 @@ fn test_json_encode_signature_help_response() {
 			active_parameter: 0
 		}
 	}
-	encoded := json.encode(response)
+	encoded := json2.encode(response, escape_unicode: true)
 	assert encoded.contains('"activeSignature":0')
 	assert encoded.contains('"activeParameter":0')
 	assert encoded.contains('"label":"fn test(a int, b string)"')
@@ -836,7 +886,7 @@ fn test_json_encode_notification() {
 			]
 		}
 	}
-	encoded := json.encode(notification)
+	encoded := json2.encode(notification, escape_unicode: true)
 	assert encoded.contains('"method":"textDocument/publishDiagnostics"')
 	assert encoded.contains('"message":"undefined identifier"')
 	assert encoded.contains('"severity":1')
@@ -844,13 +894,13 @@ fn test_json_encode_notification() {
 
 fn test_json_decode_request() {
 	request_json := '{"id":1,"method":"textDocument/completion","jsonrpc":"2.0","params":{"textDocument":{"uri":"file:///test.v"},"position":{"line":5,"character":10}}}'
-	request := json.decode(Request, request_json) or {
+	request := json2.decode[Request](request_json) or {
 		assert false, 'Failed to decode request: ${err}'
 		return
 	}
 	assert request.id == 1
 	assert request.method == 'textDocument/completion'
-	params := json.decode(Params, request.params.str()) or {
+	params := json2.decode[Params](request.params.str()) or {
 		assert false, 'Failed to decode params: ${err}'
 		return
 	}
@@ -860,12 +910,12 @@ fn test_json_decode_request() {
 
 fn test_json_decode_request_with_content_changes() {
 	request_json := '{"id":2,"method":"textDocument/didChange","jsonrpc":"2.0","params":{"textDocument":{"uri":"file:///test.v"},"contentChanges":[{"text":"fn main() {}"}]}}'
-	request := json.decode(Request, request_json) or {
+	request := json2.decode[Request](request_json) or {
 		assert false, 'Failed to decode request: ${err}'
 		return
 	}
 	assert request.method == 'textDocument/didChange'
-	params := json.decode(Params, request.params.str()) or {
+	params := json2.decode[Params](request.params.str()) or {
 		assert false, 'Failed to decode params: ${err}'
 		return
 	}
@@ -875,7 +925,7 @@ fn test_json_decode_request_with_content_changes() {
 
 fn test_json_decode_request_initialize() {
 	request_json := '{"id":0,"method":"initialize","jsonrpc":"2.0","params":{}}'
-	request := json.decode(Request, request_json) or {
+	request := json2.decode[Request](request_json) or {
 		assert false, 'Failed to decode request: ${err}'
 		return
 	}
@@ -885,13 +935,13 @@ fn test_json_decode_request_initialize() {
 
 fn test_json_decode_request_definition() {
 	request_json := '{"id":5,"method":"textDocument/definition","jsonrpc":"2.0","params":{"textDocument":{"uri":"file:///test.v"},"position":{"line":10,"character":5}}}'
-	request := json.decode(Request, request_json) or {
+	request := json2.decode[Request](request_json) or {
 		assert false, 'Failed to decode request: ${err}'
 		return
 	}
 	assert request.id == 5
 	assert request.method == 'textDocument/definition'
-	params := json.decode(Params, request.params.str()) or {
+	params := json2.decode[Params](request.params.str()) or {
 		assert false, 'Failed to decode params: ${err}'
 		return
 	}
@@ -901,7 +951,7 @@ fn test_json_decode_request_definition() {
 
 fn test_json_decode_request_params_malformed_returns_error() {
 	malformed_params := '{"textDocument":{"uri":"file:///test.v"},"position":{"line":5,"character":}}'
-	if _ := json.decode(Params, malformed_params) {
+	if _ := json2.decode[Params](malformed_params) {
 		assert false, 'Expected malformed params JSON to fail decoding'
 	} else {
 		assert true
@@ -1192,11 +1242,13 @@ fn test_multifile_tracking() {
 		must_write_file(path, 'module main\n\nfn ${file}() {}')
 		uri := path_to_uri(path)
 		app.on_did_open(Request{
-			params: json.encode(Params{
+			params: json2.encode(Params{
 				text_document: TextDocumentIdentifier{
 					uri: uri
 				}
-			})
+			},
+				escape_unicode: true
+			)
 		})
 	}
 
@@ -1223,31 +1275,37 @@ fn test_multifile_change_single_file() {
 
 	// Open both files
 	app.on_did_open(Request{
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: main_uri
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	})
 	app.on_did_open(Request{
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: utils_uri
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	})
 
 	// Change only main.v
 	new_content := 'module main\n\nfn main() { changed }'
 	app.on_did_change(Request{
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document:   TextDocumentIdentifier{
 				uri: main_uri
 			}
 			content_changes: [ContentChange{
 				text: new_content
 			}]
-		})
+		},
+			escape_unicode: true
+		)
 	})
 
 	// Verify only main.v was updated
@@ -1276,11 +1334,13 @@ fn test_handle_formatting_formats_code() {
 		id:      1
 		method:  'textDocument/formatting'
 		jsonrpc: '2.0'
-		params:  json.encode(Params{
+		params:  json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	}
 
 	response := app.handle_formatting(request)
@@ -1321,11 +1381,13 @@ fn test_handle_formatting_already_formatted() {
 		id:      2
 		method:  'textDocument/formatting'
 		jsonrpc: '2.0'
-		params:  json.encode(Params{
+		params:  json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	}
 
 	response := app.handle_formatting(request)
@@ -1352,11 +1414,13 @@ fn test_handle_formatting_nonexistent_file() {
 		id:      3
 		method:  'textDocument/formatting'
 		jsonrpc: '2.0'
-		params:  json.encode(Params{
+		params:  json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	}
 
 	response := app.handle_formatting(request)
@@ -1390,11 +1454,13 @@ fn test_handle_formatting_uses_open_file_content() {
 		id:      4
 		method:  'textDocument/formatting'
 		jsonrpc: '2.0'
-		params:  json.encode(Params{
+		params:  json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	}
 
 	response := app.handle_formatting(request)
@@ -1428,7 +1494,7 @@ fn test_find_references_returns_null_when_no_symbol_at_position() {
 	resp := app.find_references(Request{
 		id:     901
 		method: 'textDocument/references'
-		params: json.encode(ReferenceParams{
+		params: json2.encode(ReferenceParams{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
@@ -1439,7 +1505,9 @@ fn test_find_references_returns_null_when_no_symbol_at_position() {
 			context:       ReferenceContext{
 				include_declaration: true
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	})
 
 	assert resp.id == 901
@@ -1465,7 +1533,7 @@ fn test_handle_rename_returns_null_when_no_symbol_at_position() {
 	resp := app.handle_rename(Request{
 		id:     902
 		method: 'textDocument/rename'
-		params: json.encode(RenameParams{
+		params: json2.encode(RenameParams{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
@@ -1474,7 +1542,9 @@ fn test_handle_rename_returns_null_when_no_symbol_at_position() {
 				char: 0
 			}
 			new_name:      'renamed'
-		})
+		},
+			escape_unicode: true
+		)
 	})
 
 	assert resp.id == 902
@@ -1735,11 +1805,13 @@ fn test_handle_document_symbols_empty_file() {
 	request := Request{
 		id:     10
 		method: 'textDocument/documentSymbol'
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	}
 
 	response := app.handle_document_symbols(request)
@@ -1761,11 +1833,13 @@ fn test_handle_document_symbols_no_tracked_file() {
 	request := Request{
 		id:     11
 		method: 'textDocument/documentSymbol'
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: 'file:///tmp/not_tracked.v'
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	}
 
 	response := app.handle_document_symbols(request)
@@ -1789,11 +1863,13 @@ fn test_handle_document_symbols_returns_correct_symbols() {
 	request := Request{
 		id:     12
 		method: 'textDocument/documentSymbol'
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	}
 
 	response := app.handle_document_symbols(request)
@@ -1824,11 +1900,13 @@ fn test_handle_document_symbols_preserves_request_id() {
 		request := Request{
 			id:     id
 			method: 'textDocument/documentSymbol'
-			params: json.encode(Params{
+			params: json2.encode(Params{
 				text_document: TextDocumentIdentifier{
 					uri: uri
 				}
-			})
+			},
+				escape_unicode: true
+			)
 		}
 		response := app.handle_document_symbols(request)
 		assert response.id == id
@@ -1860,11 +1938,13 @@ const my_const = 42
 	request := Request{
 		id:     20
 		method: 'textDocument/documentSymbol'
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	}
 
 	response := app.handle_document_symbols(request)
@@ -2217,7 +2297,7 @@ obj := MyStruct{}
 	request := Request{
 		id:     30
 		method: 'textDocument/inlayHint'
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
@@ -2231,7 +2311,9 @@ obj := MyStruct{}
 					char: 0
 				}
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	}
 
 	response := app.handle_inlay_hints(request)
@@ -2266,7 +2348,7 @@ x := 99
 	request := Request{
 		id:     31
 		method: 'textDocument/inlayHint'
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
@@ -2280,7 +2362,9 @@ x := 99
 					char: 0
 				}
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	}
 
 	response := app.handle_inlay_hints(request)
@@ -2311,7 +2395,7 @@ fn test_handle_inlay_hints_empty_file() {
 	request := Request{
 		id:     32
 		method: 'textDocument/inlayHint'
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
@@ -2325,7 +2409,9 @@ fn test_handle_inlay_hints_empty_file() {
 					char: 0
 				}
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	}
 
 	response := app.handle_inlay_hints(request)
@@ -2352,7 +2438,7 @@ mut count := 0
 	request := Request{
 		id:     33
 		method: 'textDocument/inlayHint'
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
@@ -2366,7 +2452,9 @@ mut count := 0
 					char: 0
 				}
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	}
 
 	response := app.handle_inlay_hints(request)
@@ -2399,7 +2487,7 @@ const is_debug = false
 	request := Request{
 		id:     34
 		method: 'textDocument/inlayHint'
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
@@ -2413,7 +2501,9 @@ const is_debug = false
 					char: 0
 				}
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	}
 
 	response := app.handle_inlay_hints(request)
@@ -2452,7 +2542,7 @@ enabled   = true
 	request := Request{
 		id:     35
 		method: 'textDocument/inlayHint'
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
@@ -2466,7 +2556,9 @@ enabled   = true
 					char: 0
 				}
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	}
 
 	response := app.handle_inlay_hints(request)
@@ -2501,7 +2593,7 @@ fn test_handle_inlay_hints_local_fn_call() {
 	request := Request{
 		id:     40
 		method: 'textDocument/inlayHint'
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
@@ -2515,7 +2607,9 @@ fn test_handle_inlay_hints_local_fn_call() {
 					char: 0
 				}
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	}
 	response := app.handle_inlay_hints(request)
 	if response.result is []InlayHint {
@@ -2544,7 +2638,7 @@ fn test_handle_inlay_hints_error_result_fn() {
 	request := Request{
 		id:     41
 		method: 'textDocument/inlayHint'
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
@@ -2558,7 +2652,9 @@ fn test_handle_inlay_hints_error_result_fn() {
 					char: 0
 				}
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	}
 	response := app.handle_inlay_hints(request)
 	if response.result is []InlayHint {
@@ -2592,7 +2688,7 @@ greeting := get_greeting()
 	request := Request{
 		id:     50
 		method: 'textDocument/inlayHint'
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
@@ -2606,7 +2702,9 @@ greeting := get_greeting()
 					char: 0
 				}
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	}
 	response := app.handle_inlay_hints(request)
 	if response.result is []InlayHint {
@@ -3061,7 +3159,7 @@ fn test_operation_at_pos_completion_includes_current_file_fns() {
 	request := Request{
 		id:     1
 		method: 'textDocument/completion'
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
@@ -3069,7 +3167,9 @@ fn test_operation_at_pos_completion_includes_current_file_fns() {
 				line: 3
 				char: 4
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	}
 
 	response := app.operation_at_pos(.completion, request)
@@ -3106,7 +3206,7 @@ fn test_operation_at_pos_dot_completion_includes_imported_module_members() {
 	response := app.operation_at_pos(.completion, Request{
 		id:     9001
 		method: 'textDocument/completion'
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
@@ -3114,7 +3214,9 @@ fn test_operation_at_pos_dot_completion_includes_imported_module_members() {
 				line: 5
 				char: 8
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	})
 
 	assert response.result is CompletionList
@@ -3147,7 +3249,7 @@ fn test_operation_at_pos_dot_completion_includes_aliased_import_module_members()
 	response := app.operation_at_pos(.completion, Request{
 		id:     9002
 		method: 'textDocument/completion'
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
@@ -3155,7 +3257,9 @@ fn test_operation_at_pos_dot_completion_includes_aliased_import_module_members()
 				line: 5
 				char: 4
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	})
 
 	assert response.result is CompletionList
@@ -3176,11 +3280,13 @@ fn test_semantic_tokens_returns_data_for_known_content() {
 	resp := app.handle_semantic_tokens(Request{
 		id:     800
 		method: 'textDocument/semanticTokens/full'
-		params: json.encode(SemanticTokensParams{
+		params: json2.encode(SemanticTokensParams{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	})
 
 	assert resp.id == 800
@@ -3201,11 +3307,13 @@ fn test_semantic_tokens_returns_null_for_empty_file() {
 	resp := app.handle_semantic_tokens(Request{
 		id:     801
 		method: 'textDocument/semanticTokens/full'
-		params: json.encode(SemanticTokensParams{
+		params: json2.encode(SemanticTokensParams{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	})
 
 	assert resp.id == 801
@@ -3244,11 +3352,13 @@ fn test_code_lens_returns_run_lens_for_main() {
 	resp := app.handle_code_lens(Request{
 		id:     810
 		method: 'textDocument/codeLens'
-		params: json.encode(CodeLensParams{
+		params: json2.encode(CodeLensParams{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	})
 
 	assert resp.id == 810
@@ -3269,11 +3379,13 @@ fn test_code_lens_returns_test_lens_for_test_fn() {
 	resp := app.handle_code_lens(Request{
 		id:     811
 		method: 'textDocument/codeLens'
-		params: json.encode(CodeLensParams{
+		params: json2.encode(CodeLensParams{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	})
 
 	assert resp.id == 811
@@ -3308,7 +3420,7 @@ fn test_code_lens_resolve_returns_same_lens() {
 	resp := app.handle_code_lens_resolve(Request{
 		id:     812
 		method: 'codeLens/resolve'
-		params: json.encode(lens)
+		params: json2.encode(lens, escape_unicode: true)
 	})
 
 	assert resp.id == 812
@@ -3328,9 +3440,11 @@ fn test_execute_command_returns_null_result() {
 	resp := app.handle_execute_command(Request{
 		id:     820
 		method: 'workspace/executeCommand'
-		params: json.encode(ExecuteCommandParams{
+		params: json2.encode(ExecuteCommandParams{
 			command: 'vls.runFile'
-		})
+		},
+			escape_unicode: true
+		)
 	})
 
 	assert resp.id == 820
@@ -3347,9 +3461,11 @@ fn test_execute_command_unknown_still_returns_null() {
 	resp := app.handle_execute_command(Request{
 		id:     821
 		method: 'workspace/executeCommand'
-		params: json.encode(ExecuteCommandParams{
+		params: json2.encode(ExecuteCommandParams{
 			command: 'unknownCommand'
-		})
+		},
+			escape_unicode: true
+		)
 	})
 
 	assert resp.id == 821
@@ -3371,7 +3487,7 @@ fn test_inline_value_returns_values_for_simple_assignment() {
 	resp := app.handle_inline_value(Request{
 		id:     830
 		method: 'textDocument/inlineValue'
-		params: json.encode(InlineValueParams{
+		params: json2.encode(InlineValueParams{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
@@ -3385,7 +3501,9 @@ fn test_inline_value_returns_values_for_simple_assignment() {
 					char: 0
 				}
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	})
 
 	assert resp.id == 830
@@ -3406,7 +3524,7 @@ fn test_inline_value_returns_empty_for_no_assignments() {
 	resp := app.handle_inline_value(Request{
 		id:     831
 		method: 'textDocument/inlineValue'
-		params: json.encode(InlineValueParams{
+		params: json2.encode(InlineValueParams{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
@@ -3420,7 +3538,9 @@ fn test_inline_value_returns_empty_for_no_assignments() {
 					char: 0
 				}
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	})
 
 	assert resp.id == 831
@@ -3444,7 +3564,7 @@ fn test_linked_editing_range_returns_ranges_for_identifier() {
 	resp := app.handle_linked_editing_range(Request{
 		id:     840
 		method: 'textDocument/linkedEditingRange'
-		params: json.encode(TextDocumentPositionParams{
+		params: json2.encode(TextDocumentPositionParams{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
@@ -3452,7 +3572,9 @@ fn test_linked_editing_range_returns_ranges_for_identifier() {
 				line: 3
 				char: 2
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	})
 
 	assert resp.id == 840
@@ -3474,7 +3596,7 @@ fn test_linked_editing_range_returns_null_when_not_on_identifier() {
 	resp := app.handle_linked_editing_range(Request{
 		id:     841
 		method: 'textDocument/linkedEditingRange'
-		params: json.encode(TextDocumentPositionParams{
+		params: json2.encode(TextDocumentPositionParams{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
@@ -3482,7 +3604,9 @@ fn test_linked_editing_range_returns_null_when_not_on_identifier() {
 				line: 1
 				char: 0
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	})
 
 	assert resp.id == 841
@@ -3504,7 +3628,7 @@ fn test_selection_range_returns_one_entry_per_position() {
 	resp := app.handle_selection_range(Request{
 		id:     850
 		method: 'textDocument/selectionRange'
-		params: json.encode(SelectionRangeParams{
+		params: json2.encode(SelectionRangeParams{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
@@ -3515,7 +3639,9 @@ fn test_selection_range_returns_one_entry_per_position() {
 				line: 3
 				char: 7
 			}]
-		})
+		},
+			escape_unicode: true
+		)
 	})
 
 	assert resp.id == 850
@@ -3536,7 +3662,7 @@ fn test_selection_range_word_range_has_parent_line_range() {
 	resp := app.handle_selection_range(Request{
 		id:     851
 		method: 'textDocument/selectionRange'
-		params: json.encode(SelectionRangeParams{
+		params: json2.encode(SelectionRangeParams{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
@@ -3544,7 +3670,9 @@ fn test_selection_range_word_range_has_parent_line_range() {
 				line: 3
 				char: 2
 			}]
-		})
+		},
+			escape_unicode: true
+		)
 	})
 
 	assert resp.result is []SelectionRange
@@ -3568,7 +3696,7 @@ fn test_on_type_formatting_returns_empty_edits() {
 	resp := app.handle_on_type_formatting(Request{
 		id:     860
 		method: 'textDocument/onTypeFormatting'
-		params: json.encode(OnTypeFormattingParams{
+		params: json2.encode(OnTypeFormattingParams{
 			text_document: TextDocumentIdentifier{
 				uri: 'file:///tmp/fmt.v'
 			}
@@ -3577,7 +3705,9 @@ fn test_on_type_formatting_returns_empty_edits() {
 				char: 0
 			}
 			ch:            '}'
-		})
+		},
+			escape_unicode: true
+		)
 	})
 
 	assert resp.id == 860
@@ -3606,7 +3736,7 @@ fn test_call_hierarchy_outgoing_returns_callees() {
 	resp := app.handle_call_hierarchy_outgoing(Request{
 		id:     870
 		method: 'callHierarchy/outgoingCalls'
-		params: json.encode(CallHierarchyOutgoingCallsParams{
+		params: json2.encode(CallHierarchyOutgoingCallsParams{
 			item: CallHierarchyItem{
 				name:            'main'
 				kind:            sym_kind_function
@@ -3632,7 +3762,9 @@ fn test_call_hierarchy_outgoing_returns_callees() {
 					}
 				}
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	})
 
 	assert resp.id == 870
@@ -3659,7 +3791,7 @@ fn test_call_hierarchy_incoming_returns_callers() {
 	resp := app.handle_call_hierarchy_incoming(Request{
 		id:     871
 		method: 'callHierarchy/incomingCalls'
-		params: json.encode(CallHierarchyIncomingCallsParams{
+		params: json2.encode(CallHierarchyIncomingCallsParams{
 			item: CallHierarchyItem{
 				name:            'helper'
 				kind:            sym_kind_function
@@ -3685,7 +3817,9 @@ fn test_call_hierarchy_incoming_returns_callers() {
 					}
 				}
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	})
 
 	assert resp.id == 871
@@ -3713,7 +3847,7 @@ fn test_organize_imports_refuses_non_contiguous_block() {
 	}
 	resp := app.handle_code_action(Request{
 		id:     1
-		params: json.encode(params)
+		params: json2.encode(params, escape_unicode: true)
 	})
 	assert resp.result is []CodeAction
 	actions := resp.result as []CodeAction
@@ -3738,7 +3872,7 @@ fn test_organize_imports_sorts_contiguous_block() {
 	}
 	resp := app.handle_code_action(Request{
 		id:     2
-		params: json.encode(params)
+		params: json2.encode(params, escape_unicode: true)
 	})
 	assert resp.result is []CodeAction
 	actions := resp.result as []CodeAction

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -651,10 +651,14 @@ fn test_semantic_reference_scan_caps_candidates() {
 	dummy_anchor := Location{
 		uri: uri
 	}
-	locs := app.search_symbol_in_dirs_semantic('foo', dummy_anchor, 0)
-	// Over the cap, every lexical occurrence is returned unverified (no compiler
-	// process is launched), bounding the worst-case cost.
-	assert locs.len == reference_semantic_max_candidates + 5
+	// References (allow_lexical_fallback = true): over the cap, every lexical
+	// occurrence is returned unverified (no compiler process is launched).
+	refs := app.search_symbol_in_dirs_semantic('foo', dummy_anchor, 0, true)
+	assert refs.len == reference_semantic_max_candidates + 5
+	// Rename (allow_lexical_fallback = false): over the cap it refuses (returns
+	// none) rather than emit a scope-unsafe destructive edit.
+	rename_locs := app.search_symbol_in_dirs_semantic('foo', dummy_anchor, 0, false)
+	assert rename_locs.len == 0
 }
 
 fn test_incremental_change_is_valid_rejects_char_past_line() {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -593,6 +593,47 @@ fn test_apply_incremental_change_rejects_reversed_range() {
 	assert updated == content
 }
 
+fn test_incremental_change_is_valid_rejects_lines_past_eof() {
+	// "abc\ndef" has lines 0 and 1 only. A stale client targeting lines beyond
+	// the document must be rejected, not clamped-and-appended at EOF (P0-07).
+	content := 'abc\ndef'
+	past := LSPRange{
+		start: Position{
+			line: 5
+			char: 0
+		}
+		end:   Position{
+			line: 6
+			char: 0
+		}
+	}
+	assert !incremental_change_is_valid(content, past, .utf16)
+	// An end line past EOF is rejected even when the start line is in range.
+	half_past := LSPRange{
+		start: Position{
+			line: 1
+			char: 0
+		}
+		end:   Position{
+			line: 9
+			char: 0
+		}
+	}
+	assert !incremental_change_is_valid(content, half_past, .utf16)
+	// A range fully inside the document is still accepted.
+	ok := LSPRange{
+		start: Position{
+			line: 0
+			char: 1
+		}
+		end:   Position{
+			line: 1
+			char: 2
+		}
+	}
+	assert incremental_change_is_valid(content, ok, .utf16)
+}
+
 fn test_apply_incremental_change_handles_multiline_ranges() {
 	content := 'abc\ndef\nghi'
 	range := LSPRange{
@@ -3899,6 +3940,110 @@ fn test_organize_imports_sorts_contiguous_block() {
 		}
 	}
 	assert found, 'organize imports should be offered for a contiguous import block'
+}
+
+fn test_remove_unknown_import_range_at_eof_without_newline() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	uri := 'file:///tmp/unknown_eof.v'
+	// The unknown import is the final line and the file has NO trailing newline,
+	// so [line+1,0) would be out of bounds. The edit must end at the line's
+	// encoded length instead so clients accept the range (P0-09).
+	app.open_files[uri] = 'module main\nimport foo'
+	diag := LSPDiagnostic{
+		message: 'unknown module `foo`'
+		range:   LSPRange{
+			start: Position{
+				line: 1
+				char: 0
+			}
+			end:   Position{
+				line: 1
+				char: 10
+			}
+		}
+	}
+	params := CodeActionParams{
+		text_document: TextDocumentIdentifier{
+			uri: uri
+		}
+		range:         LSPRange{}
+		context:       CodeActionContext{
+			diagnostics: [diag]
+		}
+	}
+	resp := app.handle_code_action(Request{
+		id:     1
+		params: json2.encode(params, escape_unicode: true)
+	})
+	actions := resp.result as []CodeAction
+	mut found := false
+	for a in actions {
+		if a.title == 'Remove unknown import' {
+			found = true
+			edit := a.edit or { continue }
+			e := edit.changes[uri][0]
+			assert e.range.start.line == 1
+			assert e.range.start.char == 0
+			// Ends at the final line's length, not the nonexistent next line.
+			assert e.range.end.line == 1
+			assert e.range.end.char == 'import foo'.len
+		}
+	}
+	assert found, 'expected a Remove unknown import quick fix'
+}
+
+fn test_remove_unknown_import_range_with_trailing_newline() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	uri := 'file:///tmp/unknown_nl.v'
+	// The import line has a terminator, so the whole line (incl. newline) is
+	// removed by ending at the next line's start.
+	app.open_files[uri] = 'import foo\nmodule main\n'
+	diag := LSPDiagnostic{
+		message: 'unknown module `foo`'
+		range:   LSPRange{
+			start: Position{
+				line: 0
+				char: 0
+			}
+			end:   Position{
+				line: 0
+				char: 10
+			}
+		}
+	}
+	params := CodeActionParams{
+		text_document: TextDocumentIdentifier{
+			uri: uri
+		}
+		range:         LSPRange{}
+		context:       CodeActionContext{
+			diagnostics: [diag]
+		}
+	}
+	resp := app.handle_code_action(Request{
+		id:     1
+		params: json2.encode(params, escape_unicode: true)
+	})
+	actions := resp.result as []CodeAction
+	mut found := false
+	for a in actions {
+		if a.title == 'Remove unknown import' {
+			found = true
+			edit := a.edit or { continue }
+			e := edit.changes[uri][0]
+			assert e.range.start.line == 0
+			assert e.range.start.char == 0
+			assert e.range.end.line == 1
+			assert e.range.end.char == 0
+		}
+	}
+	assert found, 'expected a Remove unknown import quick fix'
 }
 
 fn test_code_action_kind_wanted_respects_only_filter() {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -4421,8 +4421,12 @@ fn test_classify_highlight_kind_read_write() {
 	assert classify_highlight_kind('x += 1', 1) == doc_highlight_write
 	assert classify_highlight_kind('x++', 1) == doc_highlight_write
 	assert classify_highlight_kind('x--', 1) == doc_highlight_write
+	assert classify_highlight_kind('bits <<= 1', 4) == doc_highlight_write
+	assert classify_highlight_kind('bits >>= 1', 4) == doc_highlight_write
 	// Comparisons and uses are reads.
 	assert classify_highlight_kind('x == 1', 1) == doc_highlight_read
+	assert classify_highlight_kind('bits << 1', 4) == doc_highlight_read
+	assert classify_highlight_kind('bits >> 1', 4) == doc_highlight_read
 	assert classify_highlight_kind('foo(x)', 3) == doc_highlight_read
 	assert classify_highlight_kind('return x', 8) == doc_highlight_read
 }

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -1707,6 +1707,53 @@ fn test_get_word_at_position_uses_original_client_uri() {
 	assert app.get_word_at_position(open_uri, 2, 3) == 'authoritative_open_symbol'
 }
 
+fn test_did_close_reindexes_noncanonical_uri_under_disk_uri() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	test_file := os.join_path(app.temp_dir, 'close_alias.v')
+	must_write_file(test_file, 'module main\n\nfn disk_symbol() {}\n')
+	disk_uri := path_to_uri(test_file)
+	open_uri := disk_uri.replace_once('file:///', 'file://localhost/')
+	app.open_files[open_uri] = 'module main\n\nfn open_symbol() {}\n'
+	app.reindex_uri(open_uri)
+	app.occurrences_for(open_uri)
+
+	app.on_did_close(Request{
+		params: json2.encode(DidCloseTextDocumentParams{
+			text_document: TextDocumentIdentifier{
+				uri: open_uri
+			}
+		},
+			escape_unicode: true
+		)
+	})
+
+	assert open_uri !in app.open_files
+	assert open_uri !in app.symbol_index
+	assert open_uri !in app.ref_occurrences
+	assert disk_uri in app.symbol_index
+	assert app.query_workspace_symbols('open_symbol').len == 0
+	assert app.query_workspace_symbols('disk_symbol').len == 1
+
+	app.on_did_change_watched_files(Request{
+		params: json2.encode(DidChangeWatchedFilesParams{
+			changes: [FileEvent{
+				uri:        disk_uri
+				event_type: 2
+			}]
+		})
+	})
+	mut equivalent_entries := 0
+	for indexed_uri, _ in app.symbol_index {
+		if normalized_index_path(uri_to_path(indexed_uri)) == normalized_index_path(test_file) {
+			equivalent_entries++
+		}
+	}
+	assert equivalent_entries == 1
+}
+
 fn test_handle_rename_refuses_incomplete_oversized_sibling_index() {
 	mut app := create_test_app()
 	defer {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -3296,7 +3296,7 @@ fn test_semantic_tokens_returns_data_for_known_content() {
 	assert tokens.data.len > 0
 }
 
-fn test_semantic_tokens_returns_null_for_empty_file() {
+fn test_semantic_tokens_returns_empty_object_for_empty_file() {
 	mut app := create_test_app()
 	defer {
 		cleanup_test_app(app)
@@ -3317,11 +3317,13 @@ fn test_semantic_tokens_returns_null_for_empty_file() {
 	})
 
 	assert resp.id == 801
-	assert resp.result is string
-	assert (resp.result as string) == 'null'
+	// An empty document returns an empty token set, not null (P2-01).
+	assert resp.result is SemanticTokens
+	tokens := resp.result as SemanticTokens
+	assert tokens.data.len == 0
 }
 
-fn test_semantic_tokens_range_returns_null_for_invalid_params() {
+fn test_semantic_tokens_range_returns_empty_for_missing_document() {
 	mut app := create_test_app()
 	defer {
 		cleanup_test_app(app)
@@ -3334,8 +3336,11 @@ fn test_semantic_tokens_range_returns_null_for_invalid_params() {
 	})
 
 	assert resp.id == 802
-	assert resp.result is string
-	assert (resp.result as string) == 'null'
+	// Empty params decode to an empty (untracked) document, which has an empty
+	// token set rather than null (P2-01).
+	assert resp.result is SemanticTokens
+	tokens := resp.result as SemanticTokens
+	assert tokens.data.len == 0
 }
 
 // ── code lens ────────────────────────────────────────────────────────────────

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -2267,7 +2267,7 @@ fn test_find_doc_comment_for_symbol_current_file() {
 	uri := 'file:///tmp/test_greet.v'
 	app.open_files[uri] = content
 	lines := content.split_into_lines()
-	doc := app.find_doc_comment_for_symbol('greet', lines, uri)
+	doc := app.find_doc_comment_for_symbol('greet', lines, uri, '')
 	assert doc == 'greet says hello'
 }
 
@@ -2285,8 +2285,43 @@ fn test_find_doc_comment_for_symbol_other_open_file() {
 	app.open_files[current_uri] = current_content
 	current_lines := current_content.split_into_lines()
 
-	doc := app.find_doc_comment_for_symbol('helper', current_lines, current_uri)
+	doc := app.find_doc_comment_for_symbol('helper', current_lines, current_uri, '')
 	assert doc == 'helper does the thing'
+}
+
+fn test_find_doc_comment_for_qualified_symbol_uses_imported_module() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	project_dir := os.join_path(app.temp_dir, 'hover_import')
+	a_dir := os.join_path(project_dir, 'a')
+	b_dir := os.join_path(project_dir, 'b')
+	must_mkdir_all(a_dir)
+	must_mkdir_all(b_dir)
+	must_write_file(os.join_path(project_dir, 'v.mod'), 'Module {}\n')
+	must_write_file(os.join_path(a_dir, 'a.v'), 'module a\n\n// A foo docs\npub fn foo() {}\n')
+	must_write_file(os.join_path(b_dir, 'b.v'), 'module b\n\n// B foo docs\npub fn foo() {}\n')
+	main_path := os.join_path(project_dir, 'main.v')
+	content := 'module main\n\nimport a\nimport b\n\n// Local foo docs\nfn foo() {}\n\nfn main() {\n\tb.foo()\n}\n'
+	must_write_file(main_path, content)
+	uri := path_to_uri(main_path)
+	app.open_files[uri] = content
+	lines := content.split_into_lines()
+	call_line := lines.index('\tb.foo()')
+	if call_line < 0 {
+		assert false, 'expected qualified call line'
+		return
+	}
+	foo_col := lines[call_line].index('foo') or {
+		assert false, 'expected foo column'
+		return
+	}
+	imported_module := imported_module_at_symbol(lines[call_line], foo_col, content)
+	assert imported_module == 'b'
+
+	doc := app.find_doc_comment_for_symbol('foo', lines, uri, imported_module)
+	assert doc == 'B foo docs'
 }
 
 fn test_find_doc_comment_for_symbol_not_found() {
@@ -2298,7 +2333,7 @@ fn test_find_doc_comment_for_symbol_not_found() {
 	uri := 'file:///tmp/main.v'
 	app.open_files[uri] = content
 	lines := content.split_into_lines()
-	doc := app.find_doc_comment_for_symbol('nonexistent', lines, uri)
+	doc := app.find_doc_comment_for_symbol('nonexistent', lines, uri, '')
 	assert doc == ''
 }
 

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -3390,6 +3390,71 @@ fn test_semantic_tokens_range_returns_empty_for_missing_document() {
 	assert tokens.data.len == 0
 }
 
+fn test_semantic_tokens_range_filters_by_character() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	uri := 'file:///tmp/semrange.v'
+	// Line 0 has two string tokens: `"b"` at column 5 and `"c"` at column 11.
+	app.open_files[uri] = 'a := "b" + "c"\n'
+
+	full_params := json2.encode(SemanticTokensRangeParams{
+		text_document: TextDocumentIdentifier{
+			uri: uri
+		}
+		range:         LSPRange{
+			start: Position{
+				line: 0
+				char: 0
+			}
+			end:   Position{
+				line: 0
+				char: 50
+			}
+		}
+	},
+		escape_unicode: true)
+	full := app.handle_semantic_tokens_range(Request{
+		id:     1
+		params: full_params
+	})
+	ftok := full.result as SemanticTokens
+	// The full-line request includes the token that starts at column 5.
+	assert ftok.data.len >= 5
+	assert ftok.data[0] == 0
+	assert ftok.data[1] == 5
+
+	// Narrow the range to columns [8,50): the column-5 token must be excluded, so
+	// the first returned token starts at or after column 8 (the `"c"` at 11) and
+	// the payload is strictly smaller than the full-line one.
+	narrow_params := json2.encode(SemanticTokensRangeParams{
+		text_document: TextDocumentIdentifier{
+			uri: uri
+		}
+		range:         LSPRange{
+			start: Position{
+				line: 0
+				char: 8
+			}
+			end:   Position{
+				line: 0
+				char: 50
+			}
+		}
+	},
+		escape_unicode: true)
+	narrow := app.handle_semantic_tokens_range(Request{
+		id:     2
+		params: narrow_params
+	})
+	ntok := narrow.result as SemanticTokens
+	assert ntok.data.len >= 5
+	assert ntok.data[0] == 0
+	assert ntok.data[1] >= 8
+	assert ntok.data.len < ftok.data.len
+}
+
 // ── code lens ────────────────────────────────────────────────────────────────
 
 fn test_code_lens_returns_run_lens_for_main() {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -1693,6 +1693,20 @@ fn test_handle_rename_returns_null_when_no_symbol_at_position() {
 	assert (resp.result as string) == 'null'
 }
 
+fn test_get_word_at_position_uses_original_client_uri() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	test_file := os.join_path(app.temp_dir, 'noncanonical_uri.v')
+	must_write_file(test_file, 'module main\n\nfn stale_disk_symbol() {}\n')
+	canonical_uri := path_to_uri(test_file)
+	open_uri := canonical_uri.replace_once('file:///', 'file://localhost/')
+	app.open_files[open_uri] = 'module main\n\nfn authoritative_open_symbol() {}\n'
+
+	assert app.get_word_at_position(open_uri, 2, 3) == 'authoritative_open_symbol'
+}
+
 fn test_handle_rename_refuses_incomplete_oversized_sibling_index() {
 	mut app := create_test_app()
 	defer {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -634,6 +634,48 @@ fn test_incremental_change_is_valid_rejects_lines_past_eof() {
 	assert incremental_change_is_valid(content, ok, .utf16)
 }
 
+fn test_incremental_change_is_valid_rejects_char_past_line() {
+	// Line 0 "abc" has length 3. A character offset past the line end is invalid
+	// even though the line exists: position_to_byte_offset would clamp it to EOL
+	// and the edit would be applied there while the version advances (P0-07).
+	content := 'abc\ndef'
+	past_start := LSPRange{
+		start: Position{
+			line: 0
+			char: 9
+		}
+		end:   Position{
+			line: 1
+			char: 1
+		}
+	}
+	assert !incremental_change_is_valid(content, past_start, .utf16)
+	past_end := LSPRange{
+		start: Position{
+			line: 0
+			char: 1
+		}
+		end:   Position{
+			line: 1
+			char: 9
+		}
+	}
+	assert !incremental_change_is_valid(content, past_end, .utf16)
+	// A character offset exactly at the line's length is the valid end-of-line
+	// insertion point and must be accepted.
+	at_eol := LSPRange{
+		start: Position{
+			line: 0
+			char: 3
+		}
+		end:   Position{
+			line: 0
+			char: 3
+		}
+	}
+	assert incremental_change_is_valid(content, at_eol, .utf16)
+}
+
 fn test_apply_incremental_change_handles_multiline_ranges() {
 	content := 'abc\ndef\nghi'
 	range := LSPRange{

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -651,14 +651,39 @@ fn test_semantic_reference_scan_caps_candidates() {
 	dummy_anchor := Location{
 		uri: uri
 	}
+	scope := app.index_scope_for_uri(uri)
 	// References (allow_lexical_fallback = true): over the cap, every lexical
 	// occurrence is returned unverified (no compiler process is launched).
-	refs := app.search_symbol_in_dirs_semantic('foo', dummy_anchor, 0, true)
+	refs := app.search_symbol_in_dirs_semantic('foo', dummy_anchor, scope, 0, true)
 	assert refs.len == reference_semantic_max_candidates + 5
 	// Rename (allow_lexical_fallback = false): over the cap it refuses (returns
 	// none) rather than emit a scope-unsafe destructive edit.
-	rename_locs := app.search_symbol_in_dirs_semantic('foo', dummy_anchor, 0, false)
+	rename_locs := app.search_symbol_in_dirs_semantic('foo', dummy_anchor, scope, 0, false)
 	assert rename_locs.len == 0
+}
+
+fn test_semantic_candidate_cap_ignores_unrelated_workspace_root() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	current_uri := 'file:///root_a/main.v'
+	app.open_files[current_uri] = 'module main\n\nfn main() { unique() }\n'
+	mut unrelated_content := 'module main\n'
+	for i in 0 .. reference_semantic_max_candidates + 1 {
+		unrelated_content += 'fn unrelated_${i}() { unique() }\n'
+	}
+	app.open_files['file:///root_b/many.v'] = unrelated_content
+	app.ensure_dirs_indexed(app.index_query_dirs())
+
+	current_scope := IndexScope{
+		dir:       '/root_a'
+		recursive: true
+	}
+	candidates := app.collect_semantic_candidates('unique', current_scope)
+
+	assert candidates.len == 1
+	assert candidates[0].uri == current_uri
 }
 
 fn test_incremental_change_is_valid_rejects_char_past_line() {
@@ -1701,6 +1726,7 @@ fn test_handle_rename_refuses_incomplete_oversized_sibling_index() {
 	})
 
 	assert !app.index_is_complete()
+	assert !app.index_is_complete_for_scope(app.index_scope_for_uri(uri))
 	assert resp.result is string
 	assert (resp.result as string) == 'null'
 }

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -4073,3 +4073,20 @@ fn test_on_did_change_invalid_range_does_not_advance_version() {
 	assert app.open_files[uri] == 'module main\n'
 	assert app.open_files_versions[uri] == 1
 }
+
+fn test_merge_vlib_module_fns_caches_per_module() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	mut idx := map[string]string{}
+	// A module with no matching vlib directory caches an empty index so it is
+	// never re-walked on subsequent inlayHint requests.
+	app.merge_vlib_module_fns('no_such_vlib_module_xyz', mut idx)
+	assert 'no_such_vlib_module_xyz' in app.vlib_fn_cache
+	assert app.vlib_fn_cache['no_such_vlib_module_xyz'].len == 0
+	assert idx.len == 0
+	// Second call is served from the cache and still merges nothing new.
+	app.merge_vlib_module_fns('no_such_vlib_module_xyz', mut idx)
+	assert idx.len == 0
+}

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -4419,6 +4419,8 @@ fn test_classify_highlight_kind_read_write() {
 	assert classify_highlight_kind('x := 1', 1) == doc_highlight_write
 	assert classify_highlight_kind('x = 1', 1) == doc_highlight_write
 	assert classify_highlight_kind('x += 1', 1) == doc_highlight_write
+	assert classify_highlight_kind('x++', 1) == doc_highlight_write
+	assert classify_highlight_kind('x--', 1) == doc_highlight_write
 	// Comparisons and uses are reads.
 	assert classify_highlight_kind('x == 1', 1) == doc_highlight_read
 	assert classify_highlight_kind('foo(x)', 3) == doc_highlight_read

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -4464,14 +4464,18 @@ fn test_classify_highlight_kind_read_write() {
 	assert classify_highlight_kind('for item in items {}', 12, 17) == doc_highlight_read
 }
 
-fn test_document_highlight_falls_back_to_lexical_results_over_semantic_cap() {
+fn test_document_highlight_returns_empty_over_semantic_cap() {
 	mut app := create_test_app()
 	defer {
 		cleanup_test_app(app)
 	}
 	uri := 'file:///nonexistent_vls_highlight/main.v'
-	mut content := 'module main\n\nfn main() {\n\tmut item := 0\n'
-	for _ in 0 .. document_highlight_semantic_max_candidates {
+	mut content := 'module main\n\nfn first() {\n\tmut item := 0\n'
+	for _ in 0 .. document_highlight_semantic_max_candidates / 2 {
+		content += '\titem++\n'
+	}
+	content += '}\n\nfn second() {\n\tmut item := 0\n'
+	for _ in 0 .. document_highlight_semantic_max_candidates / 2 {
 		content += '\titem++\n'
 	}
 	content += '}\n'
@@ -4495,8 +4499,7 @@ fn test_document_highlight_falls_back_to_lexical_results_over_semantic_cap() {
 
 	assert response.result is []DocumentHighlight
 	highlights := response.result as []DocumentHighlight
-	assert highlights.len == document_highlight_semantic_max_candidates + 1
-	assert highlights[0].kind == doc_highlight_write
+	assert highlights.len == 0
 }
 
 fn test_on_did_change_invalid_range_does_not_advance_version() {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -553,7 +553,7 @@ fn test_apply_incremental_change_handles_utf8_columns() {
 			char: 2
 		}
 	}
-	updated := apply_incremental_change(content, range, 'X')
+	updated := apply_incremental_change(content, range, 'X', .utf16)
 	// The trailing newline must be preserved: incremental edits are lossless and
 	// must not normalize line endings (P0-07 item 4).
 	assert updated == 'aXz\n'
@@ -572,7 +572,7 @@ fn test_apply_incremental_change_preserves_crlf() {
 			char: 3
 		}
 	}
-	updated := apply_incremental_change(content, range, 'XYZ')
+	updated := apply_incremental_change(content, range, 'XYZ', .utf16)
 	assert updated == 'abc\r\nXYZ\r\nghi\r\n'
 }
 
@@ -589,7 +589,7 @@ fn test_apply_incremental_change_rejects_reversed_range() {
 		}
 	}
 	// A reversed range is invalid; the content must be returned unchanged.
-	updated := apply_incremental_change(content, range, 'X')
+	updated := apply_incremental_change(content, range, 'X', .utf16)
 	assert updated == content
 }
 
@@ -605,7 +605,7 @@ fn test_apply_incremental_change_handles_multiline_ranges() {
 			char: 2
 		}
 	}
-	updated := apply_incremental_change(content, range, '_\n_')
+	updated := apply_incremental_change(content, range, '_\n_', .utf16)
 	assert updated == 'a_\n_f\nghi'
 }
 
@@ -2053,25 +2053,25 @@ fn test_find_declaration_line_not_found() {
 
 fn test_get_word_at_col_middle_of_word() {
 	line := 'fn my_func() {}'
-	word := get_word_at_col(line, 4)
+	word := get_word_at_col(line, 4, .utf16)
 	assert word == 'my_func'
 }
 
 fn test_get_word_at_col_start_of_word() {
 	line := 'fn my_func() {}'
-	word := get_word_at_col(line, 3)
+	word := get_word_at_col(line, 3, .utf16)
 	assert word == 'my_func'
 }
 
 fn test_get_word_at_col_on_space() {
 	line := 'fn my_func() {}'
-	word := get_word_at_col(line, 2)
+	word := get_word_at_col(line, 2, .utf16)
 	assert word == ''
 }
 
 fn test_get_word_at_col_beyond_end() {
 	line := 'fn foo()'
-	word := get_word_at_col(line, 100)
+	word := get_word_at_col(line, 100, .utf16)
 	assert word == ''
 }
 
@@ -3897,4 +3897,117 @@ fn test_code_action_kind_wanted_respects_only_filter() {
 	assert code_action_kind_wanted(['source.organizeImports'], 'source.organizeImports')
 	assert !code_action_kind_wanted(['quickfix'], 'source.organizeImports')
 	assert !code_action_kind_wanted(['source.organizeImports'], 'quickfix')
+}
+
+// --- P0-01: PositionCodec (UTF-16 / UTF-8 / UTF-32) ---
+
+fn test_encoded_col_to_byte_ascii() {
+	line := 'hello'
+	for enc in [PositionEncoding.utf16, .utf8, .utf32] {
+		assert encoded_col_to_byte(line, 0, enc) == 0
+		assert encoded_col_to_byte(line, 3, enc) == 3
+		assert encoded_col_to_byte(line, 5, enc) == 5
+		// Beyond end of line clamps to length.
+		assert encoded_col_to_byte(line, 99, enc) == 5
+	}
+}
+
+fn test_encoded_col_to_byte_bmp() {
+	// 'é' is 2 UTF-8 bytes, 1 code point, 1 UTF-16 unit.
+	line := 'aéb'
+	// utf16 and utf32 agree for BMP.
+	assert encoded_col_to_byte(line, 1, .utf16) == 1
+	assert encoded_col_to_byte(line, 2, .utf16) == 3 // after 'é'
+	assert encoded_col_to_byte(line, 3, .utf16) == 4
+	assert encoded_col_to_byte(line, 2, .utf32) == 3
+	// utf8 treats columns as raw byte offsets.
+	assert encoded_col_to_byte(line, 3, .utf8) == 3
+}
+
+fn test_encoded_col_to_byte_non_bmp() {
+	// '🚀' (U+1F680) is 4 UTF-8 bytes, 1 code point, 2 UTF-16 units.
+	line := 'a🚀b'
+	// UTF-16: a=1 unit, 🚀=2 units, b=1 unit.
+	assert encoded_col_to_byte(line, 1, .utf16) == 1 // after 'a'
+	assert encoded_col_to_byte(line, 2, .utf16) == 1 // inside surrogate pair -> clamp to char start
+	assert encoded_col_to_byte(line, 3, .utf16) == 5 // after '🚀'
+	assert encoded_col_to_byte(line, 4, .utf16) == 6 // after 'b'
+	// UTF-32: 🚀 is a single code point.
+	assert encoded_col_to_byte(line, 2, .utf32) == 5
+	assert encoded_col_to_byte(line, 3, .utf32) == 6
+}
+
+fn test_byte_to_encoded_col_non_bmp() {
+	line := 'a🚀b'
+	assert byte_to_encoded_col(line, 0, .utf16) == 0
+	assert byte_to_encoded_col(line, 1, .utf16) == 1
+	assert byte_to_encoded_col(line, 5, .utf16) == 3 // a(1) + 🚀(2)
+	assert byte_to_encoded_col(line, 6, .utf16) == 4
+	assert byte_to_encoded_col(line, 5, .utf32) == 2 // a(1) + 🚀(1)
+	assert byte_to_encoded_col(line, 5, .utf8) == 5
+}
+
+fn test_position_codec_roundtrip() {
+	for line in ['plain', 'aéb', 'a🚀b', 'éx', '🚀🚀'] {
+		for enc in [PositionEncoding.utf16, .utf8, .utf32] {
+			// Round-trip a byte offset at each character boundary.
+			mut b := 0
+			for b <= line.len {
+				col := byte_to_encoded_col(line, b, enc)
+				back := encoded_col_to_byte(line, col, enc)
+				// Converting back must not exceed the original boundary.
+				assert back <= line.len
+				b++
+			}
+		}
+	}
+}
+
+fn test_combining_mark_counts_as_separate_unit() {
+	// 'e' + U+0301 (combining acute): 3 bytes, 2 code points, 2 UTF-16 units.
+	line := 'éz'
+	assert encoded_col_to_byte(line, 1, .utf16) == 1 // after 'e'
+	assert encoded_col_to_byte(line, 2, .utf16) == 3 // after the combining mark
+	assert byte_to_encoded_col(line, 3, .utf16) == 2
+}
+
+fn test_apply_incremental_change_non_bmp_utf16() {
+	// Replace the 'b' after an emoji using UTF-16 columns.
+	content := 'a🚀b\n'
+	range := LSPRange{
+		start: Position{
+			line: 0
+			char: 3 // after 🚀 in UTF-16 units (a=1, 🚀=2)
+		}
+		end:   Position{
+			line: 0
+			char: 4
+		}
+	}
+	updated := apply_incremental_change(content, range, 'X', .utf16)
+	assert updated == 'a🚀X\n'
+}
+
+fn test_negotiate_position_encoding_prefers_utf8() {
+	params := InitializeParams{
+		capabilities: ClientCapabilities{
+			general: GeneralClientCapabilities{
+				position_encodings: ['utf-16', 'utf-8']
+			}
+		}
+	}
+	assert negotiate_position_encoding(params) == .utf8
+}
+
+fn test_negotiate_position_encoding_defaults_utf16() {
+	// No advertised encodings -> mandatory UTF-16.
+	assert negotiate_position_encoding(InitializeParams{}) == .utf16
+	params := InitializeParams{
+		capabilities: ClientCapabilities{
+			general: GeneralClientCapabilities{
+				position_encodings: ['utf-32']
+			}
+		}
+	}
+	assert negotiate_position_encoding(params) == .utf32
 }

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -4525,6 +4525,18 @@ fn test_classify_highlight_kind_read_write() {
 	assert classify_highlight_kind('for item in items {}', 12, 17) == doc_highlight_read
 }
 
+fn test_document_highlight_candidates_include_string_interpolations() {
+	content := "fn greet(name string) {\n\tprintln('hello \${name} \$name literal_name')\n}\n"
+	lines := content.split_into_lines()
+
+	candidates := collect_document_highlight_candidates(content, lines, 'name', .utf16)
+	assert candidates.len == 3
+	assert candidates[0].line_idx == 0
+	assert candidates[1].line_idx == 1
+	assert candidates[2].line_idx == 1
+	assert collect_document_highlight_candidates(content, lines, 'literal_name', .utf16).len == 0
+}
+
 fn test_document_highlight_returns_empty_over_semantic_cap() {
 	mut app := create_test_app()
 	defer {

--- a/index.v
+++ b/index.v
@@ -122,60 +122,104 @@ struct OccEntry {
 	occ         map[string][]TokenOccurrence
 }
 
+fn add_identifier_occurrence(line_text string, line_idx int, start int, end int, enc PositionEncoding, mut occ map[string][]TokenOccurrence) {
+	if line_text[start] >= `0` && line_text[start] <= `9` {
+		return
+	}
+	name := line_text[start..end]
+	occ[name] << TokenOccurrence{
+		line:       line_idx
+		start_char: byte_to_encoded_col(line_text, start, enc)
+		end_char:   byte_to_encoded_col(line_text, end, enc)
+	}
+}
+
+// scan_string_identifier_occurrences skips literal text while indexing V string
+// interpolation expressions. It returns the byte after the closing quote.
+fn scan_string_identifier_occurrences(line_text string, line_idx int, start int, enc PositionEncoding, mut occ map[string][]TokenOccurrence) int {
+	quote := line_text[start]
+	mut col := start + 1
+	for col < line_text.len {
+		if line_text[col] == `\\` {
+			col += 2
+			continue
+		}
+		if line_text[col] == quote {
+			return col + 1
+		}
+		if line_text[col] == `$` && col + 1 < line_text.len {
+			if line_text[col + 1] == `{` {
+				col =
+					scan_code_identifier_occurrences(line_text, line_idx, col + 2, enc, true, mut occ)
+				continue
+			}
+			if is_ident_char(line_text[col + 1]) && !(line_text[col + 1] >= `0`
+				&& line_text[col + 1] <= `9`) {
+				ident_start := col + 1
+				col = ident_start + 1
+				for col < line_text.len && is_ident_char(line_text[col]) {
+					col++
+				}
+				add_identifier_occurrence(line_text, line_idx, ident_start, col, enc, mut occ)
+				continue
+			}
+		}
+		col++
+	}
+	return col
+}
+
+// scan_code_identifier_occurrences indexes code between `start` and the end of
+// the line, or through the matching `}` for a braced interpolation expression.
+fn scan_code_identifier_occurrences(line_text string, line_idx int, start int, enc PositionEncoding, stop_at_closing_brace bool, mut occ map[string][]TokenOccurrence) int {
+	mut col := start
+	mut brace_depth := 0
+	for col < line_text.len {
+		c := line_text[col]
+		if col + 1 < line_text.len && c == `/` && line_text[col + 1] == `/` {
+			return line_text.len
+		}
+		if c == `"` || c == `'` {
+			col = scan_string_identifier_occurrences(line_text, line_idx, col, enc, mut occ)
+			continue
+		}
+		if c == `{` {
+			brace_depth++
+			col++
+			continue
+		}
+		if c == `}` && stop_at_closing_brace {
+			if brace_depth == 0 {
+				return col + 1
+			}
+			brace_depth--
+			col++
+			continue
+		}
+		if is_ident_char(c) {
+			ident_start := col
+			col++
+			for col < line_text.len && is_ident_char(line_text[col]) {
+				col++
+			}
+			add_identifier_occurrence(line_text, line_idx, ident_start, col, enc, mut occ)
+			continue
+		}
+		col++
+	}
+	return col
+}
+
 // extract_identifier_occurrences returns every identifier occurrence in `content`
-// grouped by name, positioned in `enc` units. Line comments and string literals
-// are skipped (matching the reference scanner), and number literals are ignored.
-// This is the reference-index tokenizer: references/rename read candidate
-// occurrences from here instead of re-walking and re-tokenizing files per request
+// grouped by name, positioned in `enc` units. Line comments and string literal
+// text are skipped, interpolation expressions are scanned, and number literals
+// are ignored. This is the reference-index tokenizer: references/rename read
+// candidates from here instead of re-walking and re-tokenizing files per request
 // (P1-05).
 fn extract_identifier_occurrences(content string, enc PositionEncoding) map[string][]TokenOccurrence {
 	mut occ := map[string][]TokenOccurrence{}
 	for line_idx, line_text in content.split_into_lines() {
-		n := line_text.len
-		mut col := 0
-		for col < n {
-			c := line_text[col]
-			// Skip line comments.
-			if col + 1 < n && c == `/` && line_text[col + 1] == `/` {
-				break
-			}
-			// Skip string literals.
-			if c == `"` || c == `'` {
-				quote := c
-				col++
-				for col < n {
-					if line_text[col] == `\\` {
-						col += 2
-						continue
-					}
-					if line_text[col] == quote {
-						col++
-						break
-					}
-					col++
-				}
-				continue
-			}
-			if is_ident_char(c) {
-				start := col
-				col++
-				for col < n && is_ident_char(line_text[col]) {
-					col++
-				}
-				// Identifiers cannot start with a digit; skip number literals.
-				if line_text[start] >= `0` && line_text[start] <= `9` {
-					continue
-				}
-				name := line_text[start..col]
-				occ[name] << TokenOccurrence{
-					line:       line_idx
-					start_char: byte_to_encoded_col(line_text, start, enc)
-					end_char:   byte_to_encoded_col(line_text, col, enc)
-				}
-				continue
-			}
-			col++
-		}
+		scan_code_identifier_occurrences(line_text, line_idx, 0, enc, false, mut occ)
 	}
 	return occ
 }

--- a/index.v
+++ b/index.v
@@ -208,6 +208,35 @@ fn (mut app App) drop_index_uri(uri string) {
 	app.ref_occurrences.delete(uri)
 }
 
+// normalized_index_path returns a stable filesystem key for matching a path
+// discovered by a directory walk to an already-open document URI. Resolving the
+// real path collapses equivalent URI spellings such as file://localhost/tmp/a.v
+// and file:///tmp/a.v. Windows filesystem paths are case-insensitive.
+fn normalized_index_path(path string) string {
+	mut normalized := os.real_path(path).replace('\\', '/')
+	$if windows {
+		normalized = normalized.to_lower()
+	}
+	return normalized
+}
+
+// open_index_uris_by_path maps normalized filesystem paths to the original URI
+// supplied by the client. Open buffers are authoritative, so index entries and
+// result locations must retain that URI rather than a reconstructed equivalent.
+fn (app &App) open_index_uris_by_path() map[string]string {
+	mut uris := map[string]string{}
+	for uri, _ in app.open_files {
+		uris[normalized_index_path(uri_to_path(uri))] = uri
+	}
+	return uris
+}
+
+// index_uri_for_path returns the client's URI when `path` names an open
+// document, otherwise it constructs the canonical file URI used for disk files.
+fn index_uri_for_path(path string, open_uris_by_path map[string]string) string {
+	return open_uris_by_path[normalized_index_path(path)] or { path_to_uri(path) }
+}
+
 // reindex_uri (re)parses `uri` from its authoritative source, skipping work when
 // the content fingerprint is unchanged. Open buffers are always authoritative.
 // Disk-backed entries obey the same file-size and total-entry limits as workspace
@@ -414,6 +443,7 @@ fn (mut app App) ensure_dirs_indexed(dirs []string) {
 	for uri, _ in app.open_files {
 		app.reindex_uri(uri)
 	}
+	open_uris_by_path := app.open_index_uris_by_path()
 	for dir in dirs {
 		if dir == '' || dir == '/' || !os.is_dir(dir) {
 			continue
@@ -430,7 +460,7 @@ fn (mut app App) ensure_dirs_indexed(dirs []string) {
 		}
 		mut present := map[string]bool{}
 		for f in files {
-			present[path_to_uri(f)] = true
+			present[index_uri_for_path(f, open_uris_by_path)] = true
 		}
 		// Reconcile the existing index against what is actually on disk: drop
 		// entries for non-open files under `dir` that the walk no longer found.
@@ -439,7 +469,7 @@ fn (mut app App) ensure_dirs_indexed(dirs []string) {
 		// partial walk must retain old entries it may simply not have reached.
 		app.reconcile_indexed_dir(dir, present, walk_complete)
 		for f in files {
-			uri := path_to_uri(f)
+			uri := index_uri_for_path(f, open_uris_by_path)
 			if uri in app.open_files {
 				continue
 			}
@@ -476,6 +506,7 @@ fn (mut app App) ensure_dir_shallow_indexed(dir string) {
 	scope := 'shallow:${dir}'
 	app.index_incomplete_scopes.delete(scope)
 	refresh := app.index_dir_needs_refresh(dir)
+	open_uris_by_path := app.open_index_uris_by_path()
 	mut present := map[string]bool{}
 	entries := os.ls(dir) or {
 		app.index_incomplete_scopes[scope] = true
@@ -489,7 +520,7 @@ fn (mut app App) ensure_dir_shallow_indexed(dir string) {
 		if !os.is_file(full) {
 			continue
 		}
-		uri := path_to_uri(full)
+		uri := index_uri_for_path(full, open_uris_by_path)
 		present[uri] = true
 		if uri in app.open_files {
 			continue

--- a/index.v
+++ b/index.v
@@ -573,6 +573,7 @@ fn (mut app App) ensure_dir_shallow_indexed(dir string) {
 	scope := 'shallow:${dir}'
 	app.index_incomplete_scopes.delete(scope)
 	refresh := app.index_dir_needs_refresh(dir)
+	canonical_dir := os.real_path(dir).replace('\\', '/')
 	open_uris_by_path := app.open_index_uris_by_path()
 	mut present := map[string]bool{}
 	mut entries := os.ls(dir) or {
@@ -587,6 +588,13 @@ fn (mut app App) ensure_dir_shallow_indexed(dir string) {
 		}
 		full := os.join_path(dir, entry)
 		if !os.is_file(full) {
+			continue
+		}
+		// os.is_file follows symlinks. Resolve the candidate as well so a
+		// directly contained link cannot pull an external source into this
+		// loose-module scope.
+		real_file := os.real_path(full).replace('\\', '/')
+		if !path_is_within(real_file, canonical_dir) {
 			continue
 		}
 		uri := index_uri_for_path(full, open_uris_by_path)

--- a/index.v
+++ b/index.v
@@ -608,16 +608,33 @@ fn (app &App) find_indexed_doc_in_scope(name string, cur_dir string, scope_root 
 	return ''
 }
 
+// uri_within_any reports whether `uri`'s path lies within any of `dirs`.
+fn uri_within_any(uri string, dirs []string) bool {
+	p := uri_to_path(uri).replace('\\', '/')
+	for d in dirs {
+		if path_is_within(p, d.replace('\\', '/')) {
+			return true
+		}
+	}
+	return false
+}
+
 // find_indexed_fn returns the (uri, symbol) of the first indexed function or
 // method whose simple name matches `name`. `_test.v` declarations are skipped
 // unless `include_tests` is set, so call hierarchy from production code never
 // resolves into a same-named test helper just because of URI ordering; a query
 // originating in a test file passes include_tests so its own helpers resolve.
-fn (app &App) find_indexed_fn(name string, include_tests bool) ?(string, DocumentSymbol) {
+// When `dirs` is non-empty the search is confined to files within those
+// directories, so a same-named function in an unrelated indexed root is not
+// returned (P1-04) — the global index can span multiple workspace roots.
+fn (app &App) find_indexed_fn(name string, include_tests bool, dirs []string) ?(string, DocumentSymbol) {
 	mut uris := app.symbol_index.keys()
 	uris.sort()
 	for uri in uris {
 		if !include_tests && uri.ends_with('_test.v') {
+			continue
+		}
+		if dirs.len > 0 && !uri_within_any(uri, dirs) {
 			continue
 		}
 		entry := app.symbol_index[uri] or { continue }

--- a/index.v
+++ b/index.v
@@ -456,23 +456,21 @@ fn collect_v_files(root string, mut acc []string) bool {
 	return collect_v_files_rec(root, canonical_root, mut acc, mut visited)
 }
 
-// collect_v_files_rec is the recursive worker; `visited` holds the canonical
-// (realpath-resolved) directories already walked, so a symlink cycle cannot
-// cause infinite recursion or double-indexing. `canonical_root` bounds the walk
-// to the workspace: a directory whose resolved path escapes it (e.g. a symlink
-// `external -> /home`) is skipped so an out-of-tree directory cannot pull an
-// unrelated file tree into the index (P1-01).
+// collect_v_files_rec is the recursive worker; `visited` holds canonical
+// directories and files already seen, so symlink cycles and file aliases cannot
+// cause infinite recursion or duplicate index entries. `canonical_root` bounds
+// the walk to the workspace: a resolved path that escapes it is skipped.
 fn collect_v_files_rec(dir string, canonical_root string, mut acc []string, mut visited map[string]bool) bool {
 	if acc.len >= index_max_files {
 		return false
 	}
-	real := os.real_path(dir)
+	real := os.real_path(dir).replace('\\', '/')
 	if real in visited {
 		return true
 	}
 	// Containment: os.real_path resolves symlinks, so a symlinked directory whose
 	// target lies outside the workspace root is rejected here rather than walked.
-	if !path_is_within(real.replace('\\', '/'), canonical_root) {
+	if !path_is_within(real, canonical_root) {
 		return true
 	}
 	visited[real] = true
@@ -494,7 +492,8 @@ fn collect_v_files_rec(dir string, canonical_root string, mut acc []string, mut 
 			// point outside the workspace. Resolve every candidate and retain it
 			// only when its canonical target remains under the canonical root.
 			real_file := os.real_path(full).replace('\\', '/')
-			if path_is_within(real_file, canonical_root) {
+			if path_is_within(real_file, canonical_root) && real_file !in visited {
+				visited[real_file] = true
 				acc << full
 			}
 		}

--- a/index.v
+++ b/index.v
@@ -1,0 +1,244 @@
+// Copyright (c) 2025 Alexander Medvednikov. All rights reserved.
+// Use of this source code is governed by a GPL license that can be found in the LICENSE file.
+module main
+
+import os
+
+// Persistent, incremental symbol index (audit Stage 4).
+//
+// The index parses every project `.v` file once into an IndexEntry and keeps it
+// keyed by document URI. Consumers (workspace/document symbols, hover docs, call
+// hierarchy) query the index instead of re-walking and re-reading the whole
+// workspace on every request. Entries are maintained incrementally: document
+// notifications and file-watcher events invalidate a single URI, which is then
+// re-parsed lazily on the next query. Open documents are always indexed from
+// their in-memory buffer (authoritative), unopened files from disk. A per-entry
+// content fingerprint avoids re-parsing files that have not changed.
+
+// IndexEntry is the parsed symbol information for one file.
+struct IndexEntry {
+	fingerprint int // content.hash(); used to skip re-parsing unchanged files
+	module_name string
+	doc_symbols []DocumentSymbol  // hierarchical symbols (as parse_document_symbols returns)
+	docs        map[string]string // simple symbol name -> leading vdoc comment
+}
+
+// build_index_entry parses `content` into an IndexEntry.
+fn build_index_entry(content string) IndexEntry {
+	lines := content.split_into_lines()
+	doc_syms := parse_document_symbols(content)
+	mut docs := map[string]string{}
+	for sym in doc_syms {
+		// Each symbol's declaration line is range.start.line; read its vdoc.
+		doc := extract_doc_comment(lines, sym.range.start.line)
+		if doc != '' {
+			simple := extract_simple_fn_name(sym.name)
+			if simple != '' && simple !in docs {
+				docs[simple] = doc
+			}
+		}
+	}
+	return IndexEntry{
+		fingerprint: content.hash()
+		module_name: get_module_name(content)
+		doc_symbols: doc_syms
+		docs:        docs
+	}
+}
+
+// index_source_for returns the authoritative content for `uri`: the open buffer
+// when the document is open, otherwise the on-disk file. Returns none when the
+// file is neither open nor readable.
+fn (app &App) index_source_for(uri string) ?string {
+	if content := app.open_files[uri] {
+		return content
+	}
+	return os.read_file(uri_to_path(uri)) or { none }
+}
+
+// reindex_uri (re)parses `uri` from its authoritative source, skipping work when
+// the content fingerprint is unchanged. Removes the entry if the file is gone.
+fn (mut app App) reindex_uri(uri string) {
+	content := app.index_source_for(uri) or {
+		app.symbol_index.delete(uri)
+		return
+	}
+	fp := content.hash()
+	if existing := app.symbol_index[uri] {
+		if existing.fingerprint == fp {
+			return
+		}
+	}
+	app.symbol_index[uri] = build_index_entry(content)
+}
+
+// invalidate_index_uri drops a URI's entry so it is re-parsed on next access.
+fn (mut app App) invalidate_index_uri(uri string) {
+	app.symbol_index.delete(uri)
+}
+
+// Bounds and exclusions for the workspace walk. Without these a stray file
+// opened at a large directory (a home dir, /tmp, or the filesystem root) would
+// pull the entire tree into the index (audit: "unbounded workspace traversal").
+const index_max_files = 20000
+const index_max_file_bytes = 2 * 1024 * 1024
+const index_excluded_dirs = ['.git', '.svn', '.hg', 'node_modules', '.vmodules', 'thirdparty',
+	'_build', 'build', 'target', '.cache']
+
+// find_project_root walks up from `dir` looking for a `v.mod` file and returns
+// the directory that contains it, or '' if none is found before the filesystem
+// root. This models the nearest V project root (audit P1-01).
+fn find_project_root(dir string) string {
+	mut d := dir
+	for d != '' && d != '/' {
+		if os.exists(os.join_path(d, 'v.mod')) {
+			return d
+		}
+		parent := os.dir(d)
+		if parent == d {
+			break
+		}
+		d = parent
+	}
+	return ''
+}
+
+// collect_v_files recursively gathers `.v` files under `root`, skipping hidden
+// and known heavy directories and stopping once `index_max_files` is reached.
+fn collect_v_files(root string, mut acc []string) {
+	if acc.len >= index_max_files {
+		return
+	}
+	entries := os.ls(root) or { return }
+	for entry in entries {
+		if acc.len >= index_max_files {
+			return
+		}
+		full := os.join_path(root, entry)
+		if os.is_dir(full) {
+			if entry.starts_with('.') || entry in index_excluded_dirs {
+				continue
+			}
+			collect_v_files(full, mut acc)
+		} else if entry.ends_with('.v') {
+			acc << full
+		}
+	}
+}
+
+// ensure_dirs_indexed makes sure every open buffer and every `.v` file under the
+// given project `dirs` has an up-to-date index entry. Each dir is walked at most
+// once (tracked in indexed_dirs); already-indexed files are skipped, so only new
+// or changed files are read and parsed rather than the whole workspace.
+fn (mut app App) ensure_dirs_indexed(dirs []string) {
+	// Open buffers are authoritative; keep their entries fresh (cheap fingerprint
+	// check skips unchanged content).
+	for uri, _ in app.open_files {
+		app.reindex_uri(uri)
+	}
+	for dir in dirs {
+		if dir == '' || dir == '/' || dir in app.indexed_dirs || !os.is_dir(dir) {
+			continue
+		}
+		mut files := []string{}
+		collect_v_files(dir, mut files)
+		for f in files {
+			uri := path_to_uri(f)
+			if uri in app.open_files || uri in app.symbol_index {
+				continue
+			}
+			if os.file_size(f) > index_max_file_bytes {
+				continue
+			}
+			content := os.read_file(f) or { continue }
+			app.symbol_index[uri] = build_index_entry(content)
+		}
+		app.indexed_dirs[dir] = true
+	}
+}
+
+// index_query_dirs returns the project directories to index: the configured
+// workspace roots plus the nearest `v.mod` root of each open file. A loose file
+// with no project root contributes only its own (already indexed) buffer, so an
+// arbitrary parent directory is never recursively walked (P1-01).
+fn (app &App) index_query_dirs() []string {
+	mut seen := map[string]bool{}
+	mut dirs := []string{}
+	for root in app.workspace_roots {
+		if root != '' && root != '/' && root !in seen {
+			seen[root] = true
+			dirs << root
+		}
+	}
+	for uri, _ in app.open_files {
+		root := find_project_root(os.dir(uri_to_path(uri)))
+		if root != '' && root != '/' && root !in seen {
+			seen[root] = true
+			dirs << root
+		}
+	}
+	dirs.sort()
+	return dirs
+}
+
+// query_workspace_symbols returns all indexed symbols whose name contains
+// `query` (case-insensitive; empty matches all), including struct fields and
+// enum members as `Parent.child`. The index must already be populated.
+fn (app &App) query_workspace_symbols(query string) []WorkspaceSymbol {
+	q := query.to_lower()
+	mut results := []WorkspaceSymbol{}
+	mut seen := map[string]bool{}
+	mut uris := app.symbol_index.keys()
+	uris.sort()
+	for uri in uris {
+		entry := app.symbol_index[uri] or { continue }
+		for sym in entry.doc_symbols {
+			if q == '' || sym.name.to_lower().contains(q) {
+				add_workspace_symbol(mut results, mut seen, sym.name, sym.kind, uri,
+					sym.selection_range)
+			}
+			for child in sym.children {
+				if q == '' || child.name.to_lower().contains(q) {
+					add_workspace_symbol(mut results, mut seen, '${sym.name}.${child.name}',
+						child.kind, uri, child.selection_range)
+				}
+			}
+		}
+	}
+	return results
+}
+
+// find_indexed_doc returns the vdoc comment for the first indexed declaration
+// whose simple name matches `name`, or '' when none is found.
+fn (app &App) find_indexed_doc(name string) string {
+	mut uris := app.symbol_index.keys()
+	uris.sort()
+	for uri in uris {
+		entry := app.symbol_index[uri] or { continue }
+		if doc := entry.docs[name] {
+			if doc != '' {
+				return doc
+			}
+		}
+	}
+	return ''
+}
+
+// find_indexed_fn returns the (uri, symbol) of the first indexed function or
+// method whose simple name matches `name`.
+fn (app &App) find_indexed_fn(name string) ?(string, DocumentSymbol) {
+	mut uris := app.symbol_index.keys()
+	uris.sort()
+	for uri in uris {
+		entry := app.symbol_index[uri] or { continue }
+		for sym in entry.doc_symbols {
+			if sym.kind != sym_kind_function && sym.kind != sym_kind_method {
+				continue
+			}
+			if extract_simple_fn_name(sym.name) == name {
+				return uri, sym
+			}
+		}
+	}
+	return none
+}

--- a/index.v
+++ b/index.v
@@ -122,6 +122,11 @@ struct OccEntry {
 	occ         map[string][]TokenOccurrence
 }
 
+struct OccurrenceScanState {
+mut:
+	in_block_comment bool
+}
+
 fn add_identifier_occurrence(line_text string, line_idx int, start int, end int, enc PositionEncoding, mut occ map[string][]TokenOccurrence) {
 	if line_text[start] >= `0` && line_text[start] <= `9` {
 		return
@@ -136,7 +141,7 @@ fn add_identifier_occurrence(line_text string, line_idx int, start int, end int,
 
 // scan_string_identifier_occurrences skips literal text while indexing V string
 // interpolation expressions. It returns the byte after the closing quote.
-fn scan_string_identifier_occurrences(line_text string, line_idx int, start int, enc PositionEncoding, mut occ map[string][]TokenOccurrence) int {
+fn scan_string_identifier_occurrences(line_text string, line_idx int, start int, enc PositionEncoding, mut state OccurrenceScanState, mut occ map[string][]TokenOccurrence) int {
 	quote := line_text[start]
 	mut col := start + 1
 	for col < line_text.len {
@@ -149,8 +154,8 @@ fn scan_string_identifier_occurrences(line_text string, line_idx int, start int,
 		}
 		if line_text[col] == `$` && col + 1 < line_text.len {
 			if line_text[col + 1] == `{` {
-				col =
-					scan_code_identifier_occurrences(line_text, line_idx, col + 2, enc, true, mut occ)
+				col = scan_code_identifier_occurrences(line_text, line_idx, col + 2, enc, true, mut
+					state, mut occ)
 				continue
 			}
 			if is_ident_char(line_text[col + 1]) && !(line_text[col + 1] >= `0`
@@ -171,16 +176,31 @@ fn scan_string_identifier_occurrences(line_text string, line_idx int, start int,
 
 // scan_code_identifier_occurrences indexes code between `start` and the end of
 // the line, or through the matching `}` for a braced interpolation expression.
-fn scan_code_identifier_occurrences(line_text string, line_idx int, start int, enc PositionEncoding, stop_at_closing_brace bool, mut occ map[string][]TokenOccurrence) int {
+fn scan_code_identifier_occurrences(line_text string, line_idx int, start int, enc PositionEncoding, stop_at_closing_brace bool, mut state OccurrenceScanState, mut occ map[string][]TokenOccurrence) int {
 	mut col := start
 	mut brace_depth := 0
 	for col < line_text.len {
 		c := line_text[col]
+		if state.in_block_comment {
+			if col + 1 < line_text.len && c == `*` && line_text[col + 1] == `/` {
+				state.in_block_comment = false
+				col += 2
+				continue
+			}
+			col++
+			continue
+		}
 		if col + 1 < line_text.len && c == `/` && line_text[col + 1] == `/` {
 			return line_text.len
 		}
+		if col + 1 < line_text.len && c == `/` && line_text[col + 1] == `*` {
+			state.in_block_comment = true
+			col += 2
+			continue
+		}
 		if c == `"` || c == `'` {
-			col = scan_string_identifier_occurrences(line_text, line_idx, col, enc, mut occ)
+			col =
+				scan_string_identifier_occurrences(line_text, line_idx, col, enc, mut state, mut occ)
 			continue
 		}
 		if c == `{` {
@@ -218,8 +238,9 @@ fn scan_code_identifier_occurrences(line_text string, line_idx int, start int, e
 // (P1-05).
 fn extract_identifier_occurrences(content string, enc PositionEncoding) map[string][]TokenOccurrence {
 	mut occ := map[string][]TokenOccurrence{}
+	mut state := OccurrenceScanState{}
 	for line_idx, line_text in content.split_into_lines() {
-		scan_code_identifier_occurrences(line_text, line_idx, 0, enc, false, mut occ)
+		scan_code_identifier_occurrences(line_text, line_idx, 0, enc, false, mut state, mut occ)
 	}
 	return occ
 }

--- a/index.v
+++ b/index.v
@@ -274,18 +274,27 @@ fn find_project_root(dir string) string {
 // and known heavy directories and stopping once `index_max_files` is reached.
 fn collect_v_files(root string, mut acc []string) {
 	mut visited := map[string]bool{}
-	collect_v_files_rec(root, mut acc, mut visited)
+	canonical_root := os.real_path(root).replace('\\', '/')
+	collect_v_files_rec(root, canonical_root, mut acc, mut visited)
 }
 
 // collect_v_files_rec is the recursive worker; `visited` holds the canonical
 // (realpath-resolved) directories already walked, so a symlink cycle cannot
-// cause infinite recursion or double-indexing.
-fn collect_v_files_rec(dir string, mut acc []string, mut visited map[string]bool) {
+// cause infinite recursion or double-indexing. `canonical_root` bounds the walk
+// to the workspace: a directory whose resolved path escapes it (e.g. a symlink
+// `external -> /home`) is skipped so an out-of-tree directory cannot pull an
+// unrelated file tree into the index (P1-01).
+fn collect_v_files_rec(dir string, canonical_root string, mut acc []string, mut visited map[string]bool) {
 	if acc.len >= index_max_files {
 		return
 	}
 	real := os.real_path(dir)
 	if real in visited {
+		return
+	}
+	// Containment: os.real_path resolves symlinks, so a symlinked directory whose
+	// target lies outside the workspace root is rejected here rather than walked.
+	if !path_is_within(real.replace('\\', '/'), canonical_root) {
 		return
 	}
 	visited[real] = true
@@ -299,7 +308,7 @@ fn collect_v_files_rec(dir string, mut acc []string, mut visited map[string]bool
 			if entry.starts_with('.') || entry in index_excluded_dirs {
 				continue
 			}
-			collect_v_files_rec(full, mut acc, mut visited)
+			collect_v_files_rec(full, canonical_root, mut acc, mut visited)
 		} else if entry.ends_with('.v') {
 			acc << full
 		}

--- a/index.v
+++ b/index.v
@@ -351,7 +351,13 @@ fn collect_v_files_rec(dir string, canonical_root string, mut acc []string, mut 
 				return false
 			}
 		} else if entry.ends_with('.v') {
-			acc << full
+			// Directory containment is not enough: an in-tree file symlink can
+			// point outside the workspace. Resolve every candidate and retain it
+			// only when its canonical target remains under the canonical root.
+			real_file := os.real_path(full).replace('\\', '/')
+			if path_is_within(real_file, canonical_root) {
+				acc << full
+			}
 		}
 	}
 	return true

--- a/index.v
+++ b/index.v
@@ -377,6 +377,25 @@ fn (app &App) index_dir_needs_refresh(dir string) bool {
 	return time.now().unix_milli() - last > index_refresh_interval_ms
 }
 
+// reconcile_indexed_dir removes stale entries only after a complete recursive
+// walk. A partial walk cannot distinguish deleted files from files it did not
+// reach, so reconciling it would incorrectly discard valid indexed symbols.
+fn (mut app App) reconcile_indexed_dir(dir string, present map[string]bool, walk_complete bool) {
+	if !walk_complete {
+		return
+	}
+	dir_norm := dir.replace('\\', '/')
+	for uri in app.symbol_index.keys() {
+		if uri in app.open_files || uri in present {
+			continue
+		}
+		if path_is_within(uri_to_path(uri).replace('\\', '/'), dir_norm) {
+			app.symbol_index.delete(uri)
+			app.ref_occurrences.delete(uri)
+		}
+	}
+}
+
 // ensure_dirs_indexed makes sure every open buffer and every `.v` file under the
 // given project `dirs` has an up-to-date index entry. A dir is walked once and
 // then, when no client file watchers are available, re-walked on a throttled
@@ -399,7 +418,8 @@ fn (mut app App) ensure_dirs_indexed(dirs []string) {
 		mut files := []string{}
 		scope := 'recursive:${dir}'
 		app.index_incomplete_scopes.delete(scope)
-		if !collect_v_files(dir, mut files) {
+		walk_complete := collect_v_files(dir, mut files)
+		if !walk_complete {
 			app.index_incomplete_scopes[scope] = true
 		}
 		mut present := map[string]bool{}
@@ -409,17 +429,9 @@ fn (mut app App) ensure_dirs_indexed(dirs []string) {
 		// Reconcile the existing index against what is actually on disk: drop
 		// entries for non-open files under `dir` that the walk no longer found.
 		// Without client watchers there is no delete notification, so a removed
-		// unopened file would otherwise linger in symbol/hover/call results.
-		dir_norm := dir.replace('\\', '/')
-		for uri in app.symbol_index.keys() {
-			if uri in app.open_files || uri in present {
-				continue
-			}
-			if path_is_within(uri_to_path(uri).replace('\\', '/'), dir_norm) {
-				app.symbol_index.delete(uri)
-				app.ref_occurrences.delete(uri)
-			}
-		}
+		// unopened file would otherwise linger in symbol/hover/call results. A
+		// partial walk must retain old entries it may simply not have reached.
+		app.reconcile_indexed_dir(dir, present, walk_complete)
 		for f in files {
 			uri := path_to_uri(f)
 			if uri in app.open_files {
@@ -637,17 +649,29 @@ fn (app &App) query_workspace_symbols(query string) []WorkspaceSymbol {
 	return results
 }
 
-// find_indexed_doc_in_scope returns the vdoc comment for `name`, preferring a
-// declaration in the current module directory `cur_dir` and otherwise limited to
-// the current project subtree `scope_root`. Scoping the search avoids returning a
-// same-named symbol's comment from an unrelated project (a multi-root workspace)
-// or another module elsewhere in the global index, which hover would otherwise
-// append to an imported symbol's documentation (P1-08). A loose file passes an
-// empty `scope_root`, restricting the lookup to its own directory.
-fn (app &App) find_indexed_doc_in_scope(name string, cur_dir string, scope_root string) string {
+// find_indexed_doc_in_scope returns the vdoc comment for `name`. When
+// `preferred_dir` is set (for a qualified imported symbol), only that module
+// directory is searched. Otherwise the current module is preferred and the
+// fallback is limited to `scope_root`.
+fn (app &App) find_indexed_doc_in_scope(name string, cur_dir string, scope_root string, preferred_dir string) string {
 	cd := cur_dir.replace('\\', '/').trim_right('/')
+	pd := preferred_dir.replace('\\', '/').trim_right('/')
 	mut uris := app.symbol_index.keys()
 	uris.sort()
+	if pd != '' {
+		for uri in uris {
+			if os.dir(uri_to_path(uri)).replace('\\', '/').trim_right('/') != pd {
+				continue
+			}
+			entry := app.symbol_index[uri] or { continue }
+			if doc := entry.docs[name] {
+				if doc != '' {
+					return doc
+				}
+			}
+		}
+		return ''
+	}
 	// Pass 1: the current module directory (where a same-module symbol lives).
 	if cd != '' {
 		for uri in uris {

--- a/index.v
+++ b/index.v
@@ -237,6 +237,24 @@ fn index_uri_for_path(path string, open_uris_by_path map[string]string) string {
 	return open_uris_by_path[normalized_index_path(path)] or { path_to_uri(path) }
 }
 
+// path_is_in_removed_workspace reports whether `path` is under a workspace root
+// explicitly removed by the client. A currently active root takes precedence,
+// allowing a nested folder to be added again under a removed parent.
+fn (app &App) path_is_in_removed_workspace(path string) bool {
+	p := path.replace('\\', '/')
+	for root in app.workspace_roots {
+		if path_is_within(p, root.replace('\\', '/')) {
+			return false
+		}
+	}
+	for root in app.removed_workspace_roots {
+		if path_is_within(p, root.replace('\\', '/')) {
+			return true
+		}
+	}
+	return false
+}
+
 // reindex_uri (re)parses `uri` from its authoritative source, skipping work when
 // the content fingerprint is unchanged. Open buffers are always authoritative.
 // Disk-backed entries obey the same file-size and total-entry limits as workspace
@@ -248,6 +266,11 @@ fn (mut app App) reindex_uri(uri string) {
 		app.index_skipped_uris.delete(uri)
 	} else {
 		path := uri_to_path(uri)
+		if app.path_is_in_removed_workspace(path) {
+			app.drop_index_uri(uri)
+			app.index_skipped_uris.delete(uri)
+			return
+		}
 		if !os.is_file(path) {
 			app.drop_index_uri(uri)
 			app.index_skipped_uris.delete(uri)
@@ -445,7 +468,7 @@ fn (mut app App) ensure_dirs_indexed(dirs []string) {
 	}
 	open_uris_by_path := app.open_index_uris_by_path()
 	for dir in dirs {
-		if dir == '' || dir == '/' || !os.is_dir(dir) {
+		if dir == '' || dir == '/' || app.path_is_in_removed_workspace(dir) || !os.is_dir(dir) {
 			continue
 		}
 		if dir in app.indexed_dirs && !app.index_dir_needs_refresh(dir) {
@@ -500,7 +523,7 @@ fn (mut app App) ensure_dirs_indexed(dirs []string) {
 // deleted from `dir` are reconciled out — otherwise a stale or removed unopened
 // sibling would keep contributing completions until restart.
 fn (mut app App) ensure_dir_shallow_indexed(dir string) {
-	if dir == '' || dir == '/' || !os.is_dir(dir) {
+	if dir == '' || dir == '/' || app.path_is_in_removed_workspace(dir) || !os.is_dir(dir) {
 		return
 	}
 	scope := 'shallow:${dir}'
@@ -625,7 +648,18 @@ fn (app &App) index_query_dirs() []string {
 		}
 	}
 	for uri, _ in app.open_files {
-		root := find_project_root(os.dir(uri_to_path(uri)))
+		open_path := uri_to_path(uri).replace('\\', '/')
+		mut covered := false
+		for workspace_root in app.workspace_roots {
+			if path_is_within(open_path, workspace_root.replace('\\', '/')) {
+				covered = true
+				break
+			}
+		}
+		if covered || app.path_is_in_removed_workspace(open_path) {
+			continue
+		}
+		root := find_project_root(os.dir(open_path))
 		if root != '' && root != '/' && root !in seen {
 			seen[root] = true
 			dirs << root
@@ -659,6 +693,9 @@ fn (mut app App) ensure_loose_file_dirs_shallow_indexed() {
 			}
 		}
 		if !covered {
+			if app.path_is_in_removed_workspace(dir) {
+				continue
+			}
 			app.ensure_dir_shallow_indexed(dir)
 		}
 	}

--- a/index.v
+++ b/index.v
@@ -389,11 +389,17 @@ fn (mut app App) ensure_dirs_indexed(dirs []string) {
 // ensure_dir_shallow_indexed indexes the `.v` files directly in `dir` (no
 // recursion). A V module occupies a single directory, so this is all that is
 // needed for same-module lookups such as completion, and it is cheap enough to
-// run on a keystroke. Already-indexed files are skipped.
+// run on a keystroke. New files are always picked up; when the client provides
+// no file watchers, already-indexed siblings are also refreshed on a throttled
+// interval (fingerprint check skips unchanged content) and entries for files
+// deleted from `dir` are reconciled out — otherwise a stale or removed unopened
+// sibling would keep contributing completions until restart.
 fn (mut app App) ensure_dir_shallow_indexed(dir string) {
 	if dir == '' || dir == '/' || !os.is_dir(dir) {
 		return
 	}
+	refresh := app.index_dir_needs_refresh(dir)
+	mut present := map[string]bool{}
 	for entry in os.ls(dir) or { return } {
 		if !entry.ends_with('.v') {
 			continue
@@ -403,7 +409,16 @@ fn (mut app App) ensure_dir_shallow_indexed(dir string) {
 			continue
 		}
 		uri := path_to_uri(full)
-		if uri in app.open_files || uri in app.symbol_index {
+		present[uri] = true
+		if uri in app.open_files {
+			continue
+		}
+		if uri in app.symbol_index {
+			// Already indexed: on a throttled refresh re-read from disk so external
+			// edits to unopened siblings are picked up (fingerprint skips no-ops).
+			if refresh {
+				app.reindex_uri(uri)
+			}
 			continue
 		}
 		if os.file_size(full) > index_max_file_bytes {
@@ -412,17 +427,40 @@ fn (mut app App) ensure_dir_shallow_indexed(dir string) {
 		content := os.read_file(full) or { continue }
 		app.symbol_index[uri] = build_index_entry(content, app.position_encoding)
 	}
+	if refresh {
+		// Reconcile deletions: drop non-open entries for files that were directly
+		// in `dir` (shallow, not recursive) but the walk no longer found.
+		dir_norm := dir.replace('\\', '/').trim_right('/')
+		for uri in app.symbol_index.keys() {
+			if uri in app.open_files || uri in present {
+				continue
+			}
+			if os.dir(uri_to_path(uri)).replace('\\', '/').trim_right('/') == dir_norm {
+				app.symbol_index.delete(uri)
+				app.ref_occurrences.delete(uri)
+			}
+		}
+		app.indexed_dir_walk_ms[dir] = time.now().unix_milli()
+	}
 }
 
-// query_module_fn_completions returns free-function completion items from every
-// indexed file that belongs to `module_name`, excluding `exclude_uri` and test
-// files. The index must already cover the relevant files.
-fn (app &App) query_module_fn_completions(module_name string, exclude_uri string) []Detail {
+// query_module_fn_completions returns free-function completion items from the
+// indexed files in `dir` that belong to `module_name`, excluding `exclude_uri`
+// and test files. A V module occupies a single directory, so the results are
+// constrained to `dir` as well as the module name: without that, distinct
+// directories that share a common module name (e.g. `main`) would leak
+// completions from unrelated indexed projects into each other. The index must
+// already cover the relevant files.
+fn (app &App) query_module_fn_completions(module_name string, exclude_uri string, dir string) []Detail {
+	d := dir.replace('\\', '/').trim_right('/')
 	mut items := []Detail{}
 	mut uris := app.symbol_index.keys()
 	uris.sort()
 	for uri in uris {
 		if uri == exclude_uri || uri.ends_with('_test.v') {
+			continue
+		}
+		if d != '' && os.dir(uri_to_path(uri)).replace('\\', '/').trim_right('/') != d {
 			continue
 		}
 		entry := app.symbol_index[uri] or { continue }
@@ -456,6 +494,35 @@ fn (app &App) index_query_dirs() []string {
 	}
 	dirs.sort()
 	return dirs
+}
+
+// ensure_loose_file_dirs_shallow_indexed shallow-indexes the directory of every
+// open file that no recursive project walk covers — a multi-file module opened
+// with no `v.mod` and no workspace root. Its sibling `.v` files must be indexed
+// so references and rename see every occurrence (a partial rename would leave
+// the module uncompilable), but the parent may be an arbitrary directory (a home
+// dir, `/tmp`), so it is indexed shallowly rather than walked recursively
+// (P1-01). Files already covered by index_query_dirs are skipped.
+fn (mut app App) ensure_loose_file_dirs_shallow_indexed() {
+	query_dirs := app.index_query_dirs()
+	mut done := map[string]bool{}
+	for uri, _ in app.open_files {
+		dir := os.dir(uri_to_path(uri)).replace('\\', '/')
+		if dir == '' || dir == '/' || dir in done {
+			continue
+		}
+		done[dir] = true
+		mut covered := false
+		for qd in query_dirs {
+			if path_is_within(dir, qd.replace('\\', '/')) {
+				covered = true
+				break
+			}
+		}
+		if !covered {
+			app.ensure_dir_shallow_indexed(dir)
+		}
+	}
 }
 
 // query_workspace_symbols returns all indexed symbols whose name contains

--- a/index.v
+++ b/index.v
@@ -252,6 +252,28 @@ fn (mut app App) drop_index_uri(uri string) {
 	app.ref_occurrences.delete(uri)
 }
 
+// drop_index_aliases_for_path removes cached URI spellings for the same physical
+// file, retaining `keep_uri` when it is the canonical disk key or another open
+// buffer still owns the file.
+fn (mut app App) drop_index_aliases_for_path(path string, keep_uri string) {
+	target_path := normalized_index_path(path)
+	for uri in app.symbol_index.keys() {
+		if uri != keep_uri && normalized_index_path(uri_to_path(uri)) == target_path {
+			app.symbol_index.delete(uri)
+		}
+	}
+	for uri in app.ref_occurrences.keys() {
+		if uri != keep_uri && normalized_index_path(uri_to_path(uri)) == target_path {
+			app.ref_occurrences.delete(uri)
+		}
+	}
+	for uri in app.index_skipped_uris.keys() {
+		if uri != keep_uri && normalized_index_path(uri_to_path(uri)) == target_path {
+			app.index_skipped_uris.delete(uri)
+		}
+	}
+}
+
 // normalized_index_path returns a stable filesystem key for matching a path
 // discovered by a directory walk to an already-open document URI. Resolving the
 // real path collapses equivalent URI spellings such as file://localhost/tmp/a.v

--- a/index.v
+++ b/index.v
@@ -222,6 +222,26 @@ fn (mut app App) invalidate_index_uri(uri string) {
 	app.symbol_index.delete(uri)
 }
 
+// drop_index_under removes indexed symbols and occurrence caches for every file
+// whose path is inside `dir_path`, and marks all project dirs for re-walk. Used
+// when a workspace folder is removed so its entries do not linger stale. Any
+// still-open files are re-indexed from their buffers on the next query.
+fn (mut app App) drop_index_under(dir_path string) {
+	d := dir_path.replace('\\', '/')
+	for uri in app.symbol_index.keys() {
+		if path_is_within(uri_to_path(uri).replace('\\', '/'), d) {
+			app.symbol_index.delete(uri)
+		}
+	}
+	for uri in app.ref_occurrences.keys() {
+		if path_is_within(uri_to_path(uri).replace('\\', '/'), d) {
+			app.ref_occurrences.delete(uri)
+		}
+	}
+	// Re-walk on next query (a removed folder must not be re-indexed).
+	app.indexed_dirs.clear()
+}
+
 // Bounds and exclusions for the workspace walk. Without these a stray file
 // opened at a large directory (a home dir, /tmp, or the filesystem root) would
 // pull the entire tree into the index (audit: "unbounded workspace traversal").

--- a/index.v
+++ b/index.v
@@ -24,10 +24,12 @@ struct IndexEntry {
 	fn_completions []Detail          // free-function completion items for this file
 }
 
-// build_index_entry parses `content` into an IndexEntry.
-fn build_index_entry(content string) IndexEntry {
+// build_index_entry parses `content` into an IndexEntry. Symbol ranges are
+// re-encoded into `enc` so document/workspace symbol positions match the
+// negotiated encoding for non-ASCII lines (P0-01).
+fn build_index_entry(content string, enc PositionEncoding) IndexEntry {
 	lines := content.split_into_lines()
-	doc_syms := parse_document_symbols(content)
+	doc_syms := encode_document_symbols(parse_document_symbols(content), lines, enc)
 	mut docs := map[string]string{}
 	for sym in doc_syms {
 		// Each symbol's declaration line is range.start.line; read its vdoc.
@@ -45,6 +47,52 @@ fn build_index_entry(content string) IndexEntry {
 		doc_symbols:    doc_syms
 		docs:           docs
 		fn_completions: parse_module_fn_completions(content)
+	}
+}
+
+// encode_document_symbols re-encodes the character offsets of `syms` (produced
+// as UTF-8 byte offsets by parse_document_symbols) into `enc` units, using
+// `lines` for the per-line conversion. Recurses into children (fields, members).
+fn encode_document_symbols(syms []DocumentSymbol, lines []string, enc PositionEncoding) []DocumentSymbol {
+	if enc == .utf8 {
+		return syms // already byte offsets
+	}
+	mut out := []DocumentSymbol{cap: syms.len}
+	for sym in syms {
+		out << DocumentSymbol{
+			name:            sym.name
+			kind:            sym.kind
+			tags:            sym.tags
+			range:           encode_range_chars(sym.range, lines, enc)
+			selection_range: encode_range_chars(sym.selection_range, lines, enc)
+			children:        encode_document_symbols(sym.children, lines, enc)
+		}
+	}
+	return out
+}
+
+// encode_range_chars converts the byte-offset character fields of `r` into `enc`
+// units using the corresponding source lines.
+fn encode_range_chars(r LSPRange, lines []string, enc PositionEncoding) LSPRange {
+	start_line := if r.start.line >= 0 && r.start.line < lines.len {
+		lines[r.start.line]
+	} else {
+		''
+	}
+	end_line := if r.end.line >= 0 && r.end.line < lines.len {
+		lines[r.end.line]
+	} else {
+		''
+	}
+	return LSPRange{
+		start: Position{
+			line: r.start.line
+			char: byte_to_encoded_col(start_line, r.start.char, enc)
+		}
+		end:   Position{
+			line: r.end.line
+			char: byte_to_encoded_col(end_line, r.end.char, enc)
+		}
 	}
 }
 
@@ -166,7 +214,7 @@ fn (mut app App) reindex_uri(uri string) {
 			return
 		}
 	}
-	app.symbol_index[uri] = build_index_entry(content)
+	app.symbol_index[uri] = build_index_entry(content, app.position_encoding)
 }
 
 // invalidate_index_uri drops a URI's entry so it is re-parsed on next access.
@@ -248,7 +296,7 @@ fn (mut app App) ensure_dirs_indexed(dirs []string) {
 				continue
 			}
 			content := os.read_file(f) or { continue }
-			app.symbol_index[uri] = build_index_entry(content)
+			app.symbol_index[uri] = build_index_entry(content, app.position_encoding)
 		}
 		app.indexed_dirs[dir] = true
 	}
@@ -278,7 +326,7 @@ fn (mut app App) ensure_dir_shallow_indexed(dir string) {
 			continue
 		}
 		content := os.read_file(full) or { continue }
-		app.symbol_index[uri] = build_index_entry(content)
+		app.symbol_index[uri] = build_index_entry(content, app.position_encoding)
 	}
 }
 

--- a/index.v
+++ b/index.v
@@ -508,10 +508,12 @@ fn (mut app App) ensure_dir_shallow_indexed(dir string) {
 	refresh := app.index_dir_needs_refresh(dir)
 	open_uris_by_path := app.open_index_uris_by_path()
 	mut present := map[string]bool{}
-	entries := os.ls(dir) or {
+	mut entries := os.ls(dir) or {
 		app.index_incomplete_scopes[scope] = true
 		return
 	}
+	entries.sort()
+	mut scan_complete := true
 	for entry in entries {
 		if !entry.ends_with('.v') {
 			continue
@@ -535,11 +537,12 @@ fn (mut app App) ensure_dir_shallow_indexed(dir string) {
 		}
 		if app.symbol_index.len >= index_max_files {
 			app.index_incomplete_scopes[scope] = true
+			scan_complete = false
 			break
 		}
 		app.reindex_uri(uri)
 	}
-	if refresh {
+	if refresh && scan_complete {
 		// Reconcile deletions: drop non-open entries for files that were directly
 		// in `dir` (shallow, not recursive) but the walk no longer found.
 		dir_norm := dir.replace('\\', '/').trim_right('/')
@@ -560,6 +563,8 @@ fn (mut app App) ensure_dir_shallow_indexed(dir string) {
 				app.index_skipped_uris.delete(uri)
 			}
 		}
+	}
+	if refresh {
 		app.indexed_dir_walk_ms[dir] = time.now().unix_milli()
 	}
 }

--- a/index.v
+++ b/index.v
@@ -202,12 +202,44 @@ fn (mut app App) occurrences_for(uri string) map[string][]TokenOccurrence {
 	return occ
 }
 
+// drop_index_uri removes all cached index data for `uri`.
+fn (mut app App) drop_index_uri(uri string) {
+	app.symbol_index.delete(uri)
+	app.ref_occurrences.delete(uri)
+}
+
 // reindex_uri (re)parses `uri` from its authoritative source, skipping work when
-// the content fingerprint is unchanged. Removes the entry if the file is gone.
+// the content fingerprint is unchanged. Open buffers are always authoritative.
+// Disk-backed entries obey the same file-size and total-entry limits as workspace
+// walks, including when this function is reached through file-watcher events.
 fn (mut app App) reindex_uri(uri string) {
-	content := app.index_source_for(uri) or {
-		app.symbol_index.delete(uri)
-		return
+	mut content := ''
+	if open_content := app.open_files[uri] {
+		content = open_content
+		app.index_skipped_uris.delete(uri)
+	} else {
+		path := uri_to_path(uri)
+		if !os.is_file(path) {
+			app.drop_index_uri(uri)
+			app.index_skipped_uris.delete(uri)
+			return
+		}
+		if os.file_size(path) > index_max_file_bytes {
+			app.drop_index_uri(uri)
+			app.index_skipped_uris[uri] = true
+			return
+		}
+		if uri !in app.symbol_index && app.symbol_index.len >= index_max_files {
+			app.ref_occurrences.delete(uri)
+			app.index_skipped_uris[uri] = true
+			return
+		}
+		content = os.read_file(path) or {
+			app.drop_index_uri(uri)
+			app.index_skipped_uris[uri] = true
+			return
+		}
+		app.index_skipped_uris.delete(uri)
 	}
 	fp := content.hash()
 	if existing := app.symbol_index[uri] {
@@ -239,9 +271,15 @@ fn (mut app App) drop_index_under(dir_path string) {
 			app.ref_occurrences.delete(uri)
 		}
 	}
+	for uri in app.index_skipped_uris.keys() {
+		if path_is_within(uri_to_path(uri).replace('\\', '/'), d) {
+			app.index_skipped_uris.delete(uri)
+		}
+	}
 	// Re-walk on next query (a removed folder must not be re-indexed).
 	app.indexed_dirs.clear()
 	app.indexed_dir_walk_ms.clear()
+	app.index_incomplete_scopes.clear()
 }
 
 // Bounds and exclusions for the workspace walk. Without these a stray file
@@ -272,10 +310,11 @@ fn find_project_root(dir string) string {
 
 // collect_v_files recursively gathers `.v` files under `root`, skipping hidden
 // and known heavy directories and stopping once `index_max_files` is reached.
-fn collect_v_files(root string, mut acc []string) {
+// It returns false when a limit or filesystem error prevents a complete walk.
+fn collect_v_files(root string, mut acc []string) bool {
 	mut visited := map[string]bool{}
 	canonical_root := os.real_path(root).replace('\\', '/')
-	collect_v_files_rec(root, canonical_root, mut acc, mut visited)
+	return collect_v_files_rec(root, canonical_root, mut acc, mut visited)
 }
 
 // collect_v_files_rec is the recursive worker; `visited` holds the canonical
@@ -284,35 +323,38 @@ fn collect_v_files(root string, mut acc []string) {
 // to the workspace: a directory whose resolved path escapes it (e.g. a symlink
 // `external -> /home`) is skipped so an out-of-tree directory cannot pull an
 // unrelated file tree into the index (P1-01).
-fn collect_v_files_rec(dir string, canonical_root string, mut acc []string, mut visited map[string]bool) {
+fn collect_v_files_rec(dir string, canonical_root string, mut acc []string, mut visited map[string]bool) bool {
 	if acc.len >= index_max_files {
-		return
+		return false
 	}
 	real := os.real_path(dir)
 	if real in visited {
-		return
+		return true
 	}
 	// Containment: os.real_path resolves symlinks, so a symlinked directory whose
 	// target lies outside the workspace root is rejected here rather than walked.
 	if !path_is_within(real.replace('\\', '/'), canonical_root) {
-		return
+		return true
 	}
 	visited[real] = true
-	entries := os.ls(dir) or { return }
+	entries := os.ls(dir) or { return false }
 	for entry in entries {
 		if acc.len >= index_max_files {
-			return
+			return false
 		}
 		full := os.join_path(dir, entry)
 		if os.is_dir(full) {
 			if entry.starts_with('.') || entry in index_excluded_dirs {
 				continue
 			}
-			collect_v_files_rec(full, canonical_root, mut acc, mut visited)
+			if !collect_v_files_rec(full, canonical_root, mut acc, mut visited) {
+				return false
+			}
 		} else if entry.ends_with('.v') {
 			acc << full
 		}
 	}
+	return true
 }
 
 // index_refresh_interval_ms bounds how often a directory is re-walked when the
@@ -355,7 +397,11 @@ fn (mut app App) ensure_dirs_indexed(dirs []string) {
 			continue
 		}
 		mut files := []string{}
-		collect_v_files(dir, mut files)
+		scope := 'recursive:${dir}'
+		app.index_incomplete_scopes.delete(scope)
+		if !collect_v_files(dir, mut files) {
+			app.index_incomplete_scopes[scope] = true
+		}
 		mut present := map[string]bool{}
 		for f in files {
 			present[path_to_uri(f)] = true
@@ -386,11 +432,11 @@ fn (mut app App) ensure_dirs_indexed(dirs []string) {
 				app.reindex_uri(uri)
 				continue
 			}
-			if os.file_size(f) > index_max_file_bytes {
-				continue
+			if app.symbol_index.len >= index_max_files {
+				app.index_incomplete_scopes[scope] = true
+				break
 			}
-			content := os.read_file(f) or { continue }
-			app.symbol_index[uri] = build_index_entry(content, app.position_encoding)
+			app.reindex_uri(uri)
 		}
 		app.indexed_dirs[dir] = true
 		app.indexed_dir_walk_ms[dir] = time.now().unix_milli()
@@ -409,9 +455,15 @@ fn (mut app App) ensure_dir_shallow_indexed(dir string) {
 	if dir == '' || dir == '/' || !os.is_dir(dir) {
 		return
 	}
+	scope := 'shallow:${dir}'
+	app.index_incomplete_scopes.delete(scope)
 	refresh := app.index_dir_needs_refresh(dir)
 	mut present := map[string]bool{}
-	for entry in os.ls(dir) or { return } {
+	entries := os.ls(dir) or {
+		app.index_incomplete_scopes[scope] = true
+		return
+	}
+	for entry in entries {
 		if !entry.ends_with('.v') {
 			continue
 		}
@@ -432,11 +484,11 @@ fn (mut app App) ensure_dir_shallow_indexed(dir string) {
 			}
 			continue
 		}
-		if os.file_size(full) > index_max_file_bytes {
-			continue
+		if app.symbol_index.len >= index_max_files {
+			app.index_incomplete_scopes[scope] = true
+			break
 		}
-		content := os.read_file(full) or { continue }
-		app.symbol_index[uri] = build_index_entry(content, app.position_encoding)
+		app.reindex_uri(uri)
 	}
 	if refresh {
 		// Reconcile deletions: drop non-open entries for files that were directly
@@ -451,8 +503,30 @@ fn (mut app App) ensure_dir_shallow_indexed(dir string) {
 				app.ref_occurrences.delete(uri)
 			}
 		}
+		for uri in app.index_skipped_uris.keys() {
+			if uri in present {
+				continue
+			}
+			if os.dir(uri_to_path(uri)).replace('\\', '/').trim_right('/') == dir_norm {
+				app.index_skipped_uris.delete(uri)
+			}
+		}
 		app.indexed_dir_walk_ms[dir] = time.now().unix_milli()
 	}
+}
+
+// index_is_complete reports whether every discovered disk source was indexed.
+// Non-destructive queries may use a partial bounded index, but rename must not.
+fn (app &App) index_is_complete() bool {
+	if app.index_incomplete_scopes.len > 0 {
+		return false
+	}
+	for uri, _ in app.index_skipped_uris {
+		if os.is_file(uri_to_path(uri)) {
+			return false
+		}
+	}
+	return true
 }
 
 // query_module_fn_completions returns free-function completion items from the

--- a/index.v
+++ b/index.v
@@ -313,11 +313,13 @@ fn collect_v_files_rec(dir string, mut acc []string, mut visited map[string]bool
 const index_refresh_interval_ms = i64(10_000)
 
 // index_dir_needs_refresh reports whether an already-walked `dir` should be
-// re-scanned. When the client supports dynamic watched-file registration we rely
-// on didChangeWatchedFiles for freshness and never re-walk; otherwise we re-walk
-// on a throttled interval so a watcher-less client still sees new/changed files.
+// re-scanned. Only once the client has actually acknowledged watcher
+// registration do we rely on didChangeWatchedFiles and stop re-walking; if the
+// client never supported it, or advertised it but rejected the registration
+// request, watcher notifications will not arrive, so we keep re-walking on a
+// throttled interval to stay fresh.
 fn (app &App) index_dir_needs_refresh(dir string) bool {
-	if app.supports_dynamic_watched_files_registration {
+	if app.watched_files_active {
 		return false
 	}
 	last := app.indexed_dir_walk_ms[dir] or { return true }
@@ -552,12 +554,41 @@ fn (app &App) query_workspace_symbols(query string) []WorkspaceSymbol {
 	return results
 }
 
-// find_indexed_doc returns the vdoc comment for the first indexed declaration
-// whose simple name matches `name`, or '' when none is found.
-fn (app &App) find_indexed_doc(name string) string {
+// find_indexed_doc_in_scope returns the vdoc comment for `name`, preferring a
+// declaration in the current module directory `cur_dir` and otherwise limited to
+// the current project subtree `scope_root`. Scoping the search avoids returning a
+// same-named symbol's comment from an unrelated project (a multi-root workspace)
+// or another module elsewhere in the global index, which hover would otherwise
+// append to an imported symbol's documentation (P1-08). A loose file passes an
+// empty `scope_root`, restricting the lookup to its own directory.
+fn (app &App) find_indexed_doc_in_scope(name string, cur_dir string, scope_root string) string {
+	cd := cur_dir.replace('\\', '/').trim_right('/')
 	mut uris := app.symbol_index.keys()
 	uris.sort()
+	// Pass 1: the current module directory (where a same-module symbol lives).
+	if cd != '' {
+		for uri in uris {
+			if os.dir(uri_to_path(uri)).replace('\\', '/').trim_right('/') != cd {
+				continue
+			}
+			entry := app.symbol_index[uri] or { continue }
+			if doc := entry.docs[name] {
+				if doc != '' {
+					return doc
+				}
+			}
+		}
+	}
+	// Pass 2: elsewhere within the same project subtree (imported sibling module).
+	sr := scope_root.replace('\\', '/').trim_right('/')
+	if sr == '' {
+		return ''
+	}
 	for uri in uris {
+		p := uri_to_path(uri).replace('\\', '/')
+		if !path_is_within(p, sr) || os.dir(p).trim_right('/') == cd {
+			continue
+		}
 		entry := app.symbol_index[uri] or { continue }
 		if doc := entry.docs[name] {
 			if doc != '' {

--- a/index.v
+++ b/index.v
@@ -251,20 +251,33 @@ fn find_project_root(dir string) string {
 // collect_v_files recursively gathers `.v` files under `root`, skipping hidden
 // and known heavy directories and stopping once `index_max_files` is reached.
 fn collect_v_files(root string, mut acc []string) {
+	mut visited := map[string]bool{}
+	collect_v_files_rec(root, mut acc, mut visited)
+}
+
+// collect_v_files_rec is the recursive worker; `visited` holds the canonical
+// (realpath-resolved) directories already walked, so a symlink cycle cannot
+// cause infinite recursion or double-indexing.
+fn collect_v_files_rec(dir string, mut acc []string, mut visited map[string]bool) {
 	if acc.len >= index_max_files {
 		return
 	}
-	entries := os.ls(root) or { return }
+	real := os.real_path(dir)
+	if real in visited {
+		return
+	}
+	visited[real] = true
+	entries := os.ls(dir) or { return }
 	for entry in entries {
 		if acc.len >= index_max_files {
 			return
 		}
-		full := os.join_path(root, entry)
+		full := os.join_path(dir, entry)
 		if os.is_dir(full) {
 			if entry.starts_with('.') || entry in index_excluded_dirs {
 				continue
 			}
-			collect_v_files(full, mut acc)
+			collect_v_files_rec(full, mut acc, mut visited)
 		} else if entry.ends_with('.v') {
 			acc << full
 		}

--- a/index.v
+++ b/index.v
@@ -592,8 +592,108 @@ fn (mut app App) ensure_dir_shallow_indexed(dir string) {
 	}
 }
 
+// IndexScope identifies the project or loose module relevant to one source file.
+// Recursive scopes are project/workspace roots; shallow scopes are loose-file
+// module directories.
+struct IndexScope {
+	dir       string
+	recursive bool
+}
+
+// index_scope_for_uri returns the narrowest configured project scope containing
+// `uri`. A nested v.mod inside an active workspace root wins; a v.mod outside a
+// configured root does not expand that root. Loose and explicitly removed files
+// are limited to their immediate directory.
+fn (app &App) index_scope_for_uri(uri string) IndexScope {
+	path := uri_to_path(uri).replace('\\', '/')
+	dir := os.dir(path).replace('\\', '/')
+	if dir == '' || dir == '/' {
+		return IndexScope{}
+	}
+	if app.path_is_in_removed_workspace(path) {
+		return IndexScope{
+			dir: dir
+		}
+	}
+	mut workspace_root := ''
+	for root in app.workspace_roots {
+		root_norm := root.replace('\\', '/')
+		if path_is_within(path, root_norm) && root_norm.len > workspace_root.len {
+			workspace_root = root_norm
+		}
+	}
+	project_root := find_project_root(dir).replace('\\', '/')
+	if project_root != '' && project_root != '/'
+		&& (workspace_root == '' || path_is_within(project_root, workspace_root)) {
+		return IndexScope{
+			dir:       project_root
+			recursive: true
+		}
+	}
+	if workspace_root != '' {
+		return IndexScope{
+			dir:       workspace_root
+			recursive: true
+		}
+	}
+	return IndexScope{
+		dir: dir
+	}
+}
+
+// path_is_in_index_scope reports whether a file belongs to `scope`.
+fn path_is_in_index_scope(path string, scope IndexScope) bool {
+	if scope.dir == '' {
+		return false
+	}
+	p := path.replace('\\', '/')
+	if scope.recursive {
+		return path_is_within(p, scope.dir.replace('\\', '/'))
+	}
+	return normalized_index_path(os.dir(p)) == normalized_index_path(scope.dir)
+}
+
+fn uri_is_in_index_scope(uri string, scope IndexScope) bool {
+	return path_is_in_index_scope(uri_to_path(uri), scope)
+}
+
+// ensure_index_scope indexes only the project/module relevant to a request.
+fn (mut app App) ensure_index_scope(scope IndexScope) {
+	if scope.dir == '' || scope.dir == '/' {
+		return
+	}
+	if scope.recursive {
+		app.ensure_dirs_indexed([scope.dir])
+		return
+	}
+	for uri, _ in app.open_files {
+		if uri_is_in_index_scope(uri, scope) {
+			app.reindex_uri(uri)
+		}
+	}
+	app.ensure_dir_shallow_indexed(scope.dir)
+}
+
+// index_is_complete_for_scope reports whether every source relevant to a
+// destructive operation in `scope` was indexed.
+fn (app &App) index_is_complete_for_scope(scope IndexScope) bool {
+	if scope.dir == '' {
+		return false
+	}
+	scope_kind := if scope.recursive { 'recursive' } else { 'shallow' }
+	if '${scope_kind}:${scope.dir}' in app.index_incomplete_scopes {
+		return false
+	}
+	for uri, _ in app.index_skipped_uris {
+		if uri_is_in_index_scope(uri, scope) && os.is_file(uri_to_path(uri)) {
+			return false
+		}
+	}
+	return true
+}
+
 // index_is_complete reports whether every discovered disk source was indexed.
-// Non-destructive queries may use a partial bounded index, but rename must not.
+// Non-destructive queries may use a partial bounded index.
 fn (app &App) index_is_complete() bool {
 	if app.index_incomplete_scopes.len > 0 {
 		return false

--- a/index.v
+++ b/index.v
@@ -600,11 +600,17 @@ fn (app &App) find_indexed_doc_in_scope(name string, cur_dir string, scope_root 
 }
 
 // find_indexed_fn returns the (uri, symbol) of the first indexed function or
-// method whose simple name matches `name`.
-fn (app &App) find_indexed_fn(name string) ?(string, DocumentSymbol) {
+// method whose simple name matches `name`. `_test.v` declarations are skipped
+// unless `include_tests` is set, so call hierarchy from production code never
+// resolves into a same-named test helper just because of URI ordering; a query
+// originating in a test file passes include_tests so its own helpers resolve.
+fn (app &App) find_indexed_fn(name string, include_tests bool) ?(string, DocumentSymbol) {
 	mut uris := app.symbol_index.keys()
 	uris.sort()
 	for uri in uris {
+		if !include_tests && uri.ends_with('_test.v') {
+			continue
+		}
 		entry := app.symbol_index[uri] or { continue }
 		for sym in entry.doc_symbols {
 			if sym.kind != sym_kind_function && sym.kind != sym_kind_method {

--- a/index.v
+++ b/index.v
@@ -58,6 +58,101 @@ fn (app &App) index_source_for(uri string) ?string {
 	return os.read_file(uri_to_path(uri)) or { none }
 }
 
+// TokenOccurrence is one identifier occurrence in a file, with its position in
+// the client's negotiated encoding.
+struct TokenOccurrence {
+	line       int
+	start_char int
+	end_char   int
+}
+
+// OccEntry caches the identifier occurrences of one file, keyed by content
+// fingerprint so unchanged files are not re-tokenized.
+struct OccEntry {
+	fingerprint int
+	occ         map[string][]TokenOccurrence
+}
+
+// extract_identifier_occurrences returns every identifier occurrence in `content`
+// grouped by name, positioned in `enc` units. Line comments and string literals
+// are skipped (matching the reference scanner), and number literals are ignored.
+// This is the reference-index tokenizer: references/rename read candidate
+// occurrences from here instead of re-walking and re-tokenizing files per request
+// (P1-05).
+fn extract_identifier_occurrences(content string, enc PositionEncoding) map[string][]TokenOccurrence {
+	mut occ := map[string][]TokenOccurrence{}
+	for line_idx, line_text in content.split_into_lines() {
+		n := line_text.len
+		mut col := 0
+		for col < n {
+			c := line_text[col]
+			// Skip line comments.
+			if col + 1 < n && c == `/` && line_text[col + 1] == `/` {
+				break
+			}
+			// Skip string literals.
+			if c == `"` || c == `'` {
+				quote := c
+				col++
+				for col < n {
+					if line_text[col] == `\\` {
+						col += 2
+						continue
+					}
+					if line_text[col] == quote {
+						col++
+						break
+					}
+					col++
+				}
+				continue
+			}
+			if is_ident_char(c) {
+				start := col
+				col++
+				for col < n && is_ident_char(line_text[col]) {
+					col++
+				}
+				// Identifiers cannot start with a digit; skip number literals.
+				if line_text[start] >= `0` && line_text[start] <= `9` {
+					continue
+				}
+				name := line_text[start..col]
+				occ[name] << TokenOccurrence{
+					line:       line_idx
+					start_char: byte_to_encoded_col(line_text, start, enc)
+					end_char:   byte_to_encoded_col(line_text, col, enc)
+				}
+				continue
+			}
+			col++
+		}
+	}
+	return occ
+}
+
+// occurrences_for returns the identifier occurrences of `uri`, building and
+// caching them from the authoritative source (open buffer or disk) and reusing
+// the cache while the content fingerprint is unchanged.
+fn (mut app App) occurrences_for(uri string) map[string][]TokenOccurrence {
+	content := app.index_source_for(uri) or {
+		app.ref_occurrences.delete(uri)
+		return map[string][]TokenOccurrence{}
+	}
+	fp := content.hash()
+	if existing := app.ref_occurrences[uri] {
+		if existing.fingerprint == fp {
+			return existing.occ
+		}
+	}
+	occ := extract_identifier_occurrences(content, app.position_encoding)
+	app.ref_occurrences[uri] = OccEntry{
+		fingerprint: fp
+		occ:         occ
+	}
+	return occ
+}
+
 // reindex_uri (re)parses `uri` from its authoritative source, skipping work when
 // the content fingerprint is unchanged. Removes the entry if the file is gone.
 fn (mut app App) reindex_uri(uri string) {

--- a/index.v
+++ b/index.v
@@ -17,10 +17,11 @@ import os
 
 // IndexEntry is the parsed symbol information for one file.
 struct IndexEntry {
-	fingerprint int // content.hash(); used to skip re-parsing unchanged files
-	module_name string
-	doc_symbols []DocumentSymbol  // hierarchical symbols (as parse_document_symbols returns)
-	docs        map[string]string // simple symbol name -> leading vdoc comment
+	fingerprint    int // content.hash(); used to skip re-parsing unchanged files
+	module_name    string
+	doc_symbols    []DocumentSymbol  // hierarchical symbols (as parse_document_symbols returns)
+	docs           map[string]string // simple symbol name -> leading vdoc comment
+	fn_completions []Detail          // free-function completion items for this file
 }
 
 // build_index_entry parses `content` into an IndexEntry.
@@ -39,10 +40,11 @@ fn build_index_entry(content string) IndexEntry {
 		}
 	}
 	return IndexEntry{
-		fingerprint: content.hash()
-		module_name: get_module_name(content)
-		doc_symbols: doc_syms
-		docs:        docs
+		fingerprint:    content.hash()
+		module_name:    get_module_name(content)
+		doc_symbols:    doc_syms
+		docs:           docs
+		fn_completions: parse_module_fn_completions(content)
 	}
 }
 
@@ -155,6 +157,54 @@ fn (mut app App) ensure_dirs_indexed(dirs []string) {
 		}
 		app.indexed_dirs[dir] = true
 	}
+}
+
+// ensure_dir_shallow_indexed indexes the `.v` files directly in `dir` (no
+// recursion). A V module occupies a single directory, so this is all that is
+// needed for same-module lookups such as completion, and it is cheap enough to
+// run on a keystroke. Already-indexed files are skipped.
+fn (mut app App) ensure_dir_shallow_indexed(dir string) {
+	if dir == '' || dir == '/' || !os.is_dir(dir) {
+		return
+	}
+	for entry in os.ls(dir) or { return } {
+		if !entry.ends_with('.v') {
+			continue
+		}
+		full := os.join_path(dir, entry)
+		if !os.is_file(full) {
+			continue
+		}
+		uri := path_to_uri(full)
+		if uri in app.open_files || uri in app.symbol_index {
+			continue
+		}
+		if os.file_size(full) > index_max_file_bytes {
+			continue
+		}
+		content := os.read_file(full) or { continue }
+		app.symbol_index[uri] = build_index_entry(content)
+	}
+}
+
+// query_module_fn_completions returns free-function completion items from every
+// indexed file that belongs to `module_name`, excluding `exclude_uri` and test
+// files. The index must already cover the relevant files.
+fn (app &App) query_module_fn_completions(module_name string, exclude_uri string) []Detail {
+	mut items := []Detail{}
+	mut uris := app.symbol_index.keys()
+	uris.sort()
+	for uri in uris {
+		if uri == exclude_uri || uri.ends_with('_test.v') {
+			continue
+		}
+		entry := app.symbol_index[uri] or { continue }
+		if module_name != '' && entry.module_name != module_name {
+			continue
+		}
+		items << entry.fn_completions
+	}
+	return items
 }
 
 // index_query_dirs returns the project directories to index: the configured

--- a/index.v
+++ b/index.v
@@ -3,6 +3,7 @@
 module main
 
 import os
+import time
 
 // Persistent, incremental symbol index (audit Stage 4).
 //
@@ -240,6 +241,7 @@ fn (mut app App) drop_index_under(dir_path string) {
 	}
 	// Re-walk on next query (a removed folder must not be re-indexed).
 	app.indexed_dirs.clear()
+	app.indexed_dir_walk_ms.clear()
 }
 
 // Bounds and exclusions for the workspace walk. Without these a stray file
@@ -304,10 +306,30 @@ fn collect_v_files_rec(dir string, mut acc []string, mut visited map[string]bool
 	}
 }
 
+// index_refresh_interval_ms bounds how often a directory is re-walked when the
+// client provides no file watchers. Without watcher notifications the index would
+// otherwise never discover files created after the first walk, nor pick up disk
+// edits to unopened files, until the server restarts.
+const index_refresh_interval_ms = i64(10_000)
+
+// index_dir_needs_refresh reports whether an already-walked `dir` should be
+// re-scanned. When the client supports dynamic watched-file registration we rely
+// on didChangeWatchedFiles for freshness and never re-walk; otherwise we re-walk
+// on a throttled interval so a watcher-less client still sees new/changed files.
+fn (app &App) index_dir_needs_refresh(dir string) bool {
+	if app.supports_dynamic_watched_files_registration {
+		return false
+	}
+	last := app.indexed_dir_walk_ms[dir] or { return true }
+	return time.now().unix_milli() - last > index_refresh_interval_ms
+}
+
 // ensure_dirs_indexed makes sure every open buffer and every `.v` file under the
-// given project `dirs` has an up-to-date index entry. Each dir is walked at most
-// once (tracked in indexed_dirs); already-indexed files are skipped, so only new
-// or changed files are read and parsed rather than the whole workspace.
+// given project `dirs` has an up-to-date index entry. A dir is walked once and
+// then, when no client file watchers are available, re-walked on a throttled
+// interval (see index_dir_needs_refresh) so new and changed unopened files are
+// still discovered. Unchanged files are skipped via a fingerprint check, so a
+// refresh walk only re-parses what actually changed.
 fn (mut app App) ensure_dirs_indexed(dirs []string) {
 	// Open buffers are authoritative; keep their entries fresh (cheap fingerprint
 	// check skips unchanged content).
@@ -315,14 +337,24 @@ fn (mut app App) ensure_dirs_indexed(dirs []string) {
 		app.reindex_uri(uri)
 	}
 	for dir in dirs {
-		if dir == '' || dir == '/' || dir in app.indexed_dirs || !os.is_dir(dir) {
+		if dir == '' || dir == '/' || !os.is_dir(dir) {
+			continue
+		}
+		if dir in app.indexed_dirs && !app.index_dir_needs_refresh(dir) {
 			continue
 		}
 		mut files := []string{}
 		collect_v_files(dir, mut files)
 		for f in files {
 			uri := path_to_uri(f)
-			if uri in app.open_files || uri in app.symbol_index {
+			if uri in app.open_files {
+				continue
+			}
+			if uri in app.symbol_index {
+				// Already indexed: on a refresh walk, re-read from disk so edits to
+				// unopened files are picked up (the fingerprint check skips work
+				// when the content is unchanged).
+				app.reindex_uri(uri)
 				continue
 			}
 			if os.file_size(f) > index_max_file_bytes {
@@ -332,6 +364,7 @@ fn (mut app App) ensure_dirs_indexed(dirs []string) {
 			app.symbol_index[uri] = build_index_entry(content, app.position_encoding)
 		}
 		app.indexed_dirs[dir] = true
+		app.indexed_dir_walk_ms[dir] = time.now().unix_milli()
 	}
 }
 

--- a/index.v
+++ b/index.v
@@ -345,6 +345,24 @@ fn (mut app App) ensure_dirs_indexed(dirs []string) {
 		}
 		mut files := []string{}
 		collect_v_files(dir, mut files)
+		mut present := map[string]bool{}
+		for f in files {
+			present[path_to_uri(f)] = true
+		}
+		// Reconcile the existing index against what is actually on disk: drop
+		// entries for non-open files under `dir` that the walk no longer found.
+		// Without client watchers there is no delete notification, so a removed
+		// unopened file would otherwise linger in symbol/hover/call results.
+		dir_norm := dir.replace('\\', '/')
+		for uri in app.symbol_index.keys() {
+			if uri in app.open_files || uri in present {
+				continue
+			}
+			if path_is_within(uri_to_path(uri).replace('\\', '/'), dir_norm) {
+				app.symbol_index.delete(uri)
+				app.ref_occurrences.delete(uri)
+			}
+		}
 		for f in files {
 			uri := path_to_uri(f)
 			if uri in app.open_files {

--- a/index_test.v
+++ b/index_test.v
@@ -88,12 +88,33 @@ fn test_index_find_fn() {
 	uri := 'file:///tmp/fn.v'
 	app.open_files[uri] = 'module main\n\nfn target() {}\n'
 	app.ensure_dirs_indexed(app.index_query_dirs())
-	found_uri, sym := app.find_indexed_fn('target', false) or {
+	found_uri, sym := app.find_indexed_fn('target', false, []) or {
 		assert false, 'expected to find target'
 		return
 	}
 	assert found_uri == uri
 	assert extract_simple_fn_name(sym.name) == 'target'
+}
+
+fn test_index_find_fn_restricted_to_dirs() {
+	mut app := index_test_app()
+	// Same simple function name in two unrelated indexed roots.
+	app.open_files['file:///rootA/a.v'] = 'module main\n\nfn shared() {}\n'
+	app.open_files['file:///rootB/b.v'] = 'module main\n\nfn shared() {}\n'
+	app.ensure_dirs_indexed(app.index_query_dirs())
+
+	// Restricting to rootB must return rootB's declaration, never rootA's, even
+	// though rootA sorts first.
+	uri_b, _ := app.find_indexed_fn('shared', false, ['/rootB']) or {
+		assert false, 'expected to find shared in rootB'
+		return
+	}
+	assert uri_b == 'file:///rootB/b.v'
+	uri_a, _ := app.find_indexed_fn('shared', false, ['/rootA']) or {
+		assert false, 'expected to find shared in rootA'
+		return
+	}
+	assert uri_a == 'file:///rootA/a.v'
 }
 
 fn test_index_find_fn_skips_test_files() {
@@ -107,7 +128,7 @@ fn test_index_find_fn_skips_test_files() {
 	// Production lookup must resolve to the production file, never the test one,
 	// regardless of URI sort order (lib.v sorts before lib_test.v here, but the
 	// filter is what guarantees it).
-	prod_uri, _ := app.find_indexed_fn('helper', false) or {
+	prod_uri, _ := app.find_indexed_fn('helper', false, []) or {
 		assert false, 'expected to find helper in production'
 		return
 	}
@@ -115,7 +136,7 @@ fn test_index_find_fn_skips_test_files() {
 	assert !prod_uri.ends_with('_test.v')
 
 	// A query originating from a test file may resolve into test declarations.
-	any_uri, _ := app.find_indexed_fn('helper', true) or {
+	any_uri, _ := app.find_indexed_fn('helper', true, []) or {
 		assert false, 'expected to find helper with tests included'
 		return
 	}

--- a/index_test.v
+++ b/index_test.v
@@ -132,12 +132,35 @@ fn test_watched_file_reindex_obeys_total_entry_limit() {
 	assert uri !in app.symbol_index
 }
 
+fn test_reconcile_indexed_dir_retains_entries_after_incomplete_walk() {
+	mut app := index_test_app()
+	kept_uri := 'file:///workspace/kept.v'
+	unseen_uri := 'file:///workspace/unseen.v'
+	app.symbol_index[kept_uri] = IndexEntry{}
+	app.symbol_index[unseen_uri] = IndexEntry{}
+	app.ref_occurrences[unseen_uri] = OccEntry{}
+	present := {
+		kept_uri: true
+	}
+
+	// A partial walk did not see unseen.v, but it must retain the old entry.
+	app.reconcile_indexed_dir('/workspace', present, false)
+	assert unseen_uri in app.symbol_index
+	assert unseen_uri in app.ref_occurrences
+
+	// The same absence after a complete walk proves the file was deleted.
+	app.reconcile_indexed_dir('/workspace', present, true)
+	assert kept_uri in app.symbol_index
+	assert unseen_uri !in app.symbol_index
+	assert unseen_uri !in app.ref_occurrences
+}
+
 fn test_index_doc_lookup() {
 	mut app := index_test_app()
 	app.open_files['file:///tmp/doc.v'] = 'module main\n\n// greet says hello\nfn greet() {}\n'
 	app.ensure_dirs_indexed(app.index_query_dirs())
-	assert app.find_indexed_doc_in_scope('greet', '/tmp', '') == 'greet says hello'
-	assert app.find_indexed_doc_in_scope('missing', '/tmp', '') == ''
+	assert app.find_indexed_doc_in_scope('greet', '/tmp', '', '') == 'greet says hello'
+	assert app.find_indexed_doc_in_scope('missing', '/tmp', '', '') == ''
 }
 
 fn test_index_doc_lookup_scoped_to_project() {
@@ -147,8 +170,8 @@ fn test_index_doc_lookup_scoped_to_project() {
 	app.open_files['file:///projB/lib.v'] = 'module main\n\n// B-foo does B\npub fn foo() {}\n'
 	app.ensure_dirs_indexed(app.index_query_dirs())
 	// A hover in project A must not pick up project B's doc for the same name.
-	assert app.find_indexed_doc_in_scope('foo', '/projA', '/projA') == 'A-foo does A'
-	assert app.find_indexed_doc_in_scope('foo', '/projB', '/projB') == 'B-foo does B'
+	assert app.find_indexed_doc_in_scope('foo', '/projA', '/projA', '') == 'A-foo does A'
+	assert app.find_indexed_doc_in_scope('foo', '/projB', '/projB', '') == 'B-foo does B'
 }
 
 fn test_index_find_fn() {

--- a/index_test.v
+++ b/index_test.v
@@ -527,6 +527,21 @@ fn test_extract_identifier_occurrences_skips_comments_strings_numbers() {
 	assert '123' !in occ
 }
 
+fn test_extract_identifier_occurrences_indexes_string_interpolations() {
+	content := "fn greet(name string) string {\n\tother := 'ignored'\n\treturn 'hello \${name} \${other.to_upper()} \$name literal_name'\n}\n"
+	occ := extract_identifier_occurrences(content, .utf16)
+
+	// The parameter plus braced and shorthand interpolation references.
+	assert occ['name'].len == 3
+	// The declaration and its use inside a compound interpolation expression.
+	assert occ['other'].len == 2
+	assert occ['to_upper'].len == 1
+	// Ordinary literal text remains excluded from rename candidates.
+	assert 'ignored' !in occ
+	assert 'hello' !in occ
+	assert 'literal_name' !in occ
+}
+
 fn test_occurrences_for_caches_by_fingerprint() {
 	mut app := index_test_app()
 	uri := 'file:///tmp/occ.v'

--- a/index_test.v
+++ b/index_test.v
@@ -68,8 +68,19 @@ fn test_index_doc_lookup() {
 	mut app := index_test_app()
 	app.open_files['file:///tmp/doc.v'] = 'module main\n\n// greet says hello\nfn greet() {}\n'
 	app.ensure_dirs_indexed(app.index_query_dirs())
-	assert app.find_indexed_doc('greet') == 'greet says hello'
-	assert app.find_indexed_doc('missing') == ''
+	assert app.find_indexed_doc_in_scope('greet', '/tmp', '') == 'greet says hello'
+	assert app.find_indexed_doc_in_scope('missing', '/tmp', '') == ''
+}
+
+fn test_index_doc_lookup_scoped_to_project() {
+	mut app := index_test_app()
+	// Two unrelated projects each declare a documented `foo` in module `main`.
+	app.open_files['file:///projA/lib.v'] = 'module main\n\n// A-foo does A\npub fn foo() {}\n'
+	app.open_files['file:///projB/lib.v'] = 'module main\n\n// B-foo does B\npub fn foo() {}\n'
+	app.ensure_dirs_indexed(app.index_query_dirs())
+	// A hover in project A must not pick up project B's doc for the same name.
+	assert app.find_indexed_doc_in_scope('foo', '/projA', '/projA') == 'A-foo does A'
+	assert app.find_indexed_doc_in_scope('foo', '/projB', '/projB') == 'B-foo does B'
 }
 
 fn test_index_find_fn() {
@@ -394,7 +405,7 @@ fn test_index_no_refresh_when_watchers_available() {
 		return
 	}
 	mut app := index_test_app()
-	app.supports_dynamic_watched_files_registration = true // rely on watcher events
+	app.watched_files_active = true // registration acknowledged; rely on watcher events
 	app.ensure_dirs_indexed([root])
 	assert app.query_workspace_symbols('alpha').len == 1
 

--- a/index_test.v
+++ b/index_test.v
@@ -571,6 +571,19 @@ fn test_extract_identifier_occurrences_indexes_string_interpolations() {
 	assert 'literal_name' !in occ
 }
 
+fn test_extract_identifier_occurrences_skips_multiline_block_comments() {
+	mut content := 'fn target() {}\n/*\n'
+	for _ in 0 .. reference_semantic_max_candidates + 1 {
+		content += 'target\n'
+	}
+	content += '*/\nfn use() { target() }\n'
+	occ := extract_identifier_occurrences(content, .utf16)
+
+	// Only the declaration and real call are candidates; repeated comment text
+	// cannot push rename over its semantic candidate cap.
+	assert occ['target'].len == 2
+}
+
 fn test_occurrences_for_caches_by_fingerprint() {
 	mut app := index_test_app()
 	uri := 'file:///tmp/occ.v'

--- a/index_test.v
+++ b/index_test.v
@@ -637,6 +637,48 @@ fn test_index_refresh_discovers_new_files_without_watchers() {
 	assert app.query_workspace_symbols('beta').len == 1
 }
 
+fn test_index_completeness_is_scoped_to_relevant_project() {
+	parent := index_test_tmpdir('scoped_complete')
+	defer {
+		os.rmdir_all(parent) or {}
+	}
+	root_a := os.join_path(parent, 'root_a')
+	root_b := os.join_path(parent, 'root_b')
+	os.mkdir_all(root_a) or {
+		assert false, 'mkdir root_a failed: ${err}'
+		return
+	}
+	os.mkdir_all(root_b) or {
+		assert false, 'mkdir root_b failed: ${err}'
+		return
+	}
+	for root in [root_a, root_b] {
+		os.write_file(os.join_path(root, 'v.mod'), 'Module {}\n') or {
+			assert false, 'write v.mod failed: ${err}'
+			return
+		}
+	}
+	path_a := os.join_path(root_a, 'main.v')
+	os.write_file(path_a, 'module main\n\nfn target() {}\n') or {
+		assert false, 'write root_a file failed: ${err}'
+		return
+	}
+	path_b := os.join_path(root_b, 'oversized.v')
+	os.write_file(path_b, 'x'.repeat(index_max_file_bytes + 1)) or {
+		assert false, 'write oversized root_b file failed: ${err}'
+		return
+	}
+	mut app := index_test_app()
+	app.workspace_roots = [root_a, root_b]
+	app.ensure_dirs_indexed(app.index_query_dirs())
+	scope_a := app.index_scope_for_uri(path_to_uri(path_a))
+	scope_b := app.index_scope_for_uri(path_to_uri(path_b))
+
+	assert app.index_is_complete_for_scope(scope_a)
+	assert !app.index_is_complete_for_scope(scope_b)
+	assert !app.index_is_complete()
+}
+
 fn test_index_refresh_removes_deleted_files_without_watchers() {
 	root := index_test_tmpdir('reconcile')
 	defer {

--- a/index_test.v
+++ b/index_test.v
@@ -39,6 +39,31 @@ fn test_index_workspace_symbols_from_open_buffers() {
 	assert betas.all(it.name.to_lower().contains('bet'))
 }
 
+fn test_index_walk_reuses_equivalent_open_document_uri() {
+	root := index_test_tmpdir('open_uri')
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	path := os.join_path(root, 'main.v')
+	os.write_file(path, 'module main\n\nfn stale_disk_symbol() {}\n') or {
+		assert false, 'write main.v failed: ${err}'
+		return
+	}
+	canonical_uri := path_to_uri(path)
+	open_uri := canonical_uri.replace_once('file:///', 'file://localhost/')
+	mut app := index_test_app()
+	app.open_files[open_uri] = 'module main\n\nfn authoritative_open_symbol() {}\n'
+
+	app.ensure_dirs_indexed([root])
+
+	assert open_uri in app.symbol_index
+	assert canonical_uri !in app.symbol_index
+	assert app.query_workspace_symbols('stale_disk_symbol').len == 0
+	open_symbols := app.query_workspace_symbols('authoritative_open_symbol')
+	assert open_symbols.len == 1
+	assert open_symbols[0].location.uri == open_uri
+}
+
 fn test_index_incremental_reindex_reflects_change() {
 	mut app := index_test_app()
 	uri := 'file:///tmp/inc.v'

--- a/index_test.v
+++ b/index_test.v
@@ -164,6 +164,55 @@ fn test_index_module_fn_completions_same_module_only() {
 	assert !comps.any(it.label == 'main')
 }
 
+fn test_index_module_fn_completions_scoped_to_directory() {
+	mut app := index_test_app()
+	// Two unrelated projects that both declare `module main`.
+	app.open_files['file:///proj1/a.v'] = 'module main\n\npub fn one() {}\n'
+	app.open_files['file:///proj1/b.v'] = 'module main\n\nfn main() {}\n'
+	app.open_files['file:///proj2/c.v'] = 'module main\n\npub fn two() {}\n'
+
+	comps := app.collect_module_fn_completions('file:///proj1/b.v', '/proj1')
+	// A same-directory sibling in the same module is offered.
+	assert comps.any(it.label == 'one')
+	// A file with the same module name in a DIFFERENT directory must not leak in.
+	assert !comps.any(it.label == 'two')
+}
+
+fn test_shallow_index_refreshes_and_reconciles_without_watchers() {
+	root := index_test_tmpdir('shallow')
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	sib := os.join_path(root, 'sib.v')
+	os.write_file(sib, 'module main\n\nfn gamma() {}\n') or {
+		assert false, 'write sib.v failed'
+		return
+	}
+	mut app := index_test_app()
+	app.supports_dynamic_watched_files_registration = false // no client watchers
+	app.ensure_dir_shallow_indexed(root)
+	assert app.query_workspace_symbols('gamma').len == 1
+
+	// An external edit to the unopened sibling is picked up on a throttled refresh.
+	os.write_file(sib, 'module main\n\nfn delta() {}\n') or {
+		assert false, 'rewrite sib.v failed'
+		return
+	}
+	app.indexed_dir_walk_ms[root] = 0
+	app.ensure_dir_shallow_indexed(root)
+	assert app.query_workspace_symbols('gamma').len == 0
+	assert app.query_workspace_symbols('delta').len == 1
+
+	// Deleting the sibling reconciles its entry out of the index.
+	os.rm(sib) or {
+		assert false, 'rm sib.v failed'
+		return
+	}
+	app.indexed_dir_walk_ms[root] = 0
+	app.ensure_dir_shallow_indexed(root)
+	assert app.query_workspace_symbols('delta').len == 0
+}
+
 // --- reference / occurrence index (P1-05) ---
 
 fn test_extract_identifier_occurrences_skips_comments_strings_numbers() {
@@ -208,6 +257,34 @@ fn test_search_symbol_in_dirs_finds_cross_file_occurrences() {
 	// declaration in a.v + call in b.v
 	assert locs.len == 2
 	uris := locs.map(it.uri)
+	assert uris.any(it.ends_with('a.v'))
+	assert uris.any(it.ends_with('b.v'))
+}
+
+fn test_search_symbol_in_dirs_indexes_loose_unopened_siblings() {
+	root := index_test_tmpdir('loose')
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	// A loose multi-file module: no v.mod, no workspace root.
+	a := os.join_path(root, 'a.v')
+	b := os.join_path(root, 'b.v')
+	os.write_file(a, 'module main\n\nfn foo() {}\n') or {
+		assert false, 'write a.v failed'
+		return
+	}
+	os.write_file(b, 'module main\n\nfn bar() {\n\tfoo()\n}\n') or {
+		assert false, 'write b.v failed'
+		return
+	}
+	mut app := index_test_app()
+	// Only a.v is open; b.v is an unopened sibling that exists only on disk.
+	app.open_files[path_to_uri(a)] = os.read_file(a) or { '' }
+
+	locs := app.search_symbol_in_dirs('foo', 0)
+	uris := locs.map(it.uri)
+	// The declaration in the open a.v AND the call in the unopened sibling b.v
+	// must both be found — otherwise rename would leave the module uncompilable.
 	assert uris.any(it.ends_with('a.v'))
 	assert uris.any(it.ends_with('b.v'))
 }

--- a/index_test.v
+++ b/index_test.v
@@ -1,0 +1,150 @@
+// Copyright (c) 2025 Alexander Medvednikov. All rights reserved.
+// Use of this source code is governed by a GPL license that can be found in the LICENSE file.
+module main
+
+import os
+import time
+
+fn index_test_app() &App {
+	return &App{
+		open_files: map[string]string{}
+		temp_dir:   os.temp_dir()
+	}
+}
+
+fn index_test_tmpdir(tag string) string {
+	dir := os.join_path(os.temp_dir(), 'vls_index_${tag}_${os.getpid()}_${time.now().unix_nano()}')
+	os.mkdir_all(dir) or { assert false, 'mkdir failed: ${err}' }
+	return dir
+}
+
+fn test_index_workspace_symbols_from_open_buffers() {
+	mut app := index_test_app()
+	app.open_files['file:///tmp/a.v'] = 'module main\n\nfn alpha() {}\n\nstruct Beta {\n\tx int\n}\n'
+	app.open_files['file:///tmp/b.v'] = 'module main\n\nfn gamma() {}\n'
+	// No workspace root / v.mod, so only the open buffers are indexed (no walk).
+	app.ensure_dirs_indexed(app.index_query_dirs())
+
+	all := app.query_workspace_symbols('')
+	names := all.map(it.name)
+	assert names.any(it == 'alpha')
+	assert names.any(it == 'gamma')
+	assert names.any(it == 'Beta')
+	assert names.any(it == 'Beta.x')
+
+	// Filtered query is case-insensitive and substring-based.
+	betas := app.query_workspace_symbols('bet')
+	assert betas.any(it.name == 'Beta')
+	assert betas.all(it.name.to_lower().contains('bet'))
+}
+
+fn test_index_incremental_reindex_reflects_change() {
+	mut app := index_test_app()
+	uri := 'file:///tmp/inc.v'
+	app.open_files[uri] = 'module main\n\nfn one() {}\n'
+	app.reindex_uri(uri)
+	assert app.query_workspace_symbols('one').len == 1
+	assert app.query_workspace_symbols('two').len == 0
+
+	// Edit the buffer and reindex: the old symbol is gone, the new one appears.
+	app.open_files[uri] = 'module main\n\nfn two() {}\n'
+	app.reindex_uri(uri)
+	assert app.query_workspace_symbols('one').len == 0
+	assert app.query_workspace_symbols('two').len == 1
+}
+
+fn test_index_reindex_skips_unchanged_content() {
+	mut app := index_test_app()
+	uri := 'file:///tmp/same.v'
+	app.open_files[uri] = 'module main\n\nfn f() {}\n'
+	app.reindex_uri(uri)
+	fp1 := app.symbol_index[uri].fingerprint
+	app.reindex_uri(uri) // same content
+	fp2 := app.symbol_index[uri].fingerprint
+	assert fp1 == fp2
+}
+
+fn test_index_doc_lookup() {
+	mut app := index_test_app()
+	app.open_files['file:///tmp/doc.v'] = 'module main\n\n// greet says hello\nfn greet() {}\n'
+	app.ensure_dirs_indexed(app.index_query_dirs())
+	assert app.find_indexed_doc('greet') == 'greet says hello'
+	assert app.find_indexed_doc('missing') == ''
+}
+
+fn test_index_find_fn() {
+	mut app := index_test_app()
+	uri := 'file:///tmp/fn.v'
+	app.open_files[uri] = 'module main\n\nfn target() {}\n'
+	app.ensure_dirs_indexed(app.index_query_dirs())
+	found_uri, sym := app.find_indexed_fn('target') or {
+		assert false, 'expected to find target'
+		return
+	}
+	assert found_uri == uri
+	assert extract_simple_fn_name(sym.name) == 'target'
+}
+
+fn test_find_project_root_walks_up_to_v_mod() {
+	root := index_test_tmpdir('proot')
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	os.write_file(os.join_path(root, 'v.mod'), 'Module {}\n') or {
+		assert false, 'write v.mod failed'
+		return
+	}
+	nested := os.join_path(root, 'sub', 'deep')
+	os.mkdir_all(nested) or {
+		assert false, 'mkdir nested failed'
+		return
+	}
+	assert find_project_root(nested) == root
+	// A directory with no v.mod above it has no project root.
+	no_mod := index_test_tmpdir('nomod')
+	defer {
+		os.rmdir_all(no_mod) or {}
+	}
+	assert find_project_root(no_mod) == ''
+}
+
+fn test_collect_v_files_excludes_hidden_and_heavy_dirs() {
+	root := index_test_tmpdir('collect')
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	os.write_file(os.join_path(root, 'main.v'), 'module main\n') or { return }
+	os.mkdir_all(os.join_path(root, '.git')) or { return }
+	os.write_file(os.join_path(root, '.git', 'hooked.v'), 'module main\n') or { return }
+	os.mkdir_all(os.join_path(root, 'node_modules')) or { return }
+	os.write_file(os.join_path(root, 'node_modules', 'dep.v'), 'module main\n') or { return }
+	os.mkdir_all(os.join_path(root, 'sub')) or { return }
+	os.write_file(os.join_path(root, 'sub', 'lib.v'), 'module main\n') or { return }
+
+	mut files := []string{}
+	collect_v_files(root, mut files)
+	assert files.any(it.ends_with('main.v'))
+	assert files.any(it.ends_with('lib.v'))
+	assert files.all(!it.contains('.git'))
+	assert files.all(!it.contains('node_modules'))
+}
+
+fn test_index_scoped_to_v_mod_project_walks_disk() {
+	root := index_test_tmpdir('scoped')
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	os.write_file(os.join_path(root, 'v.mod'), 'Module {}\n') or { return }
+	os.write_file(os.join_path(root, 'lib.v'), 'module main\n\nfn ondisk_fn() {}\n') or { return }
+	// Open a different file in the same project (not the one with the symbol).
+	uri := path_to_uri(os.join_path(root, 'main.v'))
+	app_content := 'module main\n\nfn main() {}\n'
+	os.write_file(os.join_path(root, 'main.v'), app_content) or { return }
+	mut app := index_test_app()
+	app.open_files[uri] = app_content
+
+	app.ensure_dirs_indexed(app.index_query_dirs())
+	// The on-disk sibling in the same v.mod project is indexed even though it was
+	// never opened.
+	assert app.query_workspace_symbols('ondisk_fn').len == 1
+}

--- a/index_test.v
+++ b/index_test.v
@@ -475,6 +475,35 @@ fn test_shallow_index_refreshes_and_reconciles_without_watchers() {
 	assert app.query_workspace_symbols('delta').len == 0
 }
 
+fn test_shallow_index_excludes_out_of_tree_file_symlink() {
+	root := index_test_tmpdir('shallow_file_containment')
+	outside := index_test_tmpdir('shallow_file_outside')
+	defer {
+		os.rmdir_all(root) or {}
+		os.rmdir_all(outside) or {}
+	}
+	os.write_file(os.join_path(root, 'in.v'), 'module main\n\nfn inside_symbol() {}\n') or {
+		assert false, 'write in.v failed: ${err}'
+		return
+	}
+	outside_file := os.join_path(outside, 'out.v')
+	os.write_file(outside_file, 'module main\n\nfn external_symbol() {}\n') or {
+		assert false, 'write out.v failed: ${err}'
+		return
+	}
+	os.symlink(outside_file, os.join_path(root, 'external.v')) or {
+		// Symlink creation can be unavailable (permissions/filesystem); skip then.
+		return
+	}
+
+	mut app := index_test_app()
+	app.ensure_dir_shallow_indexed(root)
+
+	assert app.query_workspace_symbols('inside_symbol').len == 1
+	assert app.query_workspace_symbols('external_symbol').len == 0
+	assert path_to_uri(os.join_path(root, 'external.v')) !in app.symbol_index
+}
+
 fn test_shallow_index_skips_reconciliation_after_hitting_entry_cap() {
 	root := index_test_tmpdir('shallow_cap')
 	defer {

--- a/index_test.v
+++ b/index_test.v
@@ -163,3 +163,51 @@ fn test_index_module_fn_completions_same_module_only() {
 	// b.v's own functions are excluded (it is the current file)
 	assert !comps.any(it.label == 'main')
 }
+
+// --- reference / occurrence index (P1-05) ---
+
+fn test_extract_identifier_occurrences_skips_comments_strings_numbers() {
+	content := 'fn foo() {\n\tbar := 123 // baz\n\ts := "qux"\n\tfoo()\n}\n'
+	occ := extract_identifier_occurrences(content, .utf16)
+	// foo: declaration (line 0) + call (line 3)
+	assert occ['foo'].len == 2
+	assert occ['foo'][0].line == 0
+	assert occ['foo'][0].start_char == 3
+	assert occ['foo'][0].end_char == 6
+	assert occ['foo'][1].line == 3
+	// bar assigned once
+	assert occ['bar'].len == 1
+	// identifiers inside a line comment (baz) and a string (qux) are not indexed
+	assert 'baz' !in occ
+	assert 'qux' !in occ
+	// number literals are not identifiers
+	assert '123' !in occ
+}
+
+fn test_occurrences_for_caches_by_fingerprint() {
+	mut app := index_test_app()
+	uri := 'file:///tmp/occ.v'
+	app.open_files[uri] = 'module main\n\nfn a() {\n\ta()\n}\n'
+	first := app.occurrences_for(uri)
+	assert first['a'].len == 2
+	fp1 := app.ref_occurrences[uri].fingerprint
+	// Unchanged content reuses the cache entry.
+	app.occurrences_for(uri)
+	assert app.ref_occurrences[uri].fingerprint == fp1
+	// Changing the buffer rebuilds it.
+	app.open_files[uri] = 'module main\n\nfn a() {\n\ta()\n\ta()\n}\n'
+	second := app.occurrences_for(uri)
+	assert second['a'].len == 3
+}
+
+fn test_search_symbol_in_dirs_finds_cross_file_occurrences() {
+	mut app := index_test_app()
+	app.open_files['file:///tmp/r/a.v'] = 'module main\n\nfn foo() {}\n'
+	app.open_files['file:///tmp/r/b.v'] = 'module main\n\nfn bar() {\n\tfoo()\n}\n'
+	locs := app.search_symbol_in_dirs('foo', 0)
+	// declaration in a.v + call in b.v
+	assert locs.len == 2
+	uris := locs.map(it.uri)
+	assert uris.any(it.ends_with('a.v'))
+	assert uris.any(it.ends_with('b.v'))
+}

--- a/index_test.v
+++ b/index_test.v
@@ -157,6 +157,40 @@ fn test_watched_file_reindex_obeys_total_entry_limit() {
 	assert uri !in app.symbol_index
 }
 
+fn test_watched_file_reuses_equivalent_open_document_uri() {
+	root := index_test_tmpdir('watched_open_uri')
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	path := os.join_path(root, 'main.v')
+	os.write_file(path, 'module main\n\nfn stale_disk_symbol() {}\n') or {
+		assert false, 'write main.v failed: ${err}'
+		return
+	}
+	event_uri := path_to_uri(path)
+	open_uri := event_uri.replace_once('file:///', 'file://localhost/')
+	mut app := index_test_app()
+	app.watched_files_active = true
+	app.open_files[open_uri] = 'module main\n\nfn authoritative_open_symbol() {}\n'
+	app.reindex_uri(open_uri)
+
+	app.on_did_change_watched_files(Request{
+		params: json2.encode(DidChangeWatchedFilesParams{
+			changes: [FileEvent{
+				uri:        event_uri
+				event_type: 2
+			}]
+		})
+	})
+
+	assert open_uri in app.symbol_index
+	assert event_uri !in app.symbol_index
+	assert app.query_workspace_symbols('stale_disk_symbol').len == 0
+	open_symbols := app.query_workspace_symbols('authoritative_open_symbol')
+	assert open_symbols.len == 1
+	assert open_symbols[0].location.uri == open_uri
+}
+
 fn test_reconcile_indexed_dir_retains_entries_after_incomplete_walk() {
 	mut app := index_test_app()
 	kept_uri := 'file:///workspace/kept.v'

--- a/index_test.v
+++ b/index_test.v
@@ -391,6 +391,32 @@ fn test_collect_v_files_excludes_out_of_tree_file_symlink() {
 	assert files.all(!it.ends_with('external.v'))
 }
 
+fn test_collect_v_files_deduplicates_in_tree_file_symlink() {
+	root := index_test_tmpdir('file_alias')
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	real_file := os.join_path(root, 'real.v')
+	os.write_file(real_file, 'module main\n\nfn unique_symbol() {}\n') or {
+		assert false, 'write real.v failed: ${err}'
+		return
+	}
+	os.symlink(real_file, os.join_path(root, 'alias.v')) or {
+		// Symlink creation can be unavailable (permissions/filesystem); skip then.
+		return
+	}
+
+	mut files := []string{}
+	assert collect_v_files(root, mut files)
+	assert files.len == 1
+	assert normalized_index_path(files[0]) == normalized_index_path(real_file)
+
+	mut app := index_test_app()
+	app.ensure_dirs_indexed([root])
+	assert app.query_workspace_symbols('unique_symbol').len == 1
+	assert app.symbol_index.len == 1
+}
+
 fn test_index_scoped_to_v_mod_project_walks_disk() {
 	root := index_test_tmpdir('scoped')
 	defer {

--- a/index_test.v
+++ b/index_test.v
@@ -305,6 +305,33 @@ fn test_collect_v_files_excludes_out_of_tree_symlink() {
 	assert files.all(!it.ends_with('out.v'))
 }
 
+fn test_collect_v_files_excludes_out_of_tree_file_symlink() {
+	root := index_test_tmpdir('file_containment')
+	outside := index_test_tmpdir('file_outside')
+	defer {
+		os.rmdir_all(root) or {}
+		os.rmdir_all(outside) or {}
+	}
+	os.write_file(os.join_path(root, 'in.v'), 'module main\n') or {
+		assert false, 'write in.v failed'
+		return
+	}
+	outside_file := os.join_path(outside, 'out.v')
+	os.write_file(outside_file, 'module external\n') or {
+		assert false, 'write out.v failed'
+		return
+	}
+	os.symlink(outside_file, os.join_path(root, 'external.v')) or {
+		// Symlink creation can be unavailable (permissions/filesystem); skip then.
+		return
+	}
+
+	mut files := []string{}
+	assert collect_v_files(root, mut files)
+	assert files.any(it.ends_with('in.v'))
+	assert files.all(!it.ends_with('external.v'))
+}
+
 fn test_index_scoped_to_v_mod_project_walks_disk() {
 	root := index_test_tmpdir('scoped')
 	defer {

--- a/index_test.v
+++ b/index_test.v
@@ -88,12 +88,38 @@ fn test_index_find_fn() {
 	uri := 'file:///tmp/fn.v'
 	app.open_files[uri] = 'module main\n\nfn target() {}\n'
 	app.ensure_dirs_indexed(app.index_query_dirs())
-	found_uri, sym := app.find_indexed_fn('target') or {
+	found_uri, sym := app.find_indexed_fn('target', false) or {
 		assert false, 'expected to find target'
 		return
 	}
 	assert found_uri == uri
 	assert extract_simple_fn_name(sym.name) == 'target'
+}
+
+fn test_index_find_fn_skips_test_files() {
+	mut app := index_test_app()
+	prod := 'file:///tmp/proj/lib.v'
+	test := 'file:///tmp/proj/lib_test.v'
+	app.open_files[prod] = 'module main\n\nfn helper() {}\n'
+	app.open_files[test] = 'module main\n\nfn helper() {}\n'
+	app.ensure_dirs_indexed(app.index_query_dirs())
+
+	// Production lookup must resolve to the production file, never the test one,
+	// regardless of URI sort order (lib.v sorts before lib_test.v here, but the
+	// filter is what guarantees it).
+	prod_uri, _ := app.find_indexed_fn('helper', false) or {
+		assert false, 'expected to find helper in production'
+		return
+	}
+	assert prod_uri == prod
+	assert !prod_uri.ends_with('_test.v')
+
+	// A query originating from a test file may resolve into test declarations.
+	any_uri, _ := app.find_indexed_fn('helper', true) or {
+		assert false, 'expected to find helper with tests included'
+		return
+	}
+	assert any_uri in [prod, test]
 }
 
 fn test_find_project_root_walks_up_to_v_mod() {

--- a/index_test.v
+++ b/index_test.v
@@ -720,3 +720,59 @@ fn test_drop_index_under_removes_folder_entries() {
 	// A boundary-similar path is NOT dropped.
 	assert app.indexed_dirs.len == 0
 }
+
+fn test_removed_workspace_root_keeps_only_open_buffer_indexed() {
+	root := index_test_tmpdir('removed_root')
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	os.write_file(os.join_path(root, 'v.mod'), 'Module {}\n') or {
+		assert false, 'write v.mod failed: ${err}'
+		return
+	}
+	open_path := os.join_path(root, 'main.v')
+	sibling_path := os.join_path(root, 'sibling.v')
+	os.write_file(open_path, 'module main\n\nfn disk_open_symbol() {}\n') or {
+		assert false, 'write main.v failed: ${err}'
+		return
+	}
+	os.write_file(sibling_path, 'module main\n\nfn removed_sibling_symbol() {}\n') or {
+		assert false, 'write sibling.v failed: ${err}'
+		return
+	}
+	open_uri := path_to_uri(open_path)
+	mut app := index_test_app()
+	app.workspace_roots = [root]
+	app.open_files[open_uri] = 'module main\n\nfn retained_open_symbol() {}\n'
+	app.ensure_dirs_indexed(app.index_query_dirs())
+	assert app.query_workspace_symbols('removed_sibling_symbol').len == 1
+
+	app.on_did_change_workspace_folders(Request{
+		params: json2.encode(DidChangeWorkspaceFoldersParams{
+			event: WorkspaceFoldersChangeEvent{
+				removed: [WorkspaceFolder{
+					uri: path_to_uri(root)
+				}]
+			}
+		})
+	})
+	app.ensure_dirs_indexed(app.index_query_dirs())
+	app.ensure_loose_file_dirs_shallow_indexed()
+
+	assert app.index_query_dirs().len == 0
+	assert open_uri in app.symbol_index
+	assert app.query_workspace_symbols('retained_open_symbol').len == 1
+	assert app.query_workspace_symbols('removed_sibling_symbol').len == 0
+
+	app.on_did_change_workspace_folders(Request{
+		params: json2.encode(DidChangeWorkspaceFoldersParams{
+			event: WorkspaceFoldersChangeEvent{
+				added: [WorkspaceFolder{
+					uri: path_to_uri(root)
+				}]
+			}
+		})
+	})
+	app.ensure_dirs_indexed(app.index_query_dirs())
+	assert app.query_workspace_symbols('removed_sibling_symbol').len == 1
+}

--- a/index_test.v
+++ b/index_test.v
@@ -266,6 +266,43 @@ fn test_index_refresh_discovers_new_files_without_watchers() {
 	assert app.query_workspace_symbols('beta').len == 1
 }
 
+fn test_index_refresh_removes_deleted_files_without_watchers() {
+	root := index_test_tmpdir('reconcile')
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	os.write_file(os.join_path(root, 'v.mod'), 'Module {}\n') or {
+		assert false, 'write v.mod failed'
+		return
+	}
+	os.write_file(os.join_path(root, 'a.v'), 'module main\n\nfn alpha() {}\n') or {
+		assert false, 'write a.v failed'
+		return
+	}
+	b_path := os.join_path(root, 'b.v')
+	os.write_file(b_path, 'module main\n\nfn beta() {}\n') or {
+		assert false, 'write b.v failed'
+		return
+	}
+	mut app := index_test_app()
+	app.supports_dynamic_watched_files_registration = false // no client watchers
+	app.ensure_dirs_indexed([root])
+	assert app.query_workspace_symbols('alpha').len == 1
+	assert app.query_workspace_symbols('beta').len == 1
+
+	// Delete an unopened file on disk. Without watchers there is no delete
+	// notification, so a throttled refresh must reconcile it out of the index.
+	os.rm(b_path) or {
+		assert false, 'rm b.v failed'
+		return
+	}
+	app.indexed_dir_walk_ms[root] = 0 // force the throttle to treat the dir as stale
+	app.ensure_dirs_indexed([root])
+	assert app.query_workspace_symbols('beta').len == 0
+	// The surviving file is untouched.
+	assert app.query_workspace_symbols('alpha').len == 1
+}
+
 fn test_index_no_refresh_when_watchers_available() {
 	root := index_test_tmpdir('nowatch')
 	defer {

--- a/index_test.v
+++ b/index_test.v
@@ -211,3 +211,21 @@ fn test_search_symbol_in_dirs_finds_cross_file_occurrences() {
 	assert uris.any(it.ends_with('a.v'))
 	assert uris.any(it.ends_with('b.v'))
 }
+
+fn test_drop_index_under_removes_folder_entries() {
+	mut app := index_test_app()
+	app.open_files['file:///proj/a/x.v'] = 'module main\n\nfn ax() {}\n'
+	app.open_files['file:///proj/b/y.v'] = 'module main\n\nfn by() {}\n'
+	app.reindex_uri('file:///proj/a/x.v')
+	app.reindex_uri('file:///proj/b/y.v')
+	app.occurrences_for('file:///proj/a/x.v')
+	app.indexed_dirs['/proj/a'] = true
+
+	app.drop_index_under('/proj/a')
+	// Entries under /proj/a are gone; /proj/b remains.
+	assert 'file:///proj/a/x.v' !in app.symbol_index
+	assert 'file:///proj/a/x.v' !in app.ref_occurrences
+	assert 'file:///proj/b/y.v' in app.symbol_index
+	// A boundary-similar path is NOT dropped.
+	assert app.indexed_dirs.len == 0
+}

--- a/index_test.v
+++ b/index_test.v
@@ -212,6 +212,89 @@ fn test_search_symbol_in_dirs_finds_cross_file_occurrences() {
 	assert uris.any(it.ends_with('b.v'))
 }
 
+fn test_generation_key_scopes_to_project_root() {
+	root := index_test_tmpdir('genkey')
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	os.write_file(os.join_path(root, 'v.mod'), 'Module {}\n') or {
+		assert false, 'write v.mod failed'
+		return
+	}
+	sub := os.join_path(root, 'sub')
+	os.mkdir_all(sub) or {
+		assert false, 'mkdir sub failed'
+		return
+	}
+	mut app := index_test_app()
+	// Two files in different directories of the same project share a generation
+	// key (the project root), so editing one invalidates the other's cache.
+	uri_a := path_to_uri(os.join_path(root, 'a.v'))
+	uri_b := path_to_uri(os.join_path(sub, 'b.v'))
+	assert app.generation_key(uri_a) == app.generation_key(uri_b)
+	before := app.project_generation(uri_a)
+	app.bump_generation(uri_b)
+	assert app.project_generation(uri_a) == before + 1
+}
+
+fn test_index_refresh_discovers_new_files_without_watchers() {
+	root := index_test_tmpdir('refresh')
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	os.write_file(os.join_path(root, 'v.mod'), 'Module {}\n') or {
+		assert false, 'write v.mod failed'
+		return
+	}
+	os.write_file(os.join_path(root, 'a.v'), 'module main\n\nfn alpha() {}\n') or {
+		assert false, 'write a.v failed'
+		return
+	}
+	mut app := index_test_app()
+	app.supports_dynamic_watched_files_registration = false // no client watchers
+	app.ensure_dirs_indexed([root])
+	assert app.query_workspace_symbols('alpha').len == 1
+	assert app.query_workspace_symbols('beta').len == 0
+
+	// A file created after the first walk is discovered on a throttled re-walk.
+	os.write_file(os.join_path(root, 'b.v'), 'module main\n\nfn beta() {}\n') or {
+		assert false, 'write b.v failed'
+		return
+	}
+	app.indexed_dir_walk_ms[root] = 0 // force the throttle to treat the dir as stale
+	app.ensure_dirs_indexed([root])
+	assert app.query_workspace_symbols('beta').len == 1
+}
+
+fn test_index_no_refresh_when_watchers_available() {
+	root := index_test_tmpdir('nowatch')
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	os.write_file(os.join_path(root, 'v.mod'), 'Module {}\n') or {
+		assert false, 'write v.mod failed'
+		return
+	}
+	os.write_file(os.join_path(root, 'a.v'), 'module main\n\nfn alpha() {}\n') or {
+		assert false, 'write a.v failed'
+		return
+	}
+	mut app := index_test_app()
+	app.supports_dynamic_watched_files_registration = true // rely on watcher events
+	app.ensure_dirs_indexed([root])
+	assert app.query_workspace_symbols('alpha').len == 1
+
+	// With watchers active, freshness comes from didChangeWatchedFiles, so a bare
+	// re-index call does NOT re-walk even when the recorded walk time looks stale.
+	os.write_file(os.join_path(root, 'b.v'), 'module main\n\nfn beta() {}\n') or {
+		assert false, 'write b.v failed'
+		return
+	}
+	app.indexed_dir_walk_ms[root] = 0
+	app.ensure_dirs_indexed([root])
+	assert app.query_workspace_symbols('beta').len == 0
+}
+
 fn test_drop_index_under_removes_folder_entries() {
 	mut app := index_test_app()
 	app.open_files['file:///proj/a/x.v'] = 'module main\n\nfn ax() {}\n'

--- a/index_test.v
+++ b/index_test.v
@@ -148,3 +148,18 @@ fn test_index_scoped_to_v_mod_project_walks_disk() {
 	// never opened.
 	assert app.query_workspace_symbols('ondisk_fn').len == 1
 }
+
+fn test_index_module_fn_completions_same_module_only() {
+	mut app := index_test_app()
+	app.open_files['file:///tmp/mod/a.v'] = 'module foo\n\npub fn helper(x int) int {\n\treturn x\n}\n'
+	app.open_files['file:///tmp/mod/b.v'] = 'module foo\n\nfn main() {}\n'
+	app.open_files['file:///tmp/mod/c.v'] = 'module bar\n\nfn other() {}\n'
+
+	comps := app.collect_module_fn_completions('file:///tmp/mod/b.v', '/tmp/mod')
+	// helper is a same-module (foo) sibling of b.v
+	assert comps.any(it.label == 'helper')
+	// other belongs to module bar and must be excluded
+	assert !comps.any(it.label == 'other')
+	// b.v's own functions are excluded (it is the current file)
+	assert !comps.any(it.label == 'main')
+}

--- a/index_test.v
+++ b/index_test.v
@@ -166,6 +166,33 @@ fn test_collect_v_files_excludes_hidden_and_heavy_dirs() {
 	assert files.all(!it.contains('node_modules'))
 }
 
+fn test_collect_v_files_excludes_out_of_tree_symlink() {
+	root := index_test_tmpdir('containment')
+	outside := index_test_tmpdir('outside')
+	defer {
+		os.rmdir_all(root) or {}
+		os.rmdir_all(outside) or {}
+	}
+	os.write_file(os.join_path(root, 'in.v'), 'module main\n') or {
+		assert false, 'write in.v failed'
+		return
+	}
+	os.write_file(os.join_path(outside, 'out.v'), 'module main\n') or {
+		assert false, 'write out.v failed'
+		return
+	}
+	// A directory symlink inside the workspace whose target is outside it.
+	os.symlink(outside, os.join_path(root, 'external')) or {
+		// Symlink creation can be unavailable (permissions/filesystem); skip then.
+		return
+	}
+	mut files := []string{}
+	collect_v_files(root, mut files)
+	assert files.any(it.ends_with('in.v'))
+	// The out-of-tree file reachable only via the symlink must NOT be indexed.
+	assert files.all(!it.ends_with('out.v'))
+}
+
 fn test_index_scoped_to_v_mod_project_walks_disk() {
 	root := index_test_tmpdir('scoped')
 	defer {

--- a/index_test.v
+++ b/index_test.v
@@ -3,6 +3,7 @@
 module main
 
 import os
+import json2
 import time
 
 fn index_test_app() &App {
@@ -62,6 +63,73 @@ fn test_index_reindex_skips_unchanged_content() {
 	app.reindex_uri(uri) // same content
 	fp2 := app.symbol_index[uri].fingerprint
 	assert fp1 == fp2
+}
+
+fn test_watched_file_reindex_drops_oversized_disk_entry() {
+	root := index_test_tmpdir('watched_large')
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	path := os.join_path(root, 'large.v')
+	uri := path_to_uri(path)
+	os.write_file(path, 'module main\n\nfn before_growth() {}\n') or {
+		assert false, 'write initial file failed: ${err}'
+		return
+	}
+	mut app := index_test_app()
+	app.on_did_change_watched_files(Request{
+		params: json2.encode(DidChangeWatchedFilesParams{
+			changes: [FileEvent{
+				uri:        uri
+				event_type: 1
+			}]
+		})
+	})
+	assert uri in app.symbol_index
+	app.occurrences_for(uri)
+	assert uri in app.ref_occurrences
+
+	os.write_file(path, 'x'.repeat(index_max_file_bytes + 1)) or {
+		assert false, 'grow watched file failed: ${err}'
+		return
+	}
+	app.on_did_change_watched_files(Request{
+		params: json2.encode(DidChangeWatchedFilesParams{
+			changes: [FileEvent{
+				uri:        uri
+				event_type: 2
+			}]
+		})
+	})
+	assert uri !in app.symbol_index
+	assert uri !in app.ref_occurrences
+}
+
+fn test_watched_file_reindex_obeys_total_entry_limit() {
+	root := index_test_tmpdir('watched_count')
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	path := os.join_path(root, 'beyond_limit.v')
+	uri := path_to_uri(path)
+	os.write_file(path, 'module main\n\nfn beyond_limit() {}\n') or {
+		assert false, 'write watched file failed: ${err}'
+		return
+	}
+	mut app := index_test_app()
+	for i in 0 .. index_max_files {
+		app.symbol_index['file:///already_indexed_${i}.v'] = IndexEntry{}
+	}
+	app.on_did_change_watched_files(Request{
+		params: json2.encode(DidChangeWatchedFilesParams{
+			changes: [FileEvent{
+				uri:        uri
+				event_type: 1
+			}]
+		})
+	})
+	assert app.symbol_index.len == index_max_files
+	assert uri !in app.symbol_index
 }
 
 fn test_index_doc_lookup() {
@@ -180,7 +248,7 @@ fn test_collect_v_files_excludes_hidden_and_heavy_dirs() {
 	os.write_file(os.join_path(root, 'sub', 'lib.v'), 'module main\n') or { return }
 
 	mut files := []string{}
-	collect_v_files(root, mut files)
+	assert collect_v_files(root, mut files)
 	assert files.any(it.ends_with('main.v'))
 	assert files.any(it.ends_with('lib.v'))
 	assert files.all(!it.contains('.git'))
@@ -208,7 +276,7 @@ fn test_collect_v_files_excludes_out_of_tree_symlink() {
 		return
 	}
 	mut files := []string{}
-	collect_v_files(root, mut files)
+	assert collect_v_files(root, mut files)
 	assert files.any(it.ends_with('in.v'))
 	// The out-of-tree file reachable only via the symlink must NOT be indexed.
 	assert files.all(!it.ends_with('out.v'))

--- a/index_test.v
+++ b/index_test.v
@@ -475,6 +475,38 @@ fn test_shallow_index_refreshes_and_reconciles_without_watchers() {
 	assert app.query_workspace_symbols('delta').len == 0
 }
 
+fn test_shallow_index_skips_reconciliation_after_hitting_entry_cap() {
+	root := index_test_tmpdir('shallow_cap')
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	new_path := os.join_path(root, 'a_new.v')
+	kept_path := os.join_path(root, 'z_kept.v')
+	os.write_file(new_path, 'module main\n\nfn new_symbol() {}\n') or {
+		assert false, 'write new file failed: ${err}'
+		return
+	}
+	os.write_file(kept_path, 'module main\n\nfn kept_symbol() {}\n') or {
+		assert false, 'write kept file failed: ${err}'
+		return
+	}
+	mut app := index_test_app()
+	for i in 0 .. index_max_files {
+		app.symbol_index['file:///already_indexed_${i}.v'] = IndexEntry{}
+	}
+	app.symbol_index.delete('file:///already_indexed_0.v')
+	kept_uri := path_to_uri(kept_path)
+	app.reindex_uri(kept_uri)
+	assert app.symbol_index.len == index_max_files
+	app.indexed_dir_walk_ms[root] = 0
+
+	app.ensure_dir_shallow_indexed(root)
+
+	assert 'shallow:${root}' in app.index_incomplete_scopes
+	assert kept_uri in app.symbol_index
+	assert app.query_workspace_symbols('kept_symbol').len == 1
+}
+
 // --- reference / occurrence index (P1-05) ---
 
 fn test_extract_identifier_occurrences_skips_comments_strings_numbers() {

--- a/integration_test.v
+++ b/integration_test.v
@@ -1361,7 +1361,9 @@ fn test_integration_malformed_json_request_writes_parse_error_response() {
 	assert outbound.contains('"id":null')
 }
 
-fn test_integration_non_default_charset_content_type_header_is_accepted() {
+fn test_integration_non_default_charset_content_type_header_is_rejected() {
+	// LSP content must be UTF-8. A declared utf-16 charset is rejected with a
+	// parse error rather than silently misdecoded (P0-11).
 	mut app, project_dir := create_integration_test_env()
 	defer {
 		cleanup_integration_test_env(app, project_dir)
@@ -1386,8 +1388,8 @@ fn test_integration_non_default_charset_content_type_header_is_accepted() {
 
 	assert app.captured_output.len >= 1
 	outbound := app.captured_output[0]
-	assert outbound.contains('"id":99')
-	assert outbound.contains('"result"')
+	assert outbound.contains('"code":-32700')
+	assert outbound.contains('"id":null')
 }
 
 fn test_integration_pre_initialize_request_rejected_with_server_not_initialized() {
@@ -1560,7 +1562,7 @@ fn test_integration_post_initialize_notification_updates_state() {
 		cleanup_integration_test_env(app, project_dir)
 	}
 
-	uri := 'file:///tmp/postinit.v'
+	uri := path_to_uri(os.join_path(project_dir, 'postinit.v'))
 	content := 'module main\n\nfn main() {}\n'
 	initialize := '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}'
 	did_open_after_init := '{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{"uri":"${uri}","text":"${content}"}}}'
@@ -1585,9 +1587,13 @@ fn test_integration_post_initialize_notification_updates_state() {
 	assert uri in app.open_files
 	assert app.open_files[uri] == content
 	assert app.text == content
-	assert app.captured_output.len == 1
+	// initialize response, then a publishDiagnostics notification emitted on
+	// didOpen (P0-07 item 10).
+	assert app.captured_output.len == 2
 	assert app.captured_output[0].contains('"id":1')
 	assert app.captured_output[0].contains('"result"')
+	assert app.captured_output[1].contains('textDocument/publishDiagnostics')
+	assert app.captured_output[1].contains(uri)
 }
 
 fn test_integration_pre_initialize_cancel_request_is_ignored() {
@@ -2063,4 +2069,90 @@ fn test_integration_capability_flags_for_new_features() {
 	assert encoded.contains('"implementationProvider":true')
 	assert encoded.contains('"renameProvider":{"prepareProvider":true}')
 	assert encoded.contains('"workspaceSymbolProvider":true')
+}
+
+// --- P0-02 / P0-03: string ids, client responses, direction (end to end) ---
+
+fn integration_run_frames(mut app App, project_dir string, name string, payloads []string) []string {
+	mut framed := ''
+	for p in payloads {
+		framed += integration_test_frame_message(p)
+	}
+	input_path := os.join_path(project_dir, '${name}_input.txt')
+	integration_test_must_write_file(input_path, framed)
+	mut input := os.open(input_path) or {
+		assert false, 'Failed to open ${name} input: ${err}'
+		return []string{}
+	}
+	defer {
+		input.close()
+	}
+	app.capture_output = true
+	mut reader := io.new_buffered_reader(reader: input, cap: 1)
+	app.handle_requests(mut reader)
+	return app.captured_output
+}
+
+fn test_integration_string_request_id_is_echoed() {
+	mut app, project_dir := create_integration_test_env()
+	defer {
+		cleanup_integration_test_env(app, project_dir)
+	}
+	out := integration_run_frames(mut app, project_dir, 'string_id', [
+		'{"jsonrpc":"2.0","id":"init-abc","method":"initialize","params":{}}',
+	])
+	assert out.len == 1
+	// The exact string id must be echoed, not collapsed to 0.
+	assert out[0].contains('"id":"init-abc"')
+	assert !out[0].contains('"id":0')
+	assert out[0].contains('"result"')
+}
+
+fn test_integration_client_response_is_consumed_not_dispatched() {
+	mut app, project_dir := create_integration_test_env()
+	defer {
+		cleanup_integration_test_env(app, project_dir)
+	}
+	out := integration_run_frames(mut app, project_dir, 'client_resp', [
+		'{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}',
+		// A response to a server-initiated request: no method. Must be consumed
+		// silently, never answered with MethodNotFound.
+		'{"jsonrpc":"2.0","id":2,"result":null}',
+	])
+	// Only the initialize response should be emitted.
+	assert out.len == 1
+	assert out[0].contains('"id":1')
+	assert !out.any(it.contains('-32601'))
+}
+
+fn test_integration_notification_shaped_shutdown_is_dropped() {
+	mut app, project_dir := create_integration_test_env()
+	defer {
+		cleanup_integration_test_env(app, project_dir)
+	}
+	out := integration_run_frames(mut app, project_dir, 'notif_shutdown', [
+		'{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}',
+		// shutdown is request-only; sent without an id it must be dropped, never
+		// answered with a bogus id:0 response.
+		'{"jsonrpc":"2.0","method":"shutdown"}',
+	])
+	assert out.len == 1
+	assert out[0].contains('"id":1')
+	assert !app.is_shutdown
+}
+
+fn test_integration_request_to_notification_only_method_is_invalid_request() {
+	mut app, project_dir := create_integration_test_env()
+	defer {
+		cleanup_integration_test_env(app, project_dir)
+	}
+	out := integration_run_frames(mut app, project_dir, 'req_to_notif', [
+		'{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}',
+		// didOpen is a notification; sending it as a request (with id) must yield
+		// an InvalidRequest error.
+		'{"jsonrpc":"2.0","id":42,"method":"textDocument/didOpen","params":{"textDocument":{"uri":"file:///tmp/x.v","text":"module main"}}}',
+	])
+	assert out.len == 2
+	assert out[1].contains('"id":42')
+	assert out[1].contains('${jsonrpc_err_invalid_request}')
 }

--- a/integration_test.v
+++ b/integration_test.v
@@ -2248,3 +2248,45 @@ fn test_integration_request_to_notification_only_method_is_invalid_request() {
 	assert out[1].contains('"id":42')
 	assert out[1].contains('${jsonrpc_err_invalid_request}')
 }
+
+fn test_integration_string_id_cancel_does_not_collide_with_numeric_zero() {
+	// Cancelling string id "a" must NOT mark numeric id 0 as cancelled, and a
+	// different string id "b" must not collide with "a" (P0-02).
+	mut app, project_dir := create_integration_test_env()
+	defer {
+		cleanup_integration_test_env(app, project_dir)
+	}
+	// Cancel string id "a".
+	app.current_request_raw_id = ''
+	app.on_cancel_request(Request{
+		method: '$/cancelRequest'
+		params: '{"id":"a"}'
+	})
+	// A numeric id-0 request is NOT cancelled by the string cancel.
+	app.current_request_raw_id = '0'
+	assert !app.request_is_cancelled(0)
+	// A different string id "b" is NOT cancelled.
+	app.current_request_raw_id = '"b"'
+	assert !app.request_is_cancelled(0)
+	// The exact string id "a" IS cancelled.
+	app.current_request_raw_id = '"a"'
+	assert app.request_is_cancelled(0)
+}
+
+fn test_integration_numeric_and_string_cancel_are_independent() {
+	mut app, project_dir := create_integration_test_env()
+	defer {
+		cleanup_integration_test_env(app, project_dir)
+	}
+	// Cancel numeric id 7.
+	app.current_request_raw_id = ''
+	app.on_cancel_request(Request{
+		method: '$/cancelRequest'
+		params: '{"id":7}'
+	})
+	app.current_request_raw_id = '7'
+	assert app.request_is_cancelled(7)
+	// A string id "7" is a different request and is not cancelled.
+	app.current_request_raw_id = '"7"'
+	assert !app.request_is_cancelled(0)
+}

--- a/integration_test.v
+++ b/integration_test.v
@@ -2105,6 +2105,37 @@ fn test_integration_workspace_symbol_query_matches() {
 	assert 'helper_name' in labels
 }
 
+fn test_integration_workspace_symbol_indexes_loose_module_sibling() {
+	mut app, project_dir := create_integration_test_env()
+	defer {
+		cleanup_integration_test_env(app, project_dir)
+	}
+
+	open_file := os.join_path(project_dir, 'main.v')
+	open_content := 'module main\n\nfn main() {}\n'
+	integration_test_must_write_file(open_file, open_content)
+	sibling_file := os.join_path(project_dir, 'sibling.v')
+	integration_test_must_write_file(sibling_file, 'module main\n\nfn unopened_loose_symbol() {}\n')
+	app.open_files[path_to_uri(open_file)] = open_content
+	assert app.workspace_roots.len == 0
+	assert find_project_root(project_dir) == ''
+
+	response := app.handle_workspace_symbol(Request{
+		id:     303
+		method: 'workspace/symbol'
+		params: json2.encode(WorkspaceSymbolParams{
+			query: 'unopened_loose'
+		},
+			escape_unicode: true
+		)
+	})
+
+	assert response.result is []WorkspaceSymbol
+	syms := response.result as []WorkspaceSymbol
+	assert syms.any(it.name == 'unopened_loose_symbol'
+		&& it.location.uri == path_to_uri(sibling_file))
+}
+
 fn test_integration_alias_navigation_methods_preserve_id() {
 	mut app, project_dir := create_integration_test_env()
 	defer {

--- a/integration_test.v
+++ b/integration_test.v
@@ -2258,6 +2258,23 @@ fn test_integration_client_response_is_consumed_not_dispatched() {
 	assert !out.any(it.contains('-32601'))
 }
 
+fn test_integration_malformed_client_response_is_not_consumed() {
+	mut app, project_dir := create_integration_test_env()
+	defer {
+		cleanup_integration_test_env(app, project_dir)
+	}
+	app.watched_files_registration_id = '2'
+	out := integration_run_frames(mut app, project_dir, 'malformed_client_resp', [
+		'{"jsonrpc":"2.0","id":2,"result":null garbage}',
+	])
+
+	assert out.len == 1
+	assert out[0].contains('"code":-32700')
+	assert out[0].contains('"id":null')
+	assert !app.watched_files_active
+	assert app.index_dir_needs_refresh(project_dir)
+}
+
 fn test_integration_notification_shaped_shutdown_is_dropped() {
 	mut app, project_dir := create_integration_test_env()
 	defer {

--- a/integration_test.v
+++ b/integration_test.v
@@ -3,7 +3,7 @@
 module main
 
 import os
-import json
+import json2
 import io
 
 fn integration_test_must_mkdir_all(path string) {
@@ -89,7 +89,7 @@ fn test_integration_initialize_response_structure() {
 		}
 	}
 
-	encoded := json.encode(response)
+	encoded := json2.encode(response, escape_unicode: true)
 	assert encoded.contains('"id":0')
 	assert encoded.contains('"jsonrpc":"2.0"')
 	assert encoded.contains('"result"')
@@ -109,7 +109,7 @@ fn test_integration_initialize_does_not_advertise_client_snippet_support() {
 		}
 	}
 
-	encoded := json.encode(response)
+	encoded := json2.encode(response, escape_unicode: true)
 	assert !encoded.contains('"snippetSupport"')
 }
 
@@ -160,7 +160,7 @@ fn test_integration_initialize_workspace_capabilities() {
 		}
 	}
 
-	encoded := json.encode(response)
+	encoded := json2.encode(response, escape_unicode: true)
 	assert encoded.contains('"executeCommandProvider":{"commands":["vls.runFile","vls.runTests"]}')
 	assert encoded.contains('"workspaceFolders":{"supported":true,"changeNotifications":true}')
 	assert encoded.contains('"fileOperations":{"willCreate"')
@@ -186,11 +186,13 @@ fn test_integration_document_lifecycle() {
 		id:      1
 		method:  'textDocument/didOpen'
 		jsonrpc: '2.0'
-		params:  json.encode(Params{
+		params:  json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	}
 	app.on_did_open(open_request)
 
@@ -203,14 +205,16 @@ fn test_integration_document_lifecycle() {
 		id:      2
 		method:  'textDocument/didChange'
 		jsonrpc: '2.0'
-		params:  json.encode(Params{
+		params:  json2.encode(Params{
 			text_document:   TextDocumentIdentifier{
 				uri: uri
 			}
 			content_changes: [ContentChange{
 				text: new_content
 			}]
-		})
+		},
+			escape_unicode: true
+		)
 	}
 	app.on_did_change(change_request)
 
@@ -232,11 +236,13 @@ fn test_integration_document_open_close_cycle() {
 
 	// Open
 	app.on_did_open(Request{
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	})
 	assert app.open_files.len == 1
 
@@ -246,11 +252,13 @@ fn test_integration_document_open_close_cycle() {
 	uri2 := path_to_uri(test_file2)
 
 	app.on_did_open(Request{
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri2
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	})
 	assert app.open_files.len == 2
 }
@@ -276,18 +284,22 @@ fn test_integration_multifile_project() {
 
 	// Open both files
 	app.on_did_open(Request{
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: main_uri
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	})
 	app.on_did_open(Request{
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: utils_uri
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	})
 
 	assert app.open_files.len == 2
@@ -316,18 +328,22 @@ fn test_integration_multifile_cross_file_reference() {
 
 	// Open both files
 	app.on_did_open(Request{
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: main_uri
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	})
 	app.on_did_open(Request{
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: helper_uri
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	})
 
 	// Verify both files are tracked
@@ -356,18 +372,22 @@ fn test_integration_multifile_nested_directories() {
 	lib_uri := path_to_uri(lib_file)
 
 	app.on_did_open(Request{
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: main_uri
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	})
 	app.on_did_open(Request{
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: lib_uri
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	})
 
 	assert app.open_files.len == 2
@@ -389,23 +409,27 @@ fn test_integration_diagnostics_syntax_error() {
 
 	// Open the file
 	app.on_did_open(Request{
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	})
 
 	// Trigger change to get diagnostics
 	change_request := Request{
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document:   TextDocumentIdentifier{
 				uri: uri
 			}
 			content_changes: [ContentChange{
 				text: error_content
 			}]
-		})
+		},
+			escape_unicode: true
+		)
 	}
 
 	result := app.on_did_change(change_request)
@@ -432,22 +456,26 @@ fn test_integration_diagnostics_valid_code() {
 	uri := path_to_uri(test_file)
 
 	app.on_did_open(Request{
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	})
 
 	change_request := Request{
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document:   TextDocumentIdentifier{
 				uri: uri
 			}
 			content_changes: [ContentChange{
 				text: valid_content
 			}]
-		})
+		},
+			escape_unicode: true
+		)
 	}
 
 	result := app.on_did_change(change_request)
@@ -507,23 +535,27 @@ fn test_integration_diagnostics_empty_file() {
 	uri := path_to_uri(test_file)
 
 	app.on_did_open(Request{
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	})
 
 	// Empty content should be processed and return diagnostics for the empty file
 	result := app.on_did_change(Request{
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document:   TextDocumentIdentifier{
 				uri: uri
 			}
 			content_changes: [ContentChange{
 				text: ''
 			}]
-		})
+		},
+			escape_unicode: true
+		)
 	})
 
 	if notif := result {
@@ -547,11 +579,13 @@ fn test_integration_completion_request() {
 	uri := path_to_uri(test_file)
 
 	app.on_did_open(Request{
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	})
 	app.text = content
 	app.open_files[uri] = content
@@ -561,7 +595,7 @@ fn test_integration_completion_request() {
 		id:      1
 		method:  'textDocument/completion'
 		jsonrpc: '2.0'
-		params:  json.encode(Params{
+		params:  json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
@@ -569,7 +603,9 @@ fn test_integration_completion_request() {
 				line: 3
 				char: 4
 			} // After "os."
-		})
+		},
+			escape_unicode: true
+		)
 	}
 
 	response := app.operation_at_pos(.completion, request)
@@ -595,7 +631,7 @@ fn test_integration_completion_request_id_preserved() {
 	for id in [1, 42, 100, 999] {
 		request := Request{
 			id:     id
-			params: json.encode(Params{
+			params: json2.encode(Params{
 				text_document: TextDocumentIdentifier{
 					uri: uri
 				}
@@ -603,7 +639,9 @@ fn test_integration_completion_request_id_preserved() {
 					line: 2
 					char: 0
 				}
-			})
+			},
+				escape_unicode: true
+			)
 		}
 		response := app.operation_at_pos(.completion, request)
 		assert response.id == id
@@ -626,7 +664,7 @@ fn test_integration_completion_at_function_call() {
 
 	request := Request{
 		id:     1
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
@@ -634,7 +672,9 @@ fn test_integration_completion_at_function_call() {
 				line: 3
 				char: 9
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	}
 
 	response := app.operation_at_pos(.completion, request)
@@ -654,11 +694,13 @@ fn test_integration_definition_request() {
 	uri := path_to_uri(test_file)
 
 	app.on_did_open(Request{
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	})
 	app.text = content
 	app.open_files[uri] = content
@@ -668,7 +710,7 @@ fn test_integration_definition_request() {
 		id:      2
 		method:  'textDocument/definition'
 		jsonrpc: '2.0'
-		params:  json.encode(Params{
+		params:  json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
@@ -676,7 +718,9 @@ fn test_integration_definition_request() {
 				line: 5
 				char: 2
 			} // At "helper()"
-		})
+		},
+			escape_unicode: true
+		)
 	}
 
 	response := app.operation_at_pos(.definition, request)
@@ -704,18 +748,22 @@ fn test_integration_definition_multifile() {
 
 	// Open both files
 	app.on_did_open(Request{
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: main_uri
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	})
 	app.on_did_open(Request{
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: utils_uri
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	})
 	app.text = main_content
 	app.open_files[main_uri] = main_content
@@ -724,7 +772,7 @@ fn test_integration_definition_multifile() {
 	// Request definition from main file
 	request := Request{
 		id:     3
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: main_uri
 			}
@@ -732,7 +780,9 @@ fn test_integration_definition_multifile() {
 				line: 3
 				char: 2
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	}
 
 	response := app.operation_at_pos(.definition, request)
@@ -752,11 +802,13 @@ fn test_integration_signature_help_request() {
 	uri := path_to_uri(test_file)
 
 	app.on_did_open(Request{
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	})
 	app.text = content
 	app.open_files[uri] = content
@@ -766,7 +818,7 @@ fn test_integration_signature_help_request() {
 		id:      3
 		method:  'textDocument/signatureHelp'
 		jsonrpc: '2.0'
-		params:  json.encode(Params{
+		params:  json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
@@ -774,7 +826,9 @@ fn test_integration_signature_help_request() {
 				line: 5
 				char: 7
 			} // After "greet("
-		})
+		},
+			escape_unicode: true
+		)
 	}
 
 	response := app.operation_at_pos(.signature_help, request)
@@ -798,7 +852,7 @@ fn test_integration_signature_help_with_params() {
 	// At second parameter position
 	request := Request{
 		id:     4
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
@@ -806,7 +860,9 @@ fn test_integration_signature_help_with_params() {
 				line: 5
 				char: 7
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	}
 
 	response := app.operation_at_pos(.signature_help, request)
@@ -827,11 +883,13 @@ fn test_integration_temp_file_single() {
 
 	// Only one file open - should use single file mode
 	app.on_did_open(Request{
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	})
 
 	assert app.open_files.len == 1
@@ -853,18 +911,22 @@ fn test_integration_temp_file_multifile() {
 	uri2 := path_to_uri(file2)
 
 	app.on_did_open(Request{
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri1
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	})
 	app.on_did_open(Request{
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri2
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	})
 
 	// Multiple files - should use multi-file mode
@@ -906,7 +968,7 @@ fn test_integration_json_error_parsing() {
 	// Test parsing of V compiler JSON error output
 	json_output := '[{"path":"/test/file.v","message":"undefined identifier `foo`","line_nr":10,"col":5,"len":3}]'
 
-	errors := json.decode([]JsonError, json_output) or {
+	errors := json2.decode[[]JsonError](json_output) or {
 		assert false, 'Failed to parse JSON errors: ${err}'
 		return
 	}
@@ -922,7 +984,7 @@ fn test_integration_json_error_parsing() {
 fn test_integration_json_error_parsing_empty() {
 	json_output := '[]'
 
-	errors := json.decode([]JsonError, json_output) or {
+	errors := json2.decode[[]JsonError](json_output) or {
 		assert false, 'Failed to parse empty JSON errors: ${err}'
 		return
 	}
@@ -933,7 +995,7 @@ fn test_integration_json_error_parsing_empty() {
 fn test_integration_json_error_parsing_multiple() {
 	json_output := '[{"path":"/test/a.v","message":"error 1","line_nr":1,"col":1,"len":1},{"path":"/test/b.v","message":"error 2","line_nr":2,"col":2,"len":2}]'
 
-	errors := json.decode([]JsonError, json_output) or {
+	errors := json2.decode[[]JsonError](json_output) or {
 		assert false, 'Failed to parse multiple JSON errors: ${err}'
 		return
 	}
@@ -946,7 +1008,7 @@ fn test_integration_json_error_parsing_multiple() {
 fn test_integration_json_error_with_special_chars() {
 	json_output := '[{"path":"/test/file.v","message":"cannot use `string` as `int` in argument","line_nr":5,"col":10,"len":6}]'
 
-	errors := json.decode([]JsonError, json_output) or {
+	errors := json2.decode[[]JsonError](json_output) or {
 		assert false, 'Failed to parse JSON errors with special chars: ${err}'
 		return
 	}
@@ -994,7 +1056,7 @@ fn test_integration_notification_encoding() {
 		}
 	}
 
-	encoded := json.encode(notification)
+	encoded := json2.encode(notification, escape_unicode: true)
 
 	assert encoded.contains('"method":"textDocument/publishDiagnostics"')
 	assert encoded.contains('"jsonrpc":"2.0"')
@@ -1053,7 +1115,7 @@ fn test_integration_completion_response_encoding() {
 		result: details
 	}
 
-	encoded := json.encode(response)
+	encoded := json2.encode(response, escape_unicode: true)
 	assert encoded.contains('"label":"println"')
 	assert encoded.contains('"label":"print"')
 }
@@ -1076,7 +1138,7 @@ fn test_integration_location_response_encoding() {
 		}
 	}
 
-	encoded := json.encode(response)
+	encoded := json2.encode(response, escape_unicode: true)
 	assert encoded.contains('"uri":"file:///test/main.v"')
 	assert encoded.contains('"line":10')
 }
@@ -1103,7 +1165,7 @@ fn test_integration_signature_help_response_encoding() {
 		}
 	}
 
-	encoded := json.encode(response)
+	encoded := json2.encode(response, escape_unicode: true)
 	assert encoded.contains('"activeSignature":0')
 	assert encoded.contains('"activeParameter":1')
 	assert encoded.contains('"label":"fn test(a int, b string)"')
@@ -1128,7 +1190,7 @@ fn test_integration_request_id_preserved() {
 		request := Request{
 			id:     id
 			method: 'textDocument/completion'
-			params: json.encode(Params{
+			params: json2.encode(Params{
 				text_document: TextDocumentIdentifier{
 					uri: uri
 				}
@@ -1136,7 +1198,9 @@ fn test_integration_request_id_preserved() {
 					line: 2
 					char: 0
 				}
-			})
+			},
+				escape_unicode: true
+			)
 		}
 
 		response := app.operation_at_pos(.completion, request)
@@ -1260,32 +1324,36 @@ fn test_integration_full_lifecycle() {
 
 	// 3. Open document
 	app.on_did_open(Request{
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	})
 	assert uri in app.open_files
 
 	// 4. Make changes
 	modified_content := 'module main\n\nfn helper() {}\n\nfn main() {\n\thelper()\n}\n'
 	app.on_did_change(Request{
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document:   TextDocumentIdentifier{
 				uri: uri
 			}
 			content_changes: [ContentChange{
 				text: modified_content
 			}]
-		})
+		},
+			escape_unicode: true
+		)
 	})
 	assert app.text == modified_content
 
 	// 5. Request completion
 	comp_response := app.operation_at_pos(.completion, Request{
 		id:     1
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
@@ -1293,14 +1361,16 @@ fn test_integration_full_lifecycle() {
 				line: 5
 				char: 2
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	})
 	assert comp_response.id == 1
 
 	// 6. Request definition
 	def_response := app.operation_at_pos(.definition, Request{
 		id:     2
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
@@ -1308,7 +1378,9 @@ fn test_integration_full_lifecycle() {
 				line: 5
 				char: 2
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	})
 	assert def_response.id == 2
 
@@ -1323,7 +1395,7 @@ fn test_integration_shutdown_response() {
 		result: 'null'
 	}
 
-	encoded := json.encode(shutdown_resp)
+	encoded := json2.encode(shutdown_resp, escape_unicode: true)
 	assert encoded.contains('"id":1')
 	assert encoded.contains('"result":"null"')
 	assert encoded.contains('"jsonrpc":"2.0"')
@@ -1787,7 +1859,7 @@ fn test_integration_completion_includes_sibling_pub_fn() {
 	// Request completion at `helper` on line 3, col 1 (not after '.')
 	response := app.operation_at_pos(.completion, Request{
 		id:     1
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: main_uri
 			}
@@ -1795,7 +1867,9 @@ fn test_integration_completion_includes_sibling_pub_fn() {
 				line: 3
 				char: 1
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	})
 
 	assert response.id == 1
@@ -1831,7 +1905,7 @@ fn test_integration_completion_includes_private_sibling_fn() {
 
 	response := app.operation_at_pos(.completion, Request{
 		id:     1
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: main_uri
 			}
@@ -1839,7 +1913,9 @@ fn test_integration_completion_includes_private_sibling_fn() {
 				line: 3
 				char: 2
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	})
 
 	assert response.id == 1
@@ -1868,7 +1944,7 @@ fn test_integration_completion_includes_current_file_fns() {
 
 	response := app.operation_at_pos(.completion, Request{
 		id:     1
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
@@ -1876,7 +1952,9 @@ fn test_integration_completion_includes_current_file_fns() {
 				line: 5 // inside fn main, after `he`
 				char: 2
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	})
 
 	assert response.id == 1
@@ -1900,20 +1978,24 @@ fn test_integration_did_close_removes_tracked_file() {
 	uri := path_to_uri(test_file)
 
 	app.on_did_open(Request{
-		params: json.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	})
 	assert uri in app.open_files
 
 	app.on_did_close(Request{
-		params: json.encode(DidCloseTextDocumentParams{
+		params: json2.encode(DidCloseTextDocumentParams{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	})
 
 	assert uri !in app.open_files
@@ -1932,11 +2014,13 @@ fn test_integration_did_save_returns_diagnostics_notification() {
 	app.open_files[uri] = content
 
 	notification := app.on_did_save(Request{
-		params: json.encode(DidSaveTextDocumentParams{
+		params: json2.encode(DidSaveTextDocumentParams{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	}) or {
 		assert false, 'Expected didSave to produce diagnostics notification'
 		return
@@ -1961,7 +2045,7 @@ fn test_integration_prepare_rename_returns_symbol_range() {
 	response := app.handle_prepare_rename(Request{
 		id:     301
 		method: 'textDocument/prepareRename'
-		params: json.encode(TextDocumentPositionParams{
+		params: json2.encode(TextDocumentPositionParams{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
@@ -1969,7 +2053,9 @@ fn test_integration_prepare_rename_returns_symbol_range() {
 				line: 4
 				char: 12
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	})
 
 	assert response.id == 301
@@ -1994,9 +2080,11 @@ fn test_integration_workspace_symbol_query_matches() {
 	response := app.handle_workspace_symbol(Request{
 		id:     302
 		method: 'workspace/symbol'
-		params: json.encode(WorkspaceSymbolParams{
+		params: json2.encode(WorkspaceSymbolParams{
 			query: 'name'
-		})
+		},
+			escape_unicode: true
+		)
 	})
 
 	assert response.id == 302
@@ -2026,7 +2114,7 @@ fn test_integration_alias_navigation_methods_preserve_id() {
 		resp := app.operation_at_pos(m, Request{
 			id:     request_id
 			method: m.str()
-			params: json.encode(TextDocumentPositionParams{
+			params: json2.encode(TextDocumentPositionParams{
 				text_document: TextDocumentIdentifier{
 					uri: uri
 				}
@@ -2034,7 +2122,9 @@ fn test_integration_alias_navigation_methods_preserve_id() {
 					line: 5
 					char: 2
 				}
-			})
+			},
+				escape_unicode: true
+			)
 		})
 		assert resp.id == request_id
 		request_id++
@@ -2059,9 +2149,11 @@ fn test_integration_capability_flags_for_new_features() {
 		workspace_symbol_provider: true
 	}
 
-	encoded := json.encode(Capabilities{
+	encoded := json2.encode(Capabilities{
 		capabilities: caps
-	})
+	},
+		escape_unicode: true
+	)
 
 	assert encoded.contains('"save":{"includeText":true}')
 	assert encoded.contains('"declarationProvider":true')

--- a/integration_test.v
+++ b/integration_test.v
@@ -2332,6 +2332,34 @@ fn test_integration_numeric_and_string_cancel_are_independent() {
 	assert !app.request_is_cancelled(0)
 }
 
+fn test_integration_numeric_cancel_ids_match_exact_raw_token() {
+	mut app, project_dir := create_integration_test_env()
+	defer {
+		cleanup_integration_test_env(app, project_dir)
+	}
+
+	app.on_cancel_request(Request{
+		method: '$/cancelRequest'
+		params: '{"id":1.25}'
+	})
+	assert app.cancelled_requests.len == 0
+	app.current_request_raw_id = '1.75'
+	assert !app.request_is_cancelled(1)
+	app.current_request_raw_id = '1.25'
+	assert app.request_is_cancelled(1)
+	assert app.consume_cancelled_request(1)
+	assert !app.request_is_cancelled(1)
+
+	app.on_cancel_request(Request{
+		method: '$/cancelRequest'
+		params: '{"id":9223372036854775808}'
+	})
+	app.current_request_raw_id = '9223372036854775809'
+	assert !app.request_is_cancelled(0)
+	app.current_request_raw_id = '9223372036854775808'
+	assert app.request_is_cancelled(0)
+}
+
 fn test_integration_diagnostics_contain_real_compiler_errors() {
 	// Regression guard: the server must surface actual compiler errors, not an
 	// empty diagnostics list (the compiler writes -json-errors output to stderr).

--- a/integration_test.v
+++ b/integration_test.v
@@ -2290,3 +2290,22 @@ fn test_integration_numeric_and_string_cancel_are_independent() {
 	app.current_request_raw_id = '"7"'
 	assert !app.request_is_cancelled(0)
 }
+
+fn test_integration_diagnostics_contain_real_compiler_errors() {
+	// Regression guard: the server must surface actual compiler errors, not an
+	// empty diagnostics list (the compiler writes -json-errors output to stderr).
+	mut app, project_dir := create_integration_test_env()
+	defer {
+		cleanup_integration_test_env(app, project_dir)
+	}
+	test_file := os.join_path(project_dir, 'err.v')
+	content := 'module main\n\nfn main() {\n\tx := undefined_thing\n}\n'
+	integration_test_must_write_file(test_file, content)
+	uri := path_to_uri(test_file)
+	app.open_files[uri] = content
+
+	notification := app.build_diagnostics_notification(uri, content)
+	assert notification.params.diagnostics.len > 0
+	assert notification.params.diagnostics.any(it.message.contains('undefined'))
+	assert notification.params.diagnostics.any(it.severity == 1)
+}

--- a/integration_test.v
+++ b/integration_test.v
@@ -725,6 +725,11 @@ fn test_integration_definition_request() {
 
 	response := app.operation_at_pos(.definition, request)
 	assert response.id == 2
+	// Must resolve to the `fn helper()` declaration (line 2), not return null —
+	// guards the compiler-interop path end to end.
+	assert response.result is Location
+	loc := response.result as Location
+	assert loc.range.start.line == 2
 }
 
 fn test_integration_definition_multifile() {
@@ -833,6 +838,11 @@ fn test_integration_signature_help_request() {
 
 	response := app.operation_at_pos(.signature_help, request)
 	assert response.id == 3
+	// Must return the actual signature via the compiler-interop path, not null.
+	assert response.result is SignatureHelp
+	sh := response.result as SignatureHelp
+	assert sh.signatures.len > 0
+	assert sh.signatures[0].label.contains('greet')
 }
 
 fn test_integration_signature_help_with_params() {

--- a/interop.v
+++ b/interop.v
@@ -4,24 +4,171 @@ module main
 
 import json
 import os
+import strings
 import time
 
-fn uri_to_path(uri string) string {
-	mut path := uri
-	// Remove file:// or file:/// prefix
-	if path.starts_with('file:///') || path.starts_with('file://') {
-		path = path[7..]
-	}
-	if path.len > 2 && path[0] == `/` && path[2] == `:` {
-		path = path[1..]
-	}
-	return path
+// v_compiler_exe is the absolute path to the V compiler executable, resolved
+// once at startup. Using an absolute path (instead of relying on PATH at exec
+// time) makes child-process invocation deterministic and shell-free.
+const v_compiler_exe = resolve_v_compiler_exe()
+
+fn resolve_v_compiler_exe() string {
+	return os.find_abs_path_of_executable('v') or { 'v' }
 }
 
+// hex_nibble returns the numeric value of a single hex digit, or none.
+fn hex_nibble(c u8) ?u8 {
+	return match c {
+		`0`...`9` { u8(c - `0`) }
+		`a`...`f` { u8(c - `a` + 10) }
+		`A`...`F` { u8(c - `A` + 10) }
+		else { none }
+	}
+}
+
+// percent_decode decodes %XX escapes in a URI path component into raw bytes.
+// Invalid escapes are left untouched so the function never fails on odd input.
+fn percent_decode(s string) string {
+	if !s.contains('%') {
+		return s
+	}
+	mut out := []u8{cap: s.len}
+	mut i := 0
+	for i < s.len {
+		c := s[i]
+		if c == `%` && i + 2 < s.len {
+			hi := hex_nibble(s[i + 1]) or {
+				out << c
+				i++
+				continue
+			}
+			lo := hex_nibble(s[i + 2]) or {
+				out << c
+				i++
+				continue
+			}
+			out << u8(hi * 16 + lo)
+			i += 3
+			continue
+		}
+		out << c
+		i++
+	}
+	return out.bytestr()
+}
+
+// path_needs_escape reports whether a byte must be percent-encoded in a URI
+// path. Unreserved characters (RFC 3986) plus the path separators '/' are kept.
+fn path_byte_needs_escape(c u8) bool {
+	return match c {
+		`a`...`z`, `A`...`Z`, `0`...`9`, `-`, `.`, `_`, `~`, `/`, `:` { false }
+		else { true }
+	}
+}
+
+// percent_encode_path percent-encodes a filesystem path for use in a file URI,
+// preserving '/' separators and drive-letter colons.
+fn percent_encode_path(s string) string {
+	mut sb := strings.new_builder(s.len + 8)
+	for c in s.bytes() {
+		if path_byte_needs_escape(c) {
+			sb.write_string('%')
+			sb.write_string(c.hex().to_upper())
+		} else {
+			sb.write_u8(c)
+		}
+	}
+	return sb.str()
+}
+
+// uri_to_path converts a `file:` DocumentUri to a local filesystem path.
+// It percent-decodes the path component, strips an empty authority, drops any
+// query/fragment, and normalizes Windows drive paths (/C:/... -> C:/...).
+// Non-`file:` URIs and bare paths are returned unchanged.
+fn uri_to_path(uri string) string {
+	if uri == '' {
+		return ''
+	}
+	if !uri.starts_with('file:') {
+		return uri
+	}
+	mut rest := uri[5..] // strip 'file:'
+	mut authority := ''
+	if rest.starts_with('//') {
+		rest = rest[2..]
+		if slash := rest.index('/') {
+			authority = rest[..slash]
+			rest = rest[slash..]
+		} else {
+			// Authority only, no path component.
+			authority = rest
+			rest = ''
+		}
+	}
+	// Strip fragment then query (these are only meaningful when unescaped).
+	if hash := rest.index('#') {
+		rest = rest[..hash]
+	}
+	if q := rest.index('?') {
+		rest = rest[..q]
+	}
+	decoded := percent_decode(rest)
+	if authority != '' {
+		// Preserve UNC authority: //server/share/...
+		return '//' + authority + decoded
+	}
+	// Windows drive path: /C:/Users/... -> C:/Users/...
+	if decoded.len > 2 && decoded[0] == `/` && decoded[2] == `:` {
+		return decoded[1..]
+	}
+	return decoded
+}
+
+// path_is_within reports whether `path` lies inside directory `dir`, using a
+// boundary-aware comparison so that e.g. /foo/barley is NOT treated as inside
+// /foo/bar (P1-01). Both arguments are expected to use '/' separators.
+fn path_is_within(path string, dir string) bool {
+	if dir == '' {
+		return false
+	}
+	d := dir.trim_right('/')
+	if d == '' {
+		// dir was the filesystem root.
+		return path.starts_with('/')
+	}
+	return path == d || path.starts_with(d + '/')
+}
+
+// path_to_uri converts a local filesystem path to a `file:` DocumentUri,
+// percent-encoding characters that are not allowed unescaped in a URI path.
 fn path_to_uri(path string) string {
-	normalized := os.to_slash(path)
-	uri_header := if normalized.starts_with('/') { 'file://' } else { 'file:///' }
-	return uri_header + normalized
+	if path == '' {
+		return 'file:///'
+	}
+	mut normalized := os.to_slash(path)
+	// Windows drive letter: C:/Users/... -> /C:/Users/... so the URI keeps a
+	// leading slash before the authority-less path.
+	if normalized.len >= 2 && normalized[1] == `:` {
+		normalized = '/' + normalized
+	}
+	encoded := percent_encode_path(normalized)
+	if encoded.starts_with('/') {
+		return 'file://' + encoded
+	}
+	return 'file:///' + encoded
+}
+
+// make_unique_temp_path returns a collision-resistant temp file path in the
+// system temp dir, tagged with the caller's purpose, the pid, and a nanosecond
+// timestamp, so concurrent requests for same-named files never overwrite one
+// another (P1-12).
+fn make_unique_temp_path(tag string, real_path string) string {
+	ext := os.file_ext(real_path)
+	safe_ext := if ext == '' { '.v' } else { ext }
+	name := os.file_name(real_path)
+	base := if name.contains('.') { name.all_before_last('.') } else { name }
+	return os.join_path(os.temp_dir(),
+		'${tag}_${os.getpid()}_${time.now().unix_nano()}_${base}${safe_ext}')
 }
 
 fn make_singlefile_temp_path(temp_root string, real_path string, purpose string) string {
@@ -32,57 +179,78 @@ fn make_singlefile_temp_path(temp_root string, real_path string, purpose string)
 	return os.join_path(root, 'vls_${tag}_${os.getpid()}_${time.now().unix_nano()}${safe_ext}')
 }
 
-fn ensure_stderr_captured(cmd string) string {
-	if cmd.contains('2>&1') {
-		return cmd
-	}
-	return '${cmd} 2>&1'
+// Argument-vector builders for the V compiler. Every value is passed as a
+// separate argv element to os.Process, so no shell metacharacter (spaces,
+// `$()`, backticks, quotes, `;`, `&`, `|`, `%`, ...) in a filename or path can
+// alter the executed command. There is no shell involved at any point.
+fn build_v_check_args_single(file_to_check string) []string {
+	return ['-w', '-vls-mode', '-check', '-json-errors', '-nocolor', file_to_check]
 }
 
-fn shell_quote(s string) string {
-	// Use double quotes for cross-platform compatibility.
-	// Windows CMD does not treat single quotes as string delimiters.
-	escaped := s.replace('"', '\\"')
-	return '"${escaped}"'
+fn build_v_check_args_multifile() []string {
+	return ['-w', '-check', '-json-errors', '-nocolor', '.']
 }
 
-fn build_v_check_cmd_single(file_to_check string) string {
-	return 'v -w -vls-mode -check -json-errors -nocolor ${shell_quote(file_to_check)}'
+fn build_v_line_info_args_multifile(rel_file string, line_info string) []string {
+	return ['-w', '-check', '-json-errors', '-nocolor', '-vls-mode', '-line-info',
+		'${rel_file}:${line_info}', '.']
 }
 
-fn build_v_check_cmd_multifile() string {
-	return 'v -w -check -json-errors -nocolor .'
+fn build_v_line_info_args_single(file_to_check string, line_info string, compile_target string) []string {
+	return ['-w', '-check', '-json-errors', '-nocolor', '-vls-mode', '-line-info',
+		'${file_to_check}:${line_info}', compile_target]
 }
 
-fn build_v_line_info_cmd_multifile(rel_file string, line_info string) string {
-	return 'v -w -check -json-errors -nocolor -vls-mode -line-info ${shell_quote('${rel_file}:${line_info}')} .'
+fn build_v_fmt_args(temp_file string) []string {
+	return ['fmt', '-inprocess', '-w', temp_file]
 }
 
-fn build_v_line_info_cmd_single(file_to_check string, line_info string, compile_target string) string {
-	vls_flag := '-vls-mode '
-	return 'v -w -check -json-errors -nocolor ${vls_flag}-line-info ${shell_quote('${file_to_check}:${line_info}')} ${shell_quote(compile_target)}'
-}
-
-fn build_v_fmt_cmd(temp_file string) string {
-	return 'v fmt -inprocess -w ${shell_quote(temp_file)}'
-}
-
-fn execute_in_dir(dir string, cmd string) os.Result {
-	original_dir := os.getwd()
-	defer {
-		os.chdir(original_dir) or {}
-	}
-	if dir != '' {
-		os.chdir(dir) or {
-			msg := 'Failed to change to working dir ${dir}: ${err}'
-			log(msg)
-			return os.Result{
-				exit_code: 1
-				output:    msg
-			}
+// run_v_argv executes the V compiler with the given argument vector in
+// `work_folder` (set on the child process, never via a process-global chdir),
+// capturing stdout. stderr is captured separately and only logged, so it can
+// never corrupt the JSON the compiler writes to stdout. This is the single,
+// shell-free entry point for all compiler invocations.
+fn run_v_argv(args []string, work_folder string) os.Result {
+	if work_folder != '' && !os.is_dir(work_folder) {
+		msg := 'Working dir does not exist: ${work_folder}'
+		log(msg)
+		return os.Result{
+			exit_code: 1
+			output:    msg
 		}
 	}
-	return os.execute(ensure_stderr_captured(cmd))
+	mut p := os.new_process(v_compiler_exe)
+	p.set_args(args)
+	if work_folder != '' {
+		p.set_work_folder(work_folder)
+	}
+	p.set_redirect_stdio()
+	p.run()
+	mut out := strings.new_builder(1024)
+	mut errb := strings.new_builder(256)
+	// Drain both pipes while the child runs so a large output cannot deadlock
+	// the child against a full pipe buffer.
+	for p.is_alive() {
+		if chunk := p.pipe_read(.stdout) {
+			out.write_string(chunk)
+		}
+		if chunk := p.pipe_read(.stderr) {
+			errb.write_string(chunk)
+		}
+	}
+	out.write_string(p.stdout_slurp())
+	errb.write_string(p.stderr_slurp())
+	p.wait()
+	code := p.code
+	p.close()
+	stderr_text := errb.str()
+	if stderr_text.trim_space() != '' {
+		log('v stderr: ${stderr_text}')
+	}
+	return os.Result{
+		exit_code: code
+		output:    out.str()
+	}
 }
 
 fn cleanup_compilation_temp(temp_project_dir string, singlefile_tmppath string) {
@@ -104,7 +272,7 @@ fn (mut app App) run_v_check(path string, text string) []JsonError {
 
 	// Check the diagnostics cache before invoking the compiler.
 	content_hash := text.hash()
-	gen := app.open_files_generation
+	gen := app.project_generation(path)
 	if cached := app.diag_cache[path] {
 		if cached.content_hash == content_hash && cached.generation == gen {
 			log('Returning cached diagnostics for ${path}')
@@ -148,17 +316,17 @@ fn (mut app App) run_v_check(path string, text string) []JsonError {
 		compile_target = singlefile_tmppath
 	}
 
-	mut cmd := ''
+	mut cmd_args := []string{}
 	if use_multifile {
-		cmd = build_v_check_cmd_multifile()
-		log('MULTIFILE CMD - compile_target=${compile_target}): ${cmd}')
+		cmd_args = build_v_check_args_multifile()
+		log('MULTIFILE CMD - compile_target=${compile_target}): v ${cmd_args.join(' ')}')
 	} else {
-		cmd = build_v_check_cmd_single(file_to_check)
-		log('SINGLEFILE CMD: ${cmd}')
+		cmd_args = build_v_check_args_single(file_to_check)
+		log('SINGLEFILE CMD: v ${cmd_args.join(' ')}')
 	}
 
 	exec_dir := if use_multifile { compile_target } else { working_dir }
-	x := execute_in_dir(exec_dir, cmd)
+	x := run_v_argv(cmd_args, exec_dir)
 
 	log('Check - RUN RES ${x}')
 
@@ -236,8 +404,8 @@ fn (mut app App) write_tracked_files_to_temp(working_dir string) !string {
 		normalized_real := real_path.replace('\\', '/')
 		normalized_working := working_dir.replace('\\', '/')
 
-		// skip not in working dir
-		if !normalized_real.starts_with(normalized_working) {
+		// skip not in working dir (boundary-aware: /foo/barley is not in /foo/bar)
+		if !path_is_within(normalized_real, normalized_working) {
 			log('SKIPPING FILE: ${real_path}')
 			continue
 		}
@@ -268,11 +436,23 @@ fn (mut app App) write_tracked_files_to_temp(working_dir string) !string {
 	return temp_project_dir
 }
 
+// has_sibling_v_files reports whether the directory of the current file holds
+// another `.v` file, i.e. the file is part of a multi-file V module. This uses a
+// shallow directory listing rather than a full recursive tree walk: V modules
+// are per-directory, and recursively walking (e.g. a huge workspace or /tmp) on
+// every diagnostics cycle was a major, unnecessary cost.
 fn has_sibling_v_files(working_dir string, current_file string) bool {
-	v_files := os.walk_ext(working_dir, '.v')
-	for v_file in v_files {
-		if v_file != current_file {
-			return true
+	cur_name := os.file_name(current_file)
+	entries := os.ls(working_dir) or { return false }
+	for entry in entries {
+		if entry == cur_name {
+			continue
+		}
+		if entry.ends_with('.v') {
+			full := os.join_path(working_dir, entry)
+			if os.is_file(full) {
+				return true
+			}
 		}
 	}
 	return false
@@ -324,25 +504,28 @@ fn (mut app App) on_did_change_watched_files(request Request) {
 		uri := change.uri
 		match change.event_type {
 			3 {
-				// Deleted — remove from tracking if present.
-				if uri in app.open_files {
-					app.open_files.delete(uri)
-					app.open_files_generation++
-					log('on_did_change_watched_files: removed deleted file ${uri}')
+				// Deleted on disk. Invalidate cached diagnostics, but do NOT drop
+				// an open editor buffer: the editor still owns the in-memory
+				// document even if the on-disk file was removed (P0-07 item 8).
+				if uri in app.diag_cache {
+					app.diag_cache.delete(uri)
 				}
+				app.bump_generation(uri)
+				log('on_did_change_watched_files: disk delete for ${uri}')
 			}
 			1, 2 {
-				// Created or Changed — reload from disk if currently tracked.
+				// Created or Changed on disk. The editor buffer is authoritative
+				// for any open document, so we must never overwrite open_files
+				// with disk content — doing so would erase unsaved edits (P0-07
+				// item 8). We only invalidate caches so future checks re-read
+				// non-open files from disk.
 				if uri in app.open_files {
-					real_path := uri_to_path(uri)
-					content := os.read_file(real_path) or {
-						log('on_did_change_watched_files: cannot read ${real_path}: ${err}')
-						continue
-					}
-					app.open_files[uri] = content
-					app.open_files_generation++
-					log('on_did_change_watched_files: reloaded ${uri}')
+					log('on_did_change_watched_files: ignoring disk change for open buffer ${uri}')
 				}
+				if uri in app.diag_cache {
+					app.diag_cache.delete(uri)
+				}
+				app.bump_generation(uri)
 			}
 			else {}
 		}
@@ -417,8 +600,12 @@ fn (mut app App) run_v_line_info(method Method, path string, line_info string) R
 			log('SINGLEFILE method=${method}')
 			singlefile_tmppath = make_singlefile_temp_path(app.temp_dir, real_path, 'lineinfo')
 			log('WRITING FILE ${time.now()} to temp path ${singlefile_tmppath}')
+			// Overlay the requested document's open buffer, never a global
+			// "last touched" field, so a request for one URI can't compile the
+			// buffer of another (P1-02).
+			request_content := app.open_files[path] or { os.read_file(real_path) or { app.text } }
 			mut wrote_temp := true
-			os.write_file(singlefile_tmppath, app.text) or {
+			os.write_file(singlefile_tmppath, request_content) or {
 				wrote_temp = false
 				log('Failed to write temp file ${singlefile_tmppath}: ${err}')
 				// Fall back to reading from disk instead of crashing.
@@ -435,19 +622,19 @@ fn (mut app App) run_v_line_info(method Method, path string, line_info string) R
 
 	log('running v.exe line info!')
 	log('file_to_check=${file_to_check}, compile_target=${compile_target}, working_dir=${working_dir}')
-	mut cmd := ''
+	mut cmd_args := []string{}
 
 	if use_multifile {
 		rel_file := os.file_name(file_to_check)
-		cmd = build_v_line_info_cmd_multifile(rel_file, line_info)
-		log('MULTIFILE CMD compile_target=${compile_target}: ${cmd}')
+		cmd_args = build_v_line_info_args_multifile(rel_file, line_info)
+		log('MULTIFILE CMD compile_target=${compile_target}: v ${cmd_args.join(' ')}')
 	} else {
-		cmd = build_v_line_info_cmd_single(file_to_check, line_info, compile_target)
-		log('SINGLEFILE CMD: ${cmd}')
+		cmd_args = build_v_line_info_args_single(file_to_check, line_info, compile_target)
+		log('SINGLEFILE CMD: v ${cmd_args.join(' ')}')
 	}
 
 	exec_dir := if use_multifile { compile_target } else { working_dir }
-	mut x := execute_in_dir(exec_dir, cmd)
+	mut x := run_v_argv(cmd_args, exec_dir)
 
 	if (method == .definition || method == .declaration || method == .type_definition
 		|| method == .implementation) && use_multifile
@@ -459,9 +646,9 @@ fn (mut app App) run_v_line_info(method Method, path string, line_info string) R
 		}
 		file_to_check = real_path
 		compile_target = real_path
-		cmd_fallback := build_v_line_info_cmd_single(file_to_check, line_info, compile_target)
-		log('cmd_fallback=${cmd_fallback}')
-		x = execute_in_dir(working_dir, cmd_fallback)
+		cmd_fallback := build_v_line_info_args_single(file_to_check, line_info, compile_target)
+		log('cmd_fallback=v ${cmd_fallback.join(' ')}')
+		x = run_v_argv(cmd_fallback, working_dir)
 		log('Fallback RUN RES ${x}')
 	}
 

--- a/interop.v
+++ b/interop.v
@@ -808,10 +808,11 @@ fn (mut app App) run_v_line_info(method Method, path string, line_info string) R
 
 					log('MAPPED TO uri_path=${uri_path}')
 				}
-				uri_header := if uri_path.starts_with('/') { 'file://' } else { 'file:///' }
-				// The compiler reports a byte column; convert it to the client's
-				// encoding using the target file's line (P0-01).
-				target_uri := uri_header + uri_path
+				// Build a proper percent-encoded DocumentUri so paths containing
+				// spaces, `#`, `%`, or Unicode are valid and match the client's URI
+				// keys (P0-10). The compiler reports a byte column; convert it to
+				// the client's encoding using the target file's line (P0-01).
+				target_uri := path_to_uri(uri_path)
 				client_col := app.byte_col_to_client_col(target_uri, line_nr, col)
 				result = Location{
 					uri:   target_uri

--- a/interop.v
+++ b/interop.v
@@ -121,8 +121,10 @@ fn uri_to_path(uri string) string {
 		rest = rest[..q]
 	}
 	decoded := percent_decode(rest)
-	if authority != '' {
-		// Preserve UNC authority: //server/share/...
+	// An empty or `localhost` authority denotes the local machine (RFC 8089), so
+	// the path is local: file://localhost/tmp/main.v -> /tmp/main.v. A genuine
+	// remote authority is preserved as a UNC path (//server/share/...).
+	if authority != '' && authority.to_lower() != 'localhost' {
 		return '//' + authority + decoded
 	}
 	// Windows drive path: /C:/Users/... -> C:/Users/...

--- a/interop.v
+++ b/interop.v
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a GPL license that can be found in the LICENSE file.
 module main
 
-import json
+import json2
 import os
 import strings
 import time
@@ -332,7 +332,7 @@ fn (mut app App) run_v_check(path string, text string) []JsonError {
 
 	cleanup_compilation_temp(temp_project_dir, singlefile_tmppath)
 
-	json_errors := json.decode([]JsonError, x.output) or {
+	json_errors := json2.decode[[]JsonError](x.output) or {
 		log('failed to parse json ${err}')
 		return []
 	}
@@ -496,7 +496,7 @@ fn symlink_untracked_files(working_dir string, temp_dir string, tracked_files ma
 // When an externally tracked file is created, changed, or deleted on disk,
 // this notification keeps the in-memory open_files map consistent.
 fn (mut app App) on_did_change_watched_files(request Request) {
-	params := json.decode(DidChangeWatchedFilesParams, request.params) or {
+	params := json2.decode[DidChangeWatchedFilesParams](request.params) or {
 		$if debug { log('Failed to decode DidChangeWatchedFilesParams: ${err}') }
 		return
 	}
@@ -659,11 +659,11 @@ fn (mut app App) run_v_line_info(method Method, path string, line_info string) R
 	mut result := ResponseResult('null')
 	match method {
 		.completion {
-			result_tmp := json.decode(JsonVarAC, x.output) or { JsonVarAC{} }
+			result_tmp := json2.decode[JsonVarAC](x.output) or { JsonVarAC{} }
 			result = result_tmp.details
 		}
 		.signature_help {
-			sig := json.decode(SignatureHelp, x.output) or { SignatureHelp{} }
+			sig := json2.decode[SignatureHelp](x.output) or { SignatureHelp{} }
 			// Return null when the compiler found no active signature so editors do not show
 			// empty signature popups (LSP spec: SignatureHelp | null).
 			if sig.signatures.len == 0 {
@@ -674,7 +674,7 @@ fn (mut app App) run_v_line_info(method Method, path string, line_info string) R
 		}
 		.hover {
 			// Decode the Hover JSON emitted by the compiler's hv^ mode.
-			hover_result := json.decode(Hover, x.output) or { Hover{} }
+			hover_result := json2.decode[Hover](x.output) or { Hover{} }
 			// Extract vdoc comment via cross-file search as a fallback when the
 			// compiler does not provide documentation.
 			mut doc := ''

--- a/interop.v
+++ b/interop.v
@@ -873,25 +873,33 @@ fn (mut app App) run_v_line_info(method Method, path string, line_info string) R
 				// spaces, `#`, `%`, or Unicode are valid and match the client's URI
 				// keys (P0-10). The compiler reports a byte column; convert it to
 				// the client's encoding using the target file's line (P0-01).
-				target_uri := path_to_uri(uri_path)
-				client_col := app.byte_col_to_client_col(target_uri, line_nr, col)
-				result = Location{
-					uri:   target_uri
-					range: LSPRange{
-						start: Position{
-							line: line_nr
-							char: client_col
-						}
-						end:   Position{
-							line: line_nr
-							char: client_col
-						}
-					}
-				}
+				result = app.compiler_location(uri_path, line_nr, col)
 			}
 		}
 		else {}
 	}
 
 	return result
+}
+
+// compiler_location maps a compiler-reported filesystem path back to the
+// original URI of an equivalent open document before converting its byte
+// column. This keeps both the URI spelling and position based on the
+// authoritative unsaved buffer.
+fn (app &App) compiler_location(path string, line int, byte_col int) Location {
+	target_uri := index_uri_for_path(path, app.open_index_uris_by_path())
+	client_col := app.byte_col_to_client_col(target_uri, line, byte_col)
+	return Location{
+		uri:   target_uri
+		range: LSPRange{
+			start: Position{
+				line: line
+				char: client_col
+			}
+			end:   Position{
+				line: line
+				char: client_col
+			}
+		}
+	}
 }

--- a/interop.v
+++ b/interop.v
@@ -234,11 +234,12 @@ fn resolve_compiler_timeout_ms() i64 {
 }
 
 // run_v_argv executes the V compiler with the given argument vector in
-// `work_folder` (set on the child process, never via a process-global chdir),
-// capturing stdout. stderr is captured separately and only logged, so it can
-// never corrupt the JSON the compiler writes to stdout. The child is killed if
-// it exceeds compiler_timeout_ms. This is the single, shell-free entry point for
-// all compiler invocations.
+// `work_folder` (set on the child process, never via a process-global chdir).
+// stdout and stderr are merged into one combined buffer because the compiler
+// writes its `-json-errors` / `-line-info` output to STDERR; returning stdout
+// alone would silently drop every diagnostic. The child is killed if it exceeds
+// compiler_timeout_ms. This is the single, shell-free entry point for all
+// compiler invocations.
 fn run_v_argv(args []string, work_folder string) os.Result {
 	if work_folder != '' && !os.is_dir(work_folder) {
 		msg := 'Working dir does not exist: ${work_folder}'
@@ -262,8 +263,12 @@ fn run_v_argv(args []string, work_folder string) os.Result {
 	mut out := strings.new_builder(1024)
 	start_ms := time.now().unix_milli()
 	mut timed_out := false
-	// Drain both pipes while the child runs so a large output cannot deadlock
-	// the child against a full pipe buffer, and enforce the timeout.
+	// Drain both pipes on every iteration and enforce the deadline. `pipe_read`
+	// is non-blocking (it polls the fd and returns none immediately when no data
+	// is pending), so a child that writes only to stderr, or one that hangs
+	// silently, never wedges this loop: the stderr drain still runs so a large
+	// payload cannot fill the pipe and deadlock the child, and the timeout check
+	// below still fires to kill a stuck process.
 	for p.is_alive() {
 		mut got_data := false
 		if chunk := p.pipe_read(.stdout) {

--- a/interop.v
+++ b/interop.v
@@ -594,8 +594,19 @@ fn (mut app App) on_did_change_watched_files(request Request) {
 		$if debug { log('Failed to decode DidChangeWatchedFilesParams: ${err}') }
 		return
 	}
+	open_uris_by_path := app.open_index_uris_by_path()
 	for change in params.changes {
-		uri := change.uri
+		event_uri := change.uri
+		uri := open_uris_by_path[normalized_index_path(uri_to_path(event_uri))] or { event_uri }
+		// A watcher may spell an open document URI differently from the client
+		// (for example file:///tmp/a.v versus file://localhost/tmp/a.v). Remove
+		// any disk-backed alias and keep all subsequent work on the authoritative
+		// editor-owned URI.
+		if event_uri != uri {
+			app.drop_index_uri(event_uri)
+			app.index_skipped_uris.delete(event_uri)
+			app.diag_cache.delete(event_uri)
+		}
 		match change.event_type {
 			3 {
 				// Deleted on disk. Invalidate cached diagnostics, but do NOT drop

--- a/interop.v
+++ b/interop.v
@@ -134,19 +134,59 @@ fn uri_to_path(uri string) string {
 	return decoded
 }
 
-// path_is_within reports whether `path` lies inside directory `dir`, using a
-// boundary-aware comparison so that e.g. /foo/barley is NOT treated as inside
-// /foo/bar (P1-01). Both arguments are expected to use '/' separators.
-fn path_is_within(path string, dir string) bool {
+// path_is_within_with_case reports whether `path` lies inside `dir` using the
+// requested case sensitivity. Both arguments are expected to use '/' separators.
+fn path_is_within_with_case(path string, dir string, case_insensitive bool) bool {
 	if dir == '' {
 		return false
 	}
-	d := dir.trim_right('/')
+	mut p := path
+	mut d := dir.trim_right('/')
+	if case_insensitive {
+		p = p.to_lower()
+		d = d.to_lower()
+	}
 	if d == '' {
 		// dir was the filesystem root.
-		return path.starts_with('/')
+		return p.starts_with('/')
 	}
-	return path == d || path.starts_with(d + '/')
+	return p == d || p.starts_with(d + '/')
+}
+
+// path_is_within reports whether `path` lies inside directory `dir`, using a
+// boundary-aware comparison so that e.g. /foo/barley is NOT treated as inside
+// /foo/bar (P1-01). Windows filesystem paths are compared case-insensitively.
+fn path_is_within(path string, dir string) bool {
+	$if windows {
+		return path_is_within_with_case(path, dir, true)
+	}
+	return path_is_within_with_case(path, dir, false)
+}
+
+// path_relative_to_with_case returns `path` relative to `dir` using the
+// requested case sensitivity. It slices by the original prefix length so paths
+// that differ only in casing still produce a valid relative path.
+fn path_relative_to_with_case(path string, dir string, case_insensitive bool) ?string {
+	if !path_is_within_with_case(path, dir, case_insensitive) {
+		return none
+	}
+	d := dir.trim_right('/')
+	if d == '' {
+		return path.trim_string_left('/')
+	}
+	if path.len == d.len {
+		return ''
+	}
+	return path[d.len..].trim_string_left('/')
+}
+
+// path_relative_to returns `path` relative to `dir` using platform filesystem
+// case rules.
+fn path_relative_to(path string, dir string) ?string {
+	$if windows {
+		return path_relative_to_with_case(path, dir, true)
+	}
+	return path_relative_to_with_case(path, dir, false)
 }
 
 // path_to_uri converts a local filesystem path to a `file:` DocumentUri,
@@ -460,15 +500,13 @@ fn (mut app App) write_tracked_files_to_temp(working_dir string) !string {
 		normalized_real := real_path.replace('\\', '/')
 		normalized_working := working_dir.replace('\\', '/')
 
-		// skip not in working dir (boundary-aware: /foo/barley is not in /foo/bar)
-		if !path_is_within(normalized_real, normalized_working) {
+		// Skip files outside the working dir. On Windows the containment check is
+		// case-insensitive, while the returned path preserves its original case.
+		mut rel_path := path_relative_to(normalized_real, normalized_working) or {
 			log('SKIPPING FILE: ${real_path}')
 			continue
 		}
 
-		// calc rel path
-		mut rel_path :=
-			normalized_real.replace(normalized_working, '').trim_string_left('/').trim_string_left('\\')
 		if rel_path == '' {
 			rel_path = os.file_name(real_path)
 		}

--- a/interop.v
+++ b/interop.v
@@ -16,6 +16,14 @@ fn resolve_v_compiler_exe() string {
 	return os.find_abs_path_of_executable('v') or { 'v' }
 }
 
+// compiler_is_available reports whether the V compiler was resolved to a real
+// executable path at startup. When false, compiler-backed features cannot work
+// and the failure should be surfaced to the user rather than masked as empty
+// results (P1-03).
+fn compiler_is_available() bool {
+	return v_compiler_exe != 'v' && os.exists(v_compiler_exe)
+}
+
 // hex_nibble returns the numeric value of a single hex digit, or none.
 fn hex_nibble(c u8) ?u8 {
 	return match c {
@@ -205,11 +213,32 @@ fn build_v_fmt_args(temp_file string) []string {
 	return ['fmt', '-inprocess', '-w', temp_file]
 }
 
+// Sentinel exit code returned when a compiler invocation is killed for
+// exceeding compiler_timeout_ms. 124 matches the coreutils `timeout` convention.
+const compiler_exit_timeout = 124
+
+// compiler_timeout_ms bounds how long any single compiler/formatter invocation
+// may run before it is force-killed, so a hung or runaway `v` process can never
+// freeze the server indefinitely (partial P0-04). Overridable via VLS_TIMEOUT_MS.
+const compiler_timeout_ms = resolve_compiler_timeout_ms()
+
+fn resolve_compiler_timeout_ms() i64 {
+	env := os.getenv('VLS_TIMEOUT_MS')
+	if env != '' {
+		n := env.i64()
+		if n > 0 {
+			return n
+		}
+	}
+	return 30_000
+}
+
 // run_v_argv executes the V compiler with the given argument vector in
 // `work_folder` (set on the child process, never via a process-global chdir),
 // capturing stdout. stderr is captured separately and only logged, so it can
-// never corrupt the JSON the compiler writes to stdout. This is the single,
-// shell-free entry point for all compiler invocations.
+// never corrupt the JSON the compiler writes to stdout. The child is killed if
+// it exceeds compiler_timeout_ms. This is the single, shell-free entry point for
+// all compiler invocations.
 fn run_v_argv(args []string, work_folder string) os.Result {
 	if work_folder != '' && !os.is_dir(work_folder) {
 		msg := 'Working dir does not exist: ${work_folder}'
@@ -228,14 +257,29 @@ fn run_v_argv(args []string, work_folder string) os.Result {
 	p.run()
 	mut out := strings.new_builder(1024)
 	mut errb := strings.new_builder(256)
+	start_ms := time.now().unix_milli()
+	mut timed_out := false
 	// Drain both pipes while the child runs so a large output cannot deadlock
-	// the child against a full pipe buffer.
+	// the child against a full pipe buffer, and enforce the timeout.
 	for p.is_alive() {
+		mut got_data := false
 		if chunk := p.pipe_read(.stdout) {
 			out.write_string(chunk)
+			got_data = true
 		}
 		if chunk := p.pipe_read(.stderr) {
 			errb.write_string(chunk)
+			got_data = true
+		}
+		if time.now().unix_milli() - start_ms > compiler_timeout_ms {
+			log('v invocation exceeded ${compiler_timeout_ms}ms; killing child')
+			p.signal_kill()
+			timed_out = true
+			break
+		}
+		if !got_data {
+			// Avoid busy-spinning while the child is compiling.
+			time.sleep(time.millisecond)
 		}
 	}
 	out.write_string(p.stdout_slurp())
@@ -246,6 +290,12 @@ fn run_v_argv(args []string, work_folder string) os.Result {
 	stderr_text := errb.str()
 	if stderr_text.trim_space() != '' {
 		log('v stderr: ${stderr_text}')
+	}
+	if timed_out {
+		return os.Result{
+			exit_code: compiler_exit_timeout
+			output:    ''
+		}
 	}
 	return os.Result{
 		exit_code: code
@@ -685,9 +735,11 @@ fn (mut app App) run_v_line_info(method Method, path string, line_info string) R
 			mut cursor_symbol := ''
 			if info_parts.len >= 2 {
 				cursor_line := info_parts[0].int() - 1
+				// cursor_col comes from the compiler line-info, which is a byte
+				// column, so treat it as a byte offset (utf8) here.
 				cursor_col := info_parts[1].all_after('hv^').int()
 				if cursor_line >= 0 && cursor_line < file_lines.len {
-					cursor_symbol = get_word_at_col(file_lines[cursor_line], cursor_col)
+					cursor_symbol = get_word_at_col(file_lines[cursor_line], cursor_col, .utf8)
 					if cursor_symbol != '' {
 						doc = app.find_doc_comment_for_symbol(cursor_symbol, file_lines, path)
 					}
@@ -749,16 +801,20 @@ fn (mut app App) run_v_line_info(method Method, path string, line_info string) R
 					log('MAPPED TO uri_path=${uri_path}')
 				}
 				uri_header := if uri_path.starts_with('/') { 'file://' } else { 'file:///' }
+				// The compiler reports a byte column; convert it to the client's
+				// encoding using the target file's line (P0-01).
+				target_uri := uri_header + uri_path
+				client_col := app.byte_col_to_client_col(target_uri, line_nr, col)
 				result = Location{
-					uri:   uri_header + uri_path
+					uri:   target_uri
 					range: LSPRange{
 						start: Position{
 							line: line_nr
-							char: col
+							char: client_col
 						}
 						end:   Position{
 							line: line_nr
-							char: col
+							char: client_col
 						}
 					}
 				}

--- a/interop.v
+++ b/interop.v
@@ -255,8 +255,11 @@ fn run_v_argv(args []string, work_folder string) os.Result {
 	}
 	p.set_redirect_stdio()
 	p.run()
+	// The V compiler writes its `-json-errors` / `-line-info` output to STDERR,
+	// so both streams are captured into one combined buffer (equivalent to the
+	// shell `2>&1` the previous implementation relied on). Returning stdout alone
+	// would silently drop every diagnostic.
 	mut out := strings.new_builder(1024)
-	mut errb := strings.new_builder(256)
 	start_ms := time.now().unix_milli()
 	mut timed_out := false
 	// Drain both pipes while the child runs so a large output cannot deadlock
@@ -268,7 +271,7 @@ fn run_v_argv(args []string, work_folder string) os.Result {
 			got_data = true
 		}
 		if chunk := p.pipe_read(.stderr) {
-			errb.write_string(chunk)
+			out.write_string(chunk)
 			got_data = true
 		}
 		if time.now().unix_milli() - start_ms > compiler_timeout_ms {
@@ -283,14 +286,10 @@ fn run_v_argv(args []string, work_folder string) os.Result {
 		}
 	}
 	out.write_string(p.stdout_slurp())
-	errb.write_string(p.stderr_slurp())
+	out.write_string(p.stderr_slurp())
 	p.wait()
 	code := p.code
 	p.close()
-	stderr_text := errb.str()
-	if stderr_text.trim_space() != '' {
-		log('v stderr: ${stderr_text}')
-	}
 	if timed_out {
 		return os.Result{
 			exit_code: compiler_exit_timeout

--- a/interop.v
+++ b/interop.v
@@ -561,6 +561,11 @@ fn (mut app App) on_did_change_watched_files(request Request) {
 					app.diag_cache.delete(uri)
 				}
 				app.bump_generation(uri)
+				// Re-index from disk when no editor buffer owns the URI (the file
+				// was removed, so this drops the entry).
+				if uri !in app.open_files {
+					app.reindex_uri(uri)
+				}
 				log('on_did_change_watched_files: disk delete for ${uri}')
 			}
 			1, 2 {
@@ -571,6 +576,9 @@ fn (mut app App) on_did_change_watched_files(request Request) {
 				// non-open files from disk.
 				if uri in app.open_files {
 					log('on_did_change_watched_files: ignoring disk change for open buffer ${uri}')
+				} else {
+					// Re-read this file from disk into the index.
+					app.reindex_uri(uri)
 				}
 				if uri in app.diag_cache {
 					app.diag_cache.delete(uri)

--- a/interop.v
+++ b/interop.v
@@ -796,7 +796,10 @@ fn (mut app App) run_v_line_info(method Method, path string, line_info string) R
 				if cursor_line >= 0 && cursor_line < file_lines.len {
 					cursor_symbol = get_word_at_col(file_lines[cursor_line], cursor_col, .utf8)
 					if cursor_symbol != '' {
-						doc = app.find_doc_comment_for_symbol(cursor_symbol, file_lines, path)
+						imported_module := imported_module_at_symbol(file_lines[cursor_line],
+							cursor_col, file_content)
+						doc = app.find_doc_comment_for_symbol(cursor_symbol, file_lines, path,
+							imported_module)
 					}
 				}
 			}

--- a/interop.v
+++ b/interop.v
@@ -660,8 +660,9 @@ fn (mut app App) run_v_line_info(method Method, path string, line_info string) R
 			log('WRITING FILE ${time.now()} to temp path ${singlefile_tmppath}')
 			// Overlay the requested document's open buffer, never a global
 			// "last touched" field, so a request for one URI can't compile the
-			// buffer of another (P1-02).
-			request_content := app.open_files[path] or { os.read_file(real_path) or { app.text } }
+			// buffer of another (P1-02). Fall back to this exact file on disk, or
+			// empty — never to another document's content.
+			request_content := app.open_files[path] or { os.read_file(real_path) or { '' } }
 			mut wrote_temp := true
 			os.write_file(singlefile_tmppath, request_content) or {
 				wrote_temp = false
@@ -736,7 +737,9 @@ fn (mut app App) run_v_line_info(method Method, path string, line_info string) R
 			// Extract vdoc comment via cross-file search as a fallback when the
 			// compiler does not provide documentation.
 			mut doc := ''
-			file_content := app.open_files[path] or { app.text }
+			// Use the requested document's buffer, else this exact file from disk
+			// — never a global last-touched buffer (P1-02).
+			file_content := app.open_files[path] or { os.read_file(real_path) or { '' } }
 			file_lines := file_content.split_into_lines()
 			// line_info format for hover is "${line_nr}:hv^${col}"
 			info_parts := line_info.split(':')

--- a/interop_test.v
+++ b/interop_test.v
@@ -67,6 +67,15 @@ fn test_uri_to_path_percent_encoded_hash_and_percent() {
 	assert uri_to_path('file:///home/user/100%25.v') == '/home/user/100%.v'
 }
 
+fn test_uri_to_path_localhost_authority_is_local() {
+	// A `localhost` authority denotes the local machine (RFC 8089), so the path
+	// must resolve to the local file, not a //localhost/... UNC-style path.
+	assert uri_to_path('file://localhost/tmp/main.v') == '/tmp/main.v'
+	assert uri_to_path('file://LOCALHOST/tmp/main.v') == '/tmp/main.v'
+	// A genuine remote authority is still preserved as a UNC path.
+	assert uri_to_path('file://server/share/main.v') == '//server/share/main.v'
+}
+
 fn test_uri_to_path_drops_fragment_and_query() {
 	assert uri_to_path('file:///home/user/test.v#L10') == '/home/user/test.v'
 	assert uri_to_path('file:///home/user/test.v?rev=2') == '/home/user/test.v'

--- a/interop_test.v
+++ b/interop_test.v
@@ -3,7 +3,7 @@
 module main
 
 import os
-import json
+import json2
 import time
 
 fn interop_test_must_mkdir_all(path string) {
@@ -597,7 +597,7 @@ fn test_request_struct() {
 		id:      1
 		method:  'textDocument/completion'
 		jsonrpc: '2.0'
-		params:  json.encode(Params{
+		params:  json2.encode(Params{
 			position:      Position{
 				line: 5
 				char: 10
@@ -605,11 +605,13 @@ fn test_request_struct() {
 			text_document: TextDocumentIdentifier{
 				uri: 'file:///test.v'
 			}
-		})
+		},
+			escape_unicode: true
+		)
 	}
 	assert req.id == 1
 	assert req.method == 'textDocument/completion'
-	params := json.decode(Params, req.params.str()) or {
+	params := json2.decode[Params](req.params.str()) or {
 		assert false, 'decode failed: ${err}'
 		return
 	}
@@ -618,7 +620,7 @@ fn test_request_struct() {
 
 fn test_request_params_decode_malformed_returns_error() {
 	malformed := '{"textDocument":{"uri":"file:///test.v"},"position":{"line":5,"character":}}'
-	if _ := json.decode(Params, malformed) {
+	if _ := json2.decode[Params](malformed) {
 		assert false, 'Expected malformed params JSON to fail decoding'
 	} else {
 		assert true

--- a/interop_test.v
+++ b/interop_test.v
@@ -114,6 +114,18 @@ fn test_uri_to_path_with_dots() {
 	assert result == '/path/./to/../file.v'
 }
 
+fn test_path_is_within_with_case_accepts_windows_case_differences() {
+	assert path_is_within_with_case('c:/repo/src/main.v', 'C:/Repo', true)
+	assert path_is_within_with_case('//server/share/FILE.v', '//SERVER/SHARE', true)
+	assert !path_is_within_with_case('c:/repository/main.v', 'C:/Repo', true)
+	assert !path_is_within_with_case('c:/repo/src/main.v', 'C:/Repo', false)
+	relative := path_relative_to_with_case('c:/repo/src/Main.v', 'C:/Repo', true) or {
+		assert false, 'expected a relative Windows path'
+		return
+	}
+	assert relative == 'src/Main.v'
+}
+
 // --- path_to_uri tests ---
 
 fn test_path_to_uri_unix() {

--- a/interop_test.v
+++ b/interop_test.v
@@ -168,6 +168,34 @@ fn test_path_to_uri_parent_dir() {
 	assert result.contains('file.v')
 }
 
+fn test_compiler_location_reuses_equivalent_open_uri() {
+	temp_dir := os.join_path(os.temp_dir(), 'vls_compiler_location_${os.getpid()}')
+	interop_test_must_mkdir_all(temp_dir)
+	defer {
+		os.rmdir_all(temp_dir) or {}
+	}
+	path := os.join_path(temp_dir, 'main.v')
+	interop_test_must_write_file(path, 'aaaa target\n')
+	canonical_uri := path_to_uri(path)
+	open_uri := canonical_uri.replace_once('file:///', 'file://localhost/')
+	mut app := &App{
+		open_files:        map[string]string{}
+		position_encoding: .utf16
+	}
+	app.open_files[open_uri] = '🚀 target\n'
+
+	location := app.compiler_location(path, 0, 5)
+
+	assert location.uri == open_uri
+	assert location.range.start.char == 3
+	assert location.range.end.char == 3
+
+	app.position_encoding = .utf32
+	location_utf32 := app.compiler_location(path, 0, 5)
+	assert location_utf32.uri == open_uri
+	assert location_utf32.range.start.char == 2
+}
+
 // --- Round-trip conversion tests ---
 
 fn test_path_uri_roundtrip() {

--- a/interop_test.v
+++ b/interop_test.v
@@ -56,9 +56,33 @@ fn test_uri_to_path_no_prefix() {
 }
 
 fn test_uri_to_path_special_characters() {
-	// Paths with spaces or special chars
+	// Percent-encoded spaces must be decoded to real spaces (P0-10).
 	result := uri_to_path('file:///home/user/my%20project/test.v')
-	assert result.contains('my%20project') || result.contains('my project')
+	assert result == '/home/user/my project/test.v'
+}
+
+fn test_uri_to_path_percent_encoded_hash_and_percent() {
+	// %23 -> '#', %25 -> '%' must round back to the literal characters.
+	assert uri_to_path('file:///home/user/a%23b.v') == '/home/user/a#b.v'
+	assert uri_to_path('file:///home/user/100%25.v') == '/home/user/100%.v'
+}
+
+fn test_uri_to_path_drops_fragment_and_query() {
+	assert uri_to_path('file:///home/user/test.v#L10') == '/home/user/test.v'
+	assert uri_to_path('file:///home/user/test.v?rev=2') == '/home/user/test.v'
+}
+
+fn test_uri_path_roundtrip_with_spaces_and_hash() {
+	for original in ['/home/user/my project/a#b.v', '/tmp/weird %name%.v', '/a/plus+file.v'] {
+		uri := path_to_uri(original)
+		// The URI must not contain a raw space.
+		assert !uri.contains(' ')
+		assert uri_to_path(uri) == original
+	}
+}
+
+fn test_path_to_uri_encodes_space() {
+	assert path_to_uri('/home/user/my project/a.v') == 'file:///home/user/my%20project/a.v'
 }
 
 fn test_uri_to_path_empty_string() {
@@ -95,9 +119,12 @@ fn test_path_to_uri_relative() {
 }
 
 fn test_path_to_uri_with_backslashes() {
-	// Backslashes should be converted to forward slashes
-	result := path_to_uri('/home/user\\project\\main.v')
-	assert result.contains('/home/user/project/main.v') || result.contains('\\')
+	// On POSIX a backslash is a valid, literal filename character. It must be
+	// percent-encoded in the URI (never left raw) and must round-trip exactly.
+	original := '/home/user\\project\\main.v'
+	result := path_to_uri(original)
+	assert !result.contains('\\')
+	assert uri_to_path(result) == original
 }
 
 fn test_path_to_uri_empty() {
@@ -186,58 +213,51 @@ fn test_cleanup_compilation_temp_removes_project_dir() {
 	assert !os.exists(project_dir)
 }
 
-fn test_ensure_stderr_captured_appends_redirect() {
-	cmd := ensure_stderr_captured('echo hello')
-	assert cmd.ends_with('2>&1')
+// Compiler invocation is now argv-based (no shell). These tests assert that
+// filenames — including ones containing shell metacharacters — are passed as
+// single, literal argument-vector elements, so command injection is impossible.
+
+fn test_build_v_check_args_single_passes_path_literally() {
+	args := build_v_check_args_single('/tmp/a b/test.v')
+	assert '/tmp/a b/test.v' in args
+	assert '-vls-mode' in args
+	assert '-check' in args
 }
 
-fn test_ensure_stderr_captured_keeps_existing_redirect() {
-	cmd := ensure_stderr_captured('echo hello 2>&1')
-	assert cmd == 'echo hello 2>&1'
-}
-
-fn test_execute_in_dir_restores_working_directory() {
-	original := os.getwd()
-	work_dir := os.join_path(os.temp_dir(), 'vls_exec_dir_${os.getpid()}_${time.now().unix_nano()}')
-	interop_test_must_mkdir_all(work_dir)
-	defer {
-		os.rmdir_all(work_dir) or {}
+fn test_build_v_check_args_single_no_shell_injection() {
+	// A path containing command substitution must remain one literal argv element.
+	malicious := '/tmp/$(touch /tmp/pwned)/x.v'
+	args := build_v_check_args_single(malicious)
+	assert malicious in args
+	// The dangerous text is never split or interpreted; it is exactly one element.
+	mut count := 0
+	for a in args {
+		if a == malicious {
+			count++
+		}
 	}
-
-	mut result := execute_in_dir(work_dir, 'pwd')
-	$if windows {
-		// On Windows, os.execute uses cmd.exe which understands echo %cd%
-		result = execute_in_dir(work_dir, 'echo %cd%')
-	}
-	// Use real_path to resolve symlinks (e.g. /tmp -> /private/tmp on macOS)
-	assert os.real_path(result.output.trim_space()) == os.real_path(work_dir)
-	assert os.getwd() == original
+	assert count == 1
 }
 
-fn test_execute_in_dir_returns_error_when_directory_missing() {
-	original := os.getwd()
+fn test_build_v_fmt_args_passes_temp_file_literally() {
+	args := build_v_fmt_args('/tmp/fmt file.v')
+	assert args == ['fmt', '-inprocess', '-w', '/tmp/fmt file.v']
+}
+
+fn test_build_v_line_info_args_single_embeds_line_info() {
+	args := build_v_line_info_args_single('/tmp/a.v', '10:gd^5', '/tmp/a.v')
+	assert '/tmp/a.v:10:gd^5' in args
+	assert '-line-info' in args
+}
+
+fn test_run_v_argv_reports_missing_working_dir() {
 	missing_dir := os.join_path(os.temp_dir(),
 		'vls_missing_dir_${os.getpid()}_${time.now().unix_nano()}')
-	result := execute_in_dir(missing_dir, 'pwd')
+	original := os.getwd()
+	result := run_v_argv(build_v_check_args_multifile(), missing_dir)
 	assert result.exit_code != 0
-	assert result.output.contains('Failed to change to working dir')
+	// The parent process working directory must never be mutated.
 	assert os.getwd() == original
-}
-
-fn test_shell_quote_handles_single_quotes() {
-	quoted := shell_quote("a'b")
-	assert quoted == '"a\'b"'
-}
-
-fn test_build_v_check_cmd_single_quotes_path() {
-	cmd := build_v_check_cmd_single('/tmp/a b/test.v')
-	assert cmd.contains('"/tmp/a b/test.v"')
-	assert cmd.contains('-vls-mode')
-}
-
-fn test_build_v_fmt_cmd_quotes_temp_file() {
-	cmd := build_v_fmt_cmd('/tmp/fmt file.v')
-	assert cmd == 'v fmt -inprocess -w "/tmp/fmt file.v"'
 }
 
 // ============================================================================
@@ -953,15 +973,19 @@ fn test_json_error_defaults() {
 }
 
 fn test_json_error_negative_values() {
-	// Negative values shouldn't crash, though they're invalid
+	// LSP positions must be non-negative. Invalid compiler values are clamped
+	// to 0 rather than emitted as negative positions (P1-09).
 	err := JsonError{
 		line_nr: -1
 		col:     -1
 		len:     -1
 	}
 	diag := v_error_to_lsp_diagnostic(err)
-	// Should still produce a diagnostic (values will be negative but won't crash)
 	assert diag.severity == 1
+	assert diag.range.start.line == 0
+	assert diag.range.start.char == 0
+	assert diag.range.end.line == 0
+	assert diag.range.end.char == 0
 }
 
 fn test_text_document_identifier() {

--- a/lsp.v
+++ b/lsp.v
@@ -756,7 +756,7 @@ struct CodeActionParams {
 // is 1 = Invoked, 2 = Automatic (LSP §3.17 CodeActionContext).
 struct CodeActionContext {
 	diagnostics  []LSPDiagnostic
-	only         ?[]string @[json: 'only']
+	only         ?[]string
 	trigger_kind ?int      @[json: 'triggerKind']
 }
 

--- a/lsp.v
+++ b/lsp.v
@@ -10,6 +10,16 @@ struct Request {
 	params  string // raw JSON for method-specific params
 }
 
+// RequestBody decodes an inbound message WITHOUT the `id` field. json2 aborts
+// the entire decode if a string id lands in an int field, so the id is parsed
+// separately (see extract_raw_id / raw_id_to_int) and this struct captures only
+// the id-independent members.
+struct RequestBody {
+	method  string
+	jsonrpc string
+	params  string // raw JSON for method-specific params
+}
+
 // Position represents a position in a text document (zero-based line and character).
 struct Position {
 	line int
@@ -768,6 +778,29 @@ struct DocumentHighlightParams {
 struct SelectionRange {
 	range  LSPRange
 	parent ?&SelectionRange
+}
+
+// to_json is a custom json2 encoder for SelectionRange. json2's compile-time
+// encoder cannot derive an encoder for the self-referential `?&SelectionRange`
+// parent field, so we serialize the recursive parent chain by hand. Implementing
+// the JsonEncoder interface makes json2 call this instead of generating code.
+pub fn (s SelectionRange) to_json() string {
+	mut out := '{"range":${lsprange_to_json(s.range)}'
+	if p := s.parent {
+		out += ',"parent":${p.to_json()}'
+	}
+	out += '}'
+	return out
+}
+
+// position_to_json and lsprange_to_json encode Position/LSPRange without pulling
+// a json dependency into the (otherwise pure) type-definition file.
+fn position_to_json(p Position) string {
+	return '{"line":${p.line},"character":${p.char}}'
+}
+
+fn lsprange_to_json(r LSPRange) string {
+	return '{"start":${position_to_json(r.start)},"end":${position_to_json(r.end)}}'
 }
 
 // SelectionRangeParams holds parameters for textDocument/selectionRange.

--- a/lsp.v
+++ b/lsp.v
@@ -263,14 +263,14 @@ struct Capability {
 	hover_provider                     bool                     @[json: 'hoverProvider']
 	references_provider                bool                     @[json: 'referencesProvider']
 	rename_provider                    RenameOptions            @[json: 'renameProvider']
-	execute_command_provider           ExecuteCommandOptions    @[json: 'executeCommandProvider']
+	execute_command_provider           ?ExecuteCommandOptions   @[json: 'executeCommandProvider']
 	document_formatting_provider       bool                     @[json: 'documentFormattingProvider']
 	document_range_formatting_provider bool                     @[json: 'documentRangeFormattingProvider']
 	document_symbol_provider           bool                     @[json: 'documentSymbolProvider']
 	workspace_symbol_provider          bool                     @[json: 'workspaceSymbolProvider']
 	inlay_hint_provider                bool                     @[json: 'inlayHintProvider']
 	code_action_provider               bool                     @[json: 'codeActionProvider']
-	code_lens_provider                 CodeLensOptions          @[json: 'codeLensProvider']
+	code_lens_provider                 ?CodeLensOptions         @[json: 'codeLensProvider']
 	inline_value_provider              bool                     @[json: 'inlineValueProvider']
 	linked_editing_range_provider      bool                     @[json: 'linkedEditingRangeProvider']
 	on_type_formatting_provider        ?OnTypeFormattingOptions @[json: 'documentOnTypeFormattingProvider']
@@ -742,8 +742,12 @@ struct CodeActionParams {
 }
 
 // CodeActionContext contains context for a code action request.
+// `only` restricts the kinds of actions the client wants; `trigger_kind`
+// is 1 = Invoked, 2 = Automatic (LSP §3.17 CodeActionContext).
 struct CodeActionContext {
-	diagnostics []LSPDiagnostic
+	diagnostics  []LSPDiagnostic
+	only         ?[]string @[json: 'only']
+	trigger_kind ?int      @[json: 'triggerKind']
 }
 
 // DocumentHighlight represents a highlighted occurrence of a symbol in a document.

--- a/lsp_test.v
+++ b/lsp_test.v
@@ -1653,6 +1653,9 @@ fn test_is_client_response_message_detection() {
 	assert is_client_response_message('{"jsonrpc":"2.0","id":2,"error":{"code":-1,"message":"x"}}')
 	assert !is_client_response_message('{"jsonrpc":"2.0","id":2,"method":"initialize","params":{}}')
 	assert !is_client_response_message('{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{}}')
+	// A response whose id key is unicode-escaped (id) must still be recognized
+	// as a response and consumed, not dispatched as an empty method.
+	assert is_client_response_message('{"jsonrpc":"2.0","\\u0069d":1,"result":null}')
 }
 
 fn test_inject_raw_id_restores_string_id() {

--- a/lsp_test.v
+++ b/lsp_test.v
@@ -674,6 +674,14 @@ fn test_read_request_accepts_lowercase_content_length_header() {
 	assert decoded == payload
 }
 
+fn test_tcp_bind_address_brackets_ipv6_literals() {
+	assert tcp_bind_address('::1', '5007') == '[::1]:5007'
+	assert tcp_bind_address('2001:db8::1', '5007') == '[2001:db8::1]:5007'
+	assert tcp_bind_address('[::1]', '5007') == '[::1]:5007'
+	assert tcp_bind_address('127.0.0.1', '5007') == '127.0.0.1:5007'
+	assert tcp_bind_address('', '5007') == '127.0.0.1:5007'
+}
+
 fn test_parse_content_length_header_rejects_non_numeric() {
 	parse_content_length_header('12x') or {
 		assert err.msg().contains('non-numeric')

--- a/lsp_test.v
+++ b/lsp_test.v
@@ -682,11 +682,40 @@ fn test_parse_content_length_header_rejects_non_numeric() {
 	assert false, 'expected parse_content_length_header to fail for non-numeric input'
 }
 
-fn test_read_request_accepts_any_content_type_charset_header() {
+fn test_read_request_rejects_non_utf8_charset_header() {
+	// LSP content is always UTF-8; a declared utf-16 charset must be rejected
+	// rather than silently misdecoded (P0-11).
 	payload := '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}'
 	framed := 'Content-Length: ${payload.len}\r\nContent-Type: application/vscode-jsonrpc; charset=utf-16\r\n\r\n${payload}'
-	tmp := os.join_path(os.temp_dir(),
-		'vls_read_request_any_charset_content_type_${os.getpid()}.txt')
+	tmp := os.join_path(os.temp_dir(), 'vls_read_request_non_utf8_charset_${os.getpid()}.txt')
+	os.write_file(tmp, framed) or {
+		assert false, 'Failed to write temp request file: ${err}'
+		return
+	}
+	defer {
+		os.rm(tmp) or {}
+	}
+	mut f := os.open(tmp) or {
+		assert false, 'Failed to open temp request file: ${err}'
+		return
+	}
+	defer {
+		f.close()
+	}
+	mut reader := io.new_buffered_reader(reader: f, cap: 1)
+	if _ := read_request(mut reader) {
+		assert false, 'expected read_request to reject non-UTF-8 charset'
+	} else {
+		assert err.msg().starts_with('invalid header:')
+		assert err.msg().contains('charset')
+	}
+}
+
+fn test_read_request_accepts_utf8_charset_header() {
+	// An explicit UTF-8 charset is fine and must not be rejected.
+	payload := '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}'
+	framed := 'Content-Length: ${payload.len}\r\nContent-Type: application/vscode-jsonrpc; charset=utf-8\r\n\r\n${payload}'
+	tmp := os.join_path(os.temp_dir(), 'vls_read_request_utf8_charset_${os.getpid()}.txt')
 	os.write_file(tmp, framed) or {
 		assert false, 'Failed to write temp request file: ${err}'
 		return
@@ -707,6 +736,32 @@ fn test_read_request_accepts_any_content_type_charset_header() {
 		return
 	}
 	assert decoded == payload
+}
+
+fn test_read_request_rejects_oversized_content_length() {
+	// A huge Content-Length must be refused before allocating (P0-11).
+	framed := 'Content-Length: 999999999999\r\n\r\n'
+	tmp := os.join_path(os.temp_dir(), 'vls_read_request_oversized_${os.getpid()}.txt')
+	os.write_file(tmp, framed) or {
+		assert false, 'Failed to write temp request file: ${err}'
+		return
+	}
+	defer {
+		os.rm(tmp) or {}
+	}
+	mut f := os.open(tmp) or {
+		assert false, 'Failed to open temp request file: ${err}'
+		return
+	}
+	defer {
+		f.close()
+	}
+	mut reader := io.new_buffered_reader(reader: f, cap: 1)
+	if _ := read_request(mut reader) {
+		assert false, 'expected read_request to reject oversized Content-Length'
+	} else {
+		assert err.msg().starts_with('invalid header:')
+	}
 }
 
 fn test_read_request_rejects_conflicting_content_length_headers() {
@@ -1480,4 +1535,64 @@ fn test_capability_code_lens_provider_json_encoding_object_shape() {
 	encoded := json.encode(caps)
 	assert encoded.contains('"codeLensProvider":{}')
 	assert !encoded.contains('"codeLensProvider":true')
+}
+
+// --- P0-02 / P0-03: JSON-RPC envelope, string ids, direction ---
+
+fn test_extract_raw_id_numeric() {
+	id := extract_raw_id('{"id":5,"method":"x"}') or {
+		assert false, 'expected id'
+		return
+	}
+	assert id == '5'
+}
+
+fn test_extract_raw_id_string_preserves_quotes() {
+	id := extract_raw_id('{"jsonrpc":"2.0","id":"abc-1","method":"x"}') or {
+		assert false, 'expected id'
+		return
+	}
+	assert id == '"abc-1"'
+}
+
+fn test_extract_raw_id_null_is_none() {
+	assert extract_raw_id('{"id":null,"method":"x"}') == none
+}
+
+fn test_extract_raw_id_ignores_nested_id() {
+	// An "id" inside params must not be mistaken for the top-level id.
+	id := extract_raw_id('{"method":"x","params":{"id":99},"id":7}') or {
+		assert false, 'expected id'
+		return
+	}
+	assert id == '7'
+}
+
+fn test_extract_raw_id_absent_is_none() {
+	assert extract_raw_id('{"method":"x","params":{}}') == none
+}
+
+fn test_is_client_response_message_detection() {
+	assert is_client_response_message('{"jsonrpc":"2.0","id":2,"result":null}')
+	assert is_client_response_message('{"jsonrpc":"2.0","id":2,"error":{"code":-1,"message":"x"}}')
+	assert !is_client_response_message('{"jsonrpc":"2.0","id":2,"method":"initialize","params":{}}')
+	assert !is_client_response_message('{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{}}')
+}
+
+fn test_inject_raw_id_restores_string_id() {
+	assert inject_raw_id('{"id":0,"result":null,"jsonrpc":"2.0"}', '"abc"') == '{"id":"abc","result":null,"jsonrpc":"2.0"}'
+}
+
+fn test_inject_raw_id_numeric_is_noop() {
+	assert inject_raw_id('{"id":5,"result":null}', '5') == '{"id":5,"result":null}'
+}
+
+fn test_method_is_notification_only_contract() {
+	assert method_is_notification_only(.did_open)
+	assert method_is_notification_only(.did_change)
+	assert method_is_notification_only(.cancel_request)
+	assert !method_is_notification_only(.completion)
+	assert !method_is_notification_only(.shutdown)
+	// exit is excluded so the shutdown/exit lifecycle stays robust.
+	assert !method_is_notification_only(.exit)
 }

--- a/lsp_test.v
+++ b/lsp_test.v
@@ -1604,6 +1604,28 @@ fn test_raw_id_is_valid_rejects_other_types() {
 	assert !raw_id_is_valid(bad)
 }
 
+fn test_watcher_registration_rejection_keeps_refresh_fallback() {
+	mut app := &App{}
+	app.watched_files_registration_id = '7' // pretend we sent registration with id 7
+	// The client rejects registration: watchers never activate, so the timed
+	// index refresh fallback must stay on (no watcher events will arrive).
+	app.note_server_request_response('{"jsonrpc":"2.0","id":7,"error":{"code":-32601,"message":"unsupported"}}')
+	assert !app.watched_files_active
+	assert app.index_dir_needs_refresh('/some/dir')
+}
+
+fn test_watcher_registration_success_stops_refresh() {
+	mut app := &App{}
+	app.watched_files_registration_id = '7'
+	// A response for a DIFFERENT id must not activate watchers.
+	app.note_server_request_response('{"jsonrpc":"2.0","id":8,"result":null}')
+	assert !app.watched_files_active
+	// The success response for our id activates watchers and stands the fallback down.
+	app.note_server_request_response('{"jsonrpc":"2.0","id":7,"result":null}')
+	assert app.watched_files_active
+	assert !app.index_dir_needs_refresh('/some/dir')
+}
+
 fn test_is_client_response_message_detection() {
 	assert is_client_response_message('{"jsonrpc":"2.0","id":2,"result":null}')
 	assert is_client_response_message('{"jsonrpc":"2.0","id":2,"error":{"code":-1,"message":"x"}}')

--- a/lsp_test.v
+++ b/lsp_test.v
@@ -1596,3 +1596,34 @@ fn test_method_is_notification_only_contract() {
 	// exit is excluded so the shutdown/exit lifecycle stays robust.
 	assert !method_is_notification_only(.exit)
 }
+
+fn test_encode_response_payload_strips_type_from_array_variant() {
+	// Array-of-struct result variants (e.g. []WorkspaceSymbol) must also have
+	// their per-element `_type` discriminators stripped (P1-10).
+	resp := Response{
+		id:     9
+		result: [
+			WorkspaceSymbol{
+				name:     'helper_fn'
+				kind:     sym_kind_function
+				location: Location{
+					uri:   'file:///tmp/lib.v'
+					range: LSPRange{}
+				}
+			},
+		]
+	}
+	encoded := encode_response_payload(resp)
+	assert encoded.contains('"name":"helper_fn"')
+	assert !encoded.contains('"_type"')
+}
+
+fn test_strip_sum_type_tags_handles_multiple_and_positions() {
+	// Tag as last member, first member, and only member.
+	assert strip_response_sum_type_tags('{"a":1,"_type":"X"}') == '{"a":1}'
+	assert strip_response_sum_type_tags('{"_type":"X","a":1}') == '{"a":1}'
+	assert strip_response_sum_type_tags('{"_type":"X"}') == '{}'
+	assert strip_response_sum_type_tags('[{"a":1,"_type":"X"},{"b":2,"_type":"Y"}]') == '[{"a":1},{"b":2}]'
+	// No tag: unchanged.
+	assert strip_response_sum_type_tags('{"a":1}') == '{"a":1}'
+}

--- a/lsp_test.v
+++ b/lsp_test.v
@@ -1572,6 +1572,30 @@ fn test_extract_raw_id_absent_is_none() {
 	assert extract_raw_id('{"method":"x","params":{}}') == none
 }
 
+fn test_raw_id_is_valid_accepts_strings_and_numbers() {
+	assert raw_id_is_valid('') // absent/null id
+	assert raw_id_is_valid('5')
+	assert raw_id_is_valid('-3')
+	assert raw_id_is_valid('"abc-1"')
+}
+
+fn test_raw_id_is_valid_rejects_other_types() {
+	// Booleans, objects, and arrays are not legal JSON-RPC ids.
+	assert !raw_id_is_valid('true')
+	assert !raw_id_is_valid('false')
+	assert !raw_id_is_valid('{}')
+	assert !raw_id_is_valid('{"a":1}')
+	assert !raw_id_is_valid('[]')
+	assert !raw_id_is_valid('[1,2]')
+	// extract_raw_id returns these exact tokens, so the pair rejects the request.
+	bad := extract_raw_id('{"id":true,"method":"x"}') or {
+		assert false, 'expected raw id token'
+		return
+	}
+	assert bad == 'true'
+	assert !raw_id_is_valid(bad)
+}
+
 fn test_is_client_response_message_detection() {
 	assert is_client_response_message('{"jsonrpc":"2.0","id":2,"result":null}')
 	assert is_client_response_message('{"jsonrpc":"2.0","id":2,"error":{"code":-1,"message":"x"}}')

--- a/lsp_test.v
+++ b/lsp_test.v
@@ -738,6 +738,32 @@ fn test_read_request_accepts_utf8_charset_header() {
 	assert decoded == payload
 }
 
+fn test_read_request_accepts_quoted_utf8_charset_with_additional_parameters() {
+	payload := '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}'
+	framed := 'Content-Length: ${payload.len}\r\nContent-Type: application/vscode-jsonrpc; charset="utf-8"; version=1\r\n\r\n${payload}'
+	tmp := os.join_path(os.temp_dir(), 'vls_read_request_quoted_utf8_${os.getpid()}.txt')
+	os.write_file(tmp, framed) or {
+		assert false, 'Failed to write temp request file: ${err}'
+		return
+	}
+	defer {
+		os.rm(tmp) or {}
+	}
+	mut f := os.open(tmp) or {
+		assert false, 'Failed to open temp request file: ${err}'
+		return
+	}
+	defer {
+		f.close()
+	}
+	mut reader := io.new_buffered_reader(reader: f, cap: 1)
+	decoded := read_request(mut reader) or {
+		assert false, 'read_request failed: ${err}'
+		return
+	}
+	assert decoded == payload
+}
+
 fn test_read_request_rejects_oversized_content_length() {
 	// A huge Content-Length must be refused before allocating (P0-11).
 	framed := 'Content-Length: 999999999999\r\n\r\n'

--- a/lsp_test.v
+++ b/lsp_test.v
@@ -1555,8 +1555,16 @@ fn test_extract_raw_id_string_preserves_quotes() {
 	assert id == '"abc-1"'
 }
 
-fn test_extract_raw_id_null_is_none() {
-	assert extract_raw_id('{"id":null,"method":"x"}') == none
+fn test_extract_raw_id_present_null_is_literal() {
+	// A present null id is a request with a null id (JSON-RPC permits it), not a
+	// notification: it must be distinguished from an absent id.
+	id := extract_raw_id('{"id":null,"method":"x"}') or {
+		assert false, 'present null id must not be none'
+		return
+	}
+	assert id == 'null'
+	assert raw_id_is_valid(id)
+	assert request_content_has_id('{"id":null,"method":"x"}')
 }
 
 fn test_extract_raw_id_ignores_nested_id() {

--- a/lsp_test.v
+++ b/lsp_test.v
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a GPL license that can be found in the LICENSE file.
 module main
 
-import json
+import json2
 import io
 import os
 
@@ -192,14 +192,14 @@ fn test_position_json_encoding() {
 		line: 10
 		char: 5
 	}
-	encoded := json.encode(pos)
+	encoded := json2.encode(pos, escape_unicode: true)
 	assert encoded.contains('"line":10')
 	assert encoded.contains('"character":5')
 }
 
 fn test_position_json_decoding() {
 	json_str := '{"line":20,"character":8}'
-	pos := json.decode(Position, json_str) or {
+	pos := json2.decode[Position](json_str) or {
 		assert false, 'Failed to decode Position: ${err}'
 		return
 	}
@@ -216,7 +216,7 @@ fn test_make_cancelled_error_response_fields() {
 
 fn test_error_response_json_encoding() {
 	err := make_cancelled_error_response(7)
-	encoded := json.encode(err)
+	encoded := json2.encode(err, escape_unicode: true)
 	assert encoded.contains('"id":7')
 	assert encoded.contains('"code":-32800')
 	assert encoded.contains('"message":"Request cancelled"')
@@ -439,7 +439,7 @@ fn test_lsp_range_json_encoding() {
 			char: 4
 		}
 	}
-	encoded := json.encode(r)
+	encoded := json2.encode(r, escape_unicode: true)
 	assert encoded.contains('"start"')
 	assert encoded.contains('"end"')
 }
@@ -455,7 +455,7 @@ fn test_text_document_identifier_json_encoding() {
 	doc := TextDocumentIdentifier{
 		uri: 'file:///path/to/file.v'
 	}
-	encoded := json.encode(doc)
+	encoded := json2.encode(doc, escape_unicode: true)
 	assert encoded.contains('"uri":"file:///path/to/file.v"')
 }
 
@@ -508,7 +508,7 @@ fn test_params_with_content_changes() {
 
 fn test_params_json_decoding() {
 	json_str := '{"textDocument":{"uri":"file:///test.v"},"position":{"line":5,"character":10}}'
-	params := json.decode(Params, json_str) or {
+	params := json2.decode[Params](json_str) or {
 		assert false, 'Failed to decode Params: ${err}'
 		return
 	}
@@ -537,13 +537,13 @@ fn test_request_with_values() {
 
 fn test_request_json_decoding_completion() {
 	json_str := '{"id":1,"method":"textDocument/completion","jsonrpc":"2.0","params":{"textDocument":{"uri":"file:///test.v"},"position":{"line":5,"character":10}}}'
-	req := json.decode(Request, json_str) or {
+	req := json2.decode[Request](json_str) or {
 		assert false, 'Failed to decode Request: \\${err}'
 		return
 	}
 	assert req.id == 1
 	assert req.method == 'textDocument/completion'
-	params := json.decode(Params, req.params.str()) or {
+	params := json2.decode[Params](req.params.str()) or {
 		assert false, 'Failed to decode Params: \\${err}'
 		return
 	}
@@ -552,12 +552,12 @@ fn test_request_json_decoding_completion() {
 
 fn test_request_json_decoding_did_change() {
 	json_str := '{"id":2,"method":"textDocument/didChange","jsonrpc":"2.0","params":{"textDocument":{"uri":"file:///test.v"},"contentChanges":[{"text":"fn main() {}"}]}}'
-	req := json.decode(Request, json_str) or {
+	req := json2.decode[Request](json_str) or {
 		assert false, 'Failed to decode Request: \\${err}'
 		return
 	}
 	assert req.method == 'textDocument/didChange'
-	params := json.decode(Params, req.params.str()) or {
+	params := json2.decode[Params](req.params.str()) or {
 		assert false, 'Failed to decode Params: \\${err}'
 		return
 	}
@@ -567,7 +567,7 @@ fn test_request_json_decoding_did_change() {
 
 fn test_request_json_decoding_initialize() {
 	json_str := '{"id":0,"method":"initialize","jsonrpc":"2.0","params":{}}'
-	req := json.decode(Request, json_str) or {
+	req := json2.decode[Request](json_str) or {
 		assert false, 'Failed to decode Request: ${err}'
 		return
 	}
@@ -588,7 +588,7 @@ fn test_response_json_encoding() {
 		id:     42
 		result: 'null'
 	}
-	encoded := json.encode(resp)
+	encoded := json2.encode(resp, escape_unicode: true)
 	assert encoded.contains('"id":42')
 	assert encoded.contains('"jsonrpc":"2.0"')
 }
@@ -806,7 +806,7 @@ fn test_notification_json_encoding() {
 			diagnostics: []
 		}
 	}
-	encoded := json.encode(notif)
+	encoded := json2.encode(notif, escape_unicode: true)
 	assert encoded.contains('"method":"textDocument/publishDiagnostics"')
 	assert encoded.contains('"jsonrpc":"2.0"')
 }
@@ -845,7 +845,7 @@ fn test_lsp_diagnostic_json_encoding() {
 		message:  'undefined identifier'
 		severity: 1
 	}
-	encoded := json.encode(diag)
+	encoded := json2.encode(diag, escape_unicode: true)
 	assert encoded.contains('"message":"undefined identifier"')
 	assert encoded.contains('"severity":1')
 }
@@ -888,7 +888,7 @@ fn test_detail_json_encoding() {
 		kind:  6
 		label: 'test_fn'
 	}
-	encoded := json.encode(detail)
+	encoded := json2.encode(detail, escape_unicode: true)
 	assert encoded.contains('"kind":6')
 	assert encoded.contains('"label":"test_fn"')
 }
@@ -925,7 +925,7 @@ fn test_location_json_encoding() {
 			}
 		}
 	}
-	encoded := json.encode(loc)
+	encoded := json2.encode(loc, escape_unicode: true)
 	assert encoded.contains('"uri":"file:///path/to/file.v"')
 	assert encoded.contains('"range"')
 }
@@ -970,7 +970,7 @@ fn test_signature_help_json_encoding() {
 		active_signature: 0
 		active_parameter: 0
 	}
-	encoded := json.encode(sig)
+	encoded := json2.encode(sig, escape_unicode: true)
 	assert encoded.contains('"activeSignature":0')
 	assert encoded.contains('"activeParameter":0')
 }
@@ -1003,7 +1003,7 @@ fn test_capabilities_json_encoding() {
 			definition_provider: true
 		}
 	}
-	encoded := json.encode(caps)
+	encoded := json2.encode(caps, escape_unicode: true)
 	assert encoded.contains('"definitionProvider":true')
 }
 
@@ -1155,7 +1155,7 @@ fn test_json_error_struct() {
 
 fn test_json_error_json_decoding() {
 	json_str := '{"path":"/test/file.v","message":"error","line_nr":5,"col":10,"len":2}'
-	err := json.decode(JsonError, json_str) or {
+	err := json2.decode[JsonError](json_str) or {
 		assert false, 'Failed to decode JsonError: ${err}'
 		return
 	}
@@ -1165,7 +1165,7 @@ fn test_json_error_json_decoding() {
 
 fn test_json_error_array_decoding() {
 	json_str := '[{"path":"/a.v","message":"err1","line_nr":1,"col":1,"len":1},{"path":"/b.v","message":"err2","line_nr":2,"col":2,"len":2}]'
-	errors := json.decode([]JsonError, json_str) or {
+	errors := json2.decode[[]JsonError](json_str) or {
 		assert false, 'Failed to decode JsonError array: ${err}'
 		return
 	}
@@ -1197,7 +1197,7 @@ fn test_json_var_ac_with_details() {
 
 fn test_json_var_ac_json_decoding() {
 	json_str := '{"details":[{"kind":6,"label":"test","detail":"","documentation":""}]}'
-	ac := json.decode(JsonVarAC, json_str) or {
+	ac := json2.decode[JsonVarAC](json_str) or {
 		assert false, 'Failed to decode JsonVarAC: ${err}'
 		return
 	}
@@ -1274,7 +1274,7 @@ fn test_document_symbol_json_encoding() {
 		}
 		children:        []DocumentSymbol{}
 	}
-	encoded := json.encode(sym)
+	encoded := json2.encode(sym, escape_unicode: true)
 	assert encoded.contains('"name":"Person"')
 	assert encoded.contains('"kind":${sym_kind_struct}')
 	assert encoded.contains('"selectionRange"')
@@ -1283,7 +1283,7 @@ fn test_document_symbol_json_encoding() {
 
 fn test_document_symbol_json_decoding() {
 	json_str := '{"name":"Color","kind":10,"range":{"start":{"line":8,"character":0},"end":{"line":8,"character":11}},"selectionRange":{"start":{"line":8,"character":5},"end":{"line":8,"character":10}},"children":[]}'
-	sym := json.decode(DocumentSymbol, json_str) or {
+	sym := json2.decode[DocumentSymbol](json_str) or {
 		assert false, 'Failed to decode DocumentSymbol: ${err}'
 		return
 	}
@@ -1495,7 +1495,7 @@ fn test_response_with_document_symbols_json_encoding() {
 		id:     7
 		result: syms
 	}
-	encoded := json.encode(resp)
+	encoded := json2.encode(resp, escape_unicode: true)
 	assert encoded.contains('"id":7')
 	assert encoded.contains('"name":"greet"')
 	assert encoded.contains('"kind":${sym_kind_function}')
@@ -1521,7 +1521,7 @@ fn test_capability_document_symbol_provider_json_encoding() {
 			definition_provider:      true
 		}
 	}
-	encoded := json.encode(caps)
+	encoded := json2.encode(caps, escape_unicode: true)
 	assert encoded.contains('"documentSymbolProvider":true')
 	assert encoded.contains('"definitionProvider":true')
 }
@@ -1532,7 +1532,7 @@ fn test_capability_code_lens_provider_json_encoding_object_shape() {
 			code_lens_provider: CodeLensOptions{}
 		}
 	}
-	encoded := json.encode(caps)
+	encoded := json2.encode(caps, escape_unicode: true)
 	assert encoded.contains('"codeLensProvider":{}')
 	assert !encoded.contains('"codeLensProvider":true')
 }

--- a/lsp_test.v
+++ b/lsp_test.v
@@ -1627,3 +1627,18 @@ fn test_strip_sum_type_tags_handles_multiple_and_positions() {
 	// No tag: unchanged.
 	assert strip_response_sum_type_tags('{"a":1}') == '{"a":1}'
 }
+
+fn test_validate_rename_rejects_keyword_new_name() {
+	// Renaming to a V keyword must be rejected (uncompilable result).
+	params := '{"textDocument":{"uri":"file:///a.v"},"position":{"line":0,"character":0},"newName":"fn"}'
+	if err := validate_request_params(.rename, params) {
+		assert err.contains('reserved')
+	} else {
+		assert false, 'expected keyword newName to be rejected'
+	}
+}
+
+fn test_validate_rename_accepts_normal_new_name() {
+	params := '{"textDocument":{"uri":"file:///a.v"},"position":{"line":0,"character":0},"newName":"my_fn"}'
+	assert validate_request_params(.rename, params) == none
+}

--- a/lsp_test.v
+++ b/lsp_test.v
@@ -1580,6 +1580,28 @@ fn test_extract_raw_id_absent_is_none() {
 	assert extract_raw_id('{"method":"x","params":{}}') == none
 }
 
+fn test_extract_raw_id_decodes_escaped_id_key() {
+	// The `id` key is JSON-escaped as id ('i' = i). A compliant server
+	// must decode the key and still find the top-level id.
+	id := extract_raw_id('{"\\u0069d":1,"method":"initialize"}') or {
+		assert false, 'escaped id key must decode to `id`'
+		return
+	}
+	assert id == '1'
+}
+
+fn test_read_json_string_token_decodes_unicode_escapes() {
+	// ASCII via \uXXXX.
+	key, _ := read_json_string_token('"\\u0069d"', 0)
+	assert key == 'id'
+	// Non-ASCII BMP codepoint (é = é, two UTF-8 bytes).
+	accented, _ := read_json_string_token('"caf\\u00e9"', 0)
+	assert accented == 'café'
+	// Astral codepoint via a surrogate pair (😀 = 😀).
+	emoji, _ := read_json_string_token('"\\uD83D\\uDE00"', 0)
+	assert emoji == '😀'
+}
+
 fn test_raw_id_is_valid_accepts_strings_and_numbers() {
 	assert raw_id_is_valid('') // absent/null id
 	assert raw_id_is_valid('5')

--- a/main.v
+++ b/main.v
@@ -233,6 +233,30 @@ fn (mut app App) write_data(data string) {
 	}
 }
 
+// send_framed prepends a Content-Length header to `content` and writes the
+// message. LSP requires CRLF-delimited headers. A TCP connection is a raw byte
+// stream, so it always gets literal `\r\n\r\n`; only Windows *stdio* uses `\n\n`,
+// relying on text-mode stdout to translate each `\n` into `\r\n` on the wire
+// (P0-11). This prevents Windows TCP from emitting LF-only framing.
+fn (mut app App) send_framed(content string) {
+	mut is_tcp := false
+	if _ := app.tcp_conn {
+		is_tcp = true
+	}
+	header := if is_tcp {
+		'Content-Length: ${content.len}\r\n\r\n'
+	} else {
+		$if windows {
+			'Content-Length: ${content.len}\n\n'
+		} $else {
+			'Content-Length: ${content.len}\r\n\r\n'
+		}
+	}
+	full_message := '${header}${content}'
+	log('SEND: ${full_message}')
+	app.write_data(full_message)
+}
+
 // Transport framing limits (P0-11). These bound how much memory an untrusted
 // client (local or over TCP) can force the server to allocate.
 const transport_buffer_cap = 64 * 1024 // buffered reader capacity
@@ -356,8 +380,12 @@ fn (mut app App) handle_requests(mut reader io.BufferedReader) {
 				break
 			}
 			if err.msg().starts_with('invalid header:') {
+				// The frame body was not consumed, so the stream is now
+				// desynchronized: the unread body would be misread as the next
+				// header. Report the error, then close the connection rather than
+				// attempting to resynchronize (P0-11).
 				app.write_error_response(make_parse_error_response(err.msg()))
-				continue
+				break
 			}
 			$if debug { log('Error reading request: ${err.msg()}') }
 			break
@@ -918,15 +946,7 @@ fn inject_raw_id(encoded string, raw_id string) string {
 
 fn (mut app App) write_response(response Response) {
 	content := inject_raw_id(encode_response_payload(response), app.current_request_raw_id)
-	headers := $if windows {
-		// windows text stdio will output `\r\n` for every `\n`
-		'Content-Length: ${content.len}\n\n'
-	} $else {
-		'Content-Length: ${content.len}\r\n\r\n'
-	}
-	full_message := '${headers}${content}'
-	log('SEND: ${full_message}')
-	app.write_data(full_message)
+	app.send_framed(content)
 }
 
 fn encode_response_payload(response Response) string {
@@ -992,16 +1012,7 @@ fn matches_needle_at(s string, i int, needle string) bool {
 }
 
 fn (mut app App) write_notification(notification Notification) {
-	content := json2.encode(notification, escape_unicode: true)
-	headers := $if windows {
-		// windows text stdio will output `\r\n` for every `\n`
-		'Content-Length: ${content.len}\n\n'
-	} $else {
-		'Content-Length: ${content.len}\r\n\r\n'
-	}
-	full_message := '${headers}${content}'
-	log('SEND: ${full_message}')
-	app.write_data(full_message)
+	app.send_framed(json2.encode(notification, escape_unicode: true))
 }
 
 fn (mut app App) write_error_response(response ErrorResponse) {
@@ -1011,15 +1022,7 @@ fn (mut app App) write_error_response(response ErrorResponse) {
 	if response.error.code != jsonrpc_err_parse_error {
 		content = inject_raw_id(content, app.current_request_raw_id)
 	}
-	headers := $if windows {
-		// windows text stdio will output `\r\n` for every `\n`
-		'Content-Length: ${content.len}\n\n'
-	} $else {
-		'Content-Length: ${content.len}\r\n\r\n'
-	}
-	full_message := '${headers}${content}'
-	log('SEND: ${full_message}')
-	app.write_data(full_message)
+	app.send_framed(content)
 }
 
 fn encode_error_response_payload(response ErrorResponse) string {
@@ -1532,28 +1535,12 @@ fn is_valid_v_identifier_name(name string) bool {
 // write_raw_notification sends an arbitrary JSON-RPC notification to the client.
 // params_json must already be a valid JSON value (object or array).
 fn (mut app App) write_raw_notification(method string, params_json string) {
-	content := '{"jsonrpc":"2.0","method":"${method}","params":${params_json}}'
-	headers := $if windows {
-		'Content-Length: ${content.len}\n\n'
-	} $else {
-		'Content-Length: ${content.len}\r\n\r\n'
-	}
-	full_message := '${headers}${content}'
-	log('SEND: ${full_message}')
-	app.write_data(full_message)
+	app.send_framed('{"jsonrpc":"2.0","method":"${method}","params":${params_json}}')
 }
 
 // write_raw_request sends an arbitrary JSON-RPC request from the server to the client.
 fn (mut app App) write_raw_request(id int, method string, params_json string) {
-	content := '{"jsonrpc":"2.0","id":${id},"method":"${method}","params":${params_json}}'
-	headers := $if windows {
-		'Content-Length: ${content.len}\n\n'
-	} $else {
-		'Content-Length: ${content.len}\r\n\r\n'
-	}
-	full_message := '${headers}${content}'
-	log('SEND: ${full_message}')
-	app.write_data(full_message)
+	app.send_framed('{"jsonrpc":"2.0","id":${id},"method":"${method}","params":${params_json}}')
 }
 
 // send_show_message pushes a window/showMessage notification to the client.
@@ -1657,15 +1644,7 @@ fn (mut app App) on_initialized(_ Request) {
 		}
 	}
 	app.next_request_id++
-	content := json2.encode(reg, escape_unicode: true)
-	headers := $if windows {
-		'Content-Length: ${content.len}\n\n'
-	} $else {
-		'Content-Length: ${content.len}\r\n\r\n'
-	}
-	full_message := '${headers}${content}'
-	log('SEND: ${full_message}')
-	app.write_data(full_message)
+	app.send_framed(json2.encode(reg, escape_unicode: true))
 	app.sent_watched_files_registration = true
 }
 

--- a/main.v
+++ b/main.v
@@ -35,6 +35,7 @@ mut:
 	position_encoding                           PositionEncoding = .utf16 // Negotiated LSP position encoding (default UTF-16)
 	symbol_index                                map[string]IndexEntry // Persistent per-URI symbol index (see index.v)
 	indexed_dirs                                map[string]bool       // Project dirs already walked into the index
+	indexed_dir_walk_ms                         map[string]i64        // Last walk time per dir, for watcher-less refresh
 	ref_occurrences                             map[string]OccEntry   // Per-URI identifier occurrences for references (see index.v)
 	vlib_fn_cache                               map[string]map[string]string // Per-vlib-module fn→return-type index (immutable during a session)
 	tcp_conn                                    ?&net.TcpConn         // Non-nil when serving a TCP client
@@ -407,6 +408,15 @@ fn (mut app App) handle_requests(mut reader io.BufferedReader) {
 		// Preserve the exact id (numeric or string) so responses echo it
 		// verbatim; string ids would otherwise collapse to 0 (P0-02).
 		app.current_request_raw_id = extract_raw_id(content) or { '' }
+		// JSON-RPC ids may only be a string, number, or null (an absent raw id).
+		// A present id of any other type (object, array, boolean) is an Invalid
+		// Request: respond with a null id — the id could not be validly
+		// determined — rather than dispatching and echoing a bogus id (P0-02).
+		if app.current_request_raw_id != '' && !raw_id_is_valid(app.current_request_raw_id) {
+			app.current_request_raw_id = 'null'
+			app.write_error_response(make_invalid_request_error_response(0, 'Request id must be a string, number, or null'))
+			continue
+		}
 		// Decode the body WITHOUT the id field: json2 aborts the whole decode on
 		// a string value in an int field, which would otherwise make every
 		// string-id request undecodable. The numeric id is derived from the raw
@@ -763,6 +773,17 @@ fn raw_id_to_int(raw string) int {
 		return 0
 	}
 	return raw.int()
+}
+
+// raw_id_is_valid reports whether a raw JSON id token is a legal JSON-RPC id: a
+// string or a number. Objects, arrays, and booleans are rejected. An absent or
+// null id is represented by an empty token and is handled by the caller.
+fn raw_id_is_valid(raw string) bool {
+	if raw == '' || raw[0] == `"` {
+		return true
+	}
+	c := raw[0]
+	return c == `-` || (c >= `0` && c <= `9`)
 }
 
 // json_is_ws reports whether a byte is JSON insignificant whitespace.
@@ -1697,20 +1718,29 @@ fn (mut app App) consume_cancelled_request(id int) bool {
 	return was_cancelled
 }
 
-// bump_generation records a mutation to `uri`, advancing both the global
-// counter and the per-project-directory revision. Diagnostic caching keys off
-// the per-project revision so that editing one file only invalidates cached
-// diagnostics for files in the same project directory, not every open document
-// (P1-06).
-fn (mut app App) bump_generation(uri string) {
-	app.open_files_generation++
+// generation_key returns the cache-invalidation scope for `uri`: its enclosing
+// `v.mod` project root, or its immediate directory when the file belongs to no
+// project. Keying on the project root (not just `os.dir`) means editing one
+// module invalidates diagnostics for sibling modules in the same project that
+// import it — otherwise an importer keyed on its own directory would reuse
+// diagnostics computed against the imported module's old API (P1-06).
+fn (app &App) generation_key(uri string) string {
 	dir := os.dir(uri_to_path(uri))
-	app.project_generations[dir] = app.project_generations[dir] + 1
+	root := find_project_root(dir)
+	return if root != '' { root } else { dir }
 }
 
-// project_generation returns the current revision for the project directory
-// that owns `uri`.
+// bump_generation records a mutation to `uri`, advancing both the global counter
+// and the per-project revision. Diagnostic caching keys off the per-project
+// revision so that editing one file invalidates cached diagnostics for the whole
+// owning project (covering cross-module imports), not every open document (P1-06).
+fn (mut app App) bump_generation(uri string) {
+	app.open_files_generation++
+	key := app.generation_key(uri)
+	app.project_generations[key] = app.project_generations[key] + 1
+}
+
+// project_generation returns the current revision for the project that owns `uri`.
 fn (app &App) project_generation(uri string) int {
-	dir := os.dir(uri_to_path(uri))
-	return app.project_generations[dir]
+	return app.project_generations[app.generation_key(uri)]
 }

--- a/main.v
+++ b/main.v
@@ -24,6 +24,8 @@ mut:
 	supports_dynamic_watched_files_registration bool              // Client supports dynamic workspace watcher registration
 	supports_work_done_progress                 bool              // Client supports window/workDoneProgress + $/progress
 	sent_watched_files_registration             bool              // client/registerCapability watcher registration was sent
+	watched_files_registration_id               string            // Raw id of the watcher registration request, to match its response
+	watched_files_active                        bool              // True once the client acknowledged watcher registration (not rejected)
 	inlay_hints_enabled                         bool = true // toggled via workspace/didChangeConfiguration
 	diagnostics_enabled                         bool = true // toggled via workspace/didChangeConfiguration
 	diag_cache                                  map[string]DiagCacheEntry // Per-URI cached diagnostics
@@ -401,6 +403,7 @@ fn (mut app App) handle_requests(mut reader io.BufferedReader) {
 		// Consume it without dispatching so it never hits the method router or
 		// produces a spurious MethodNotFound error (P0-02).
 		if is_client_response_message(content) {
+			app.note_server_request_response(content)
 			log('Consumed client response to a server-initiated request: ${content}')
 			continue
 		}
@@ -952,6 +955,27 @@ fn is_client_response_message(content string) bool {
 	}
 	has_id := content.contains('"id"')
 	return has_id && (content_has_member(content, 'result') || content_has_member(content, 'error'))
+}
+
+// note_server_request_response inspects a client's response to a server-initiated
+// request. When it is the reply to our watched-files registration, a success
+// confirms watchers are active so the timed index refresh can stand down; an
+// error (the client rejected registration) or a mismatched id leaves the
+// watcher-less refresh fallback on, since no watcher notifications will arrive.
+fn (mut app App) note_server_request_response(content string) {
+	if app.watched_files_registration_id == '' || app.watched_files_active {
+		return
+	}
+	raw := extract_raw_id(content) or { return }
+	if raw != app.watched_files_registration_id {
+		return
+	}
+	if content_has_member(content, 'error') {
+		log('VLS: client rejected watched-files registration; keeping timed index refresh')
+		return
+	}
+	app.watched_files_active = true
+	log('VLS: watched-files registration acknowledged; watcher events drive index freshness')
 }
 
 // inject_raw_id rewrites the first `"id":<value>` in an encoded response so the
@@ -1659,8 +1683,9 @@ fn (mut app App) on_initialized(_ Request) {
 		log('VLS: dynamic watched-files registration already sent; skipping duplicate')
 		return
 	}
+	reg_id := app.next_request_id
 	reg := RegisterCapabilityRequest{
-		id:     app.next_request_id
+		id:     reg_id
 		params: WatcherRegistrationParams{
 			registrations: [
 				WatcherRegistration{
@@ -1680,6 +1705,7 @@ fn (mut app App) on_initialized(_ Request) {
 	app.next_request_id++
 	app.send_framed(json2.encode(reg, escape_unicode: true))
 	app.sent_watched_files_registration = true
+	app.watched_files_registration_id = reg_id.str()
 }
 
 // write_response_or_cancelled sends a cancelled error if the request was

--- a/main.v
+++ b/main.v
@@ -32,10 +32,11 @@ mut:
 	cancelled_requests                          map[int]bool              // Request ids cancelled via $/cancelRequest
 	cancelled_raw_ids                           map[string]bool           // String/raw request ids cancelled via $/cancelRequest
 	current_request_raw_id                      string                    // Raw JSON id of the request being processed (echoed verbatim)
-	tcp_conn                                    ?&net.TcpConn             // Non-nil when serving a TCP client
-	is_shutdown                                 bool                      // True after shutdown request was acknowledged
-	exit_was_requested                          bool                      // True when the exit notification was received
-	received_initialize                         bool                      // True after initialize request was processed
+	position_encoding                           PositionEncoding = .utf16 // Negotiated LSP position encoding (default UTF-16)
+	tcp_conn                                    ?&net.TcpConn // Non-nil when serving a TCP client
+	is_shutdown                                 bool          // True after shutdown request was acknowledged
+	exit_was_requested                          bool          // True when the exit notification was received
+	received_initialize                         bool          // True after initialize request was processed
 	next_request_id                             int = 1 // Counter for server-initiated request ids
 }
 
@@ -539,6 +540,7 @@ fn (mut app App) handle_requests(mut reader io.BufferedReader) {
 							document_highlight_provider:        true
 							selection_range_provider:           true
 							document_range_formatting_provider: true
+							position_encoding:                  position_encoding_string(app.position_encoding)
 							workspace:                          WorkspaceCapability{
 								workspace_folders: WorkspaceFoldersServerCapability{
 									supported:            true
@@ -554,6 +556,13 @@ fn (mut app App) handle_requests(mut reader io.BufferedReader) {
 				}
 				app.write_response(response)
 				app.received_initialize = true
+				// Surface a clearly actionable message if the V compiler is not
+				// available, instead of silently returning empty diagnostics,
+				// completion, and navigation for every request (P1-03).
+				if !compiler_is_available() {
+					app.send_show_message('vls: the V compiler (`v`) was not found on PATH. Diagnostics, completion, and navigation will not work until `v` is installed and on PATH.',
+						1)
+				}
 			}
 			.did_open {
 				app.on_did_open(request)

--- a/main.v
+++ b/main.v
@@ -1129,15 +1129,17 @@ fn method_is_notification_only(method Method) bool {
 }
 
 // request_is_cancelled reports whether the request currently being processed was
-// cancelled, checking both numeric and string/raw ids.
+// cancelled. A string-id request is matched ONLY by its exact raw id, so it can
+// never be falsely cancelled by a numeric cancel of id 0 (P0-02).
 fn (app &App) request_is_cancelled(id int) bool {
+	raw := app.current_request_raw_id
+	if raw.starts_with('"') {
+		return raw in app.cancelled_raw_ids
+	}
 	if id in app.cancelled_requests {
 		return true
 	}
-	if app.current_request_raw_id != '' && app.current_request_raw_id in app.cancelled_raw_ids {
-		return true
-	}
-	return false
+	return raw != '' && raw in app.cancelled_raw_ids
 }
 
 fn make_invalid_request_error_response(id int, message string) ErrorResponse {
@@ -1665,13 +1667,22 @@ fn (mut app App) write_response_or_cancelled(id int, response Response) {
 }
 
 fn (mut app App) consume_cancelled_request(id int) bool {
+	raw := app.current_request_raw_id
 	mut was_cancelled := false
+	if raw.starts_with('"') {
+		// String-id request: consume only its exact raw id.
+		if raw in app.cancelled_raw_ids {
+			app.cancelled_raw_ids.delete(raw)
+			was_cancelled = true
+		}
+		return was_cancelled
+	}
 	if id in app.cancelled_requests {
 		app.cancelled_requests.delete(id)
 		was_cancelled = true
 	}
-	if app.current_request_raw_id != '' && app.current_request_raw_id in app.cancelled_raw_ids {
-		app.cancelled_raw_ids.delete(app.current_request_raw_id)
+	if raw != '' && raw in app.cancelled_raw_ids {
+		app.cancelled_raw_ids.delete(raw)
 		was_cancelled = true
 	}
 	return was_cancelled

--- a/main.v
+++ b/main.v
@@ -33,10 +33,12 @@ mut:
 	cancelled_raw_ids                           map[string]bool           // String/raw request ids cancelled via $/cancelRequest
 	current_request_raw_id                      string                    // Raw JSON id of the request being processed (echoed verbatim)
 	position_encoding                           PositionEncoding = .utf16 // Negotiated LSP position encoding (default UTF-16)
-	tcp_conn                                    ?&net.TcpConn // Non-nil when serving a TCP client
-	is_shutdown                                 bool          // True after shutdown request was acknowledged
-	exit_was_requested                          bool          // True when the exit notification was received
-	received_initialize                         bool          // True after initialize request was processed
+	symbol_index                                map[string]IndexEntry // Persistent per-URI symbol index (see index.v)
+	indexed_dirs                                map[string]bool       // Project dirs already walked into the index
+	tcp_conn                                    ?&net.TcpConn         // Non-nil when serving a TCP client
+	is_shutdown                                 bool                  // True after shutdown request was acknowledged
+	exit_was_requested                          bool                  // True when the exit notification was received
+	received_initialize                         bool                  // True after initialize request was processed
 	next_request_id                             int = 1 // Counter for server-initiated request ids
 }
 
@@ -937,16 +939,55 @@ fn encode_response_payload(response Response) string {
 	return content
 }
 
+// strip_response_sum_type_tags removes V's non-standard `_type` sum-type
+// discriminator members from an encoded result payload. LSP/JSON-RPC responses
+// must not expose them. This strips the tag for EVERY result variant — including
+// array-of-struct variants and any future type — rather than a hardcoded list,
+// so a newly added result type can never leak a `_type` field (P1-10). The tag
+// value is always a bare V struct name (identifier characters only), so scanning
+// to its closing quote is unambiguous.
 fn strip_response_sum_type_tags(content string) string {
-	mut cleaned := content
-	// V sum-type JSON encoding injects a non-standard `_type` discriminator for
-	// struct variants. LSP/JSON-RPC result payloads must not expose those tags.
-	for type_name in ['CompletionList', 'Capabilities', 'SignatureHelp', 'Location', 'Hover',
-		'WorkspaceEdit', 'PrepareRenameResult', 'SemanticTokens', 'CodeLens', 'LinkedEditingRanges'] {
-		cleaned = cleaned.replace(',"_type":"${type_name}"', '')
-		cleaned = cleaned.replace('"_type":"${type_name}",', '')
+	needle := '"_type":"'
+	if !content.contains(needle) {
+		return content
 	}
-	return cleaned
+	mut sb := []u8{cap: content.len}
+	mut i := 0
+	for i < content.len {
+		if content[i] == `"` && matches_needle_at(content, i, needle) {
+			mut j := i + needle.len
+			for j < content.len && content[j] != `"` {
+				j++
+			}
+			member_end := if j < content.len { j + 1 } else { j } // just past closing quote
+			if i > 0 && content[i - 1] == `,` {
+				// The separating comma was already emitted; drop it.
+				sb.delete_last()
+				i = member_end
+			} else if member_end < content.len && content[member_end] == `,` {
+				i = member_end + 1
+			} else {
+				i = member_end
+			}
+			continue
+		}
+		sb << content[i]
+		i++
+	}
+	return sb.bytestr()
+}
+
+// matches_needle_at reports whether `needle` occurs in `s` starting at `i`.
+fn matches_needle_at(s string, i int, needle string) bool {
+	if i + needle.len > s.len {
+		return false
+	}
+	for k in 0 .. needle.len {
+		if s[i + k] != needle[k] {
+			return false
+		}
+	}
+	return true
 }
 
 fn (mut app App) write_notification(notification Notification) {

--- a/main.v
+++ b/main.v
@@ -169,6 +169,16 @@ fn is_loopback_host(host string) bool {
 	return host in ['127.0.0.1', '::1', 'localhost', '']
 }
 
+// tcp_bind_address joins a host and port using the bracketed representation
+// required for IPv6 literals.
+fn tcp_bind_address(host string, port string) string {
+	mut bind_host := if host == '' { '127.0.0.1' } else { host }
+	if bind_host.contains(':') && !(bind_host.starts_with('[') && bind_host.ends_with(']')) {
+		bind_host = '[${bind_host}]'
+	}
+	return '${bind_host}:${port}'
+}
+
 // run_tcp_server listens on the given host/port and spawns a goroutine for each
 // incoming client connection.  Each client gets its own App instance so all
 // state is fully isolated.  Non-loopback binds require an explicit opt-in
@@ -182,8 +192,7 @@ fn run_tcp_server(host string, port string, allow_remote bool) {
 		eprintln(msg)
 		return
 	}
-	bind_host := if host == '' { '127.0.0.1' } else { host }
-	addr := '${bind_host}:${port}'
+	addr := tcp_bind_address(host, port)
 	log('VLS TCP server starting on ${addr}...')
 	mut listener := net.listen_tcp(.ip, addr) or {
 		log('Failed to start TCP listener on ${addr}: ${err}')

--- a/main.v
+++ b/main.v
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a GPL license that can be found in the LICENSE file.
 module main
 
-import json
+import json2
 import net
 import os
 import time
@@ -374,13 +374,22 @@ fn (mut app App) handle_requests(mut reader io.BufferedReader) {
 		// Preserve the exact id (numeric or string) so responses echo it
 		// verbatim; string ids would otherwise collapse to 0 (P0-02).
 		app.current_request_raw_id = extract_raw_id(content) or { '' }
-		request := json.decode(Request, content) or {
+		// Decode the body WITHOUT the id field: json2 aborts the whole decode on
+		// a string value in an int field, which would otherwise make every
+		// string-id request undecodable. The numeric id is derived from the raw
+		// id (0 for non-numeric ids), while the exact id is echoed via the raw id.
+		body := json2.decode[RequestBody](content) or {
 			log('Failed to decode JSON request: ${err.msg()}. Content: "${content}"')
 			app.write_error_response(make_parse_error_response(err.msg()))
 			continue
 		}
-		pretty := json.encode_pretty(request)
-		log('\n\nRECV (pretty): ${pretty}')
+		request := Request{
+			id:      raw_id_to_int(app.current_request_raw_id)
+			method:  body.method
+			jsonrpc: body.jsonrpc
+			params:  body.params
+		}
+		log('\n\nRECV (pretty): ${content}')
 		method := Method.from_string(request.method)
 		log('method="${method}" request.method="${request.method}" ${method == .completion}')
 		// Enforce request/notification direction (P0-03): a message with an id
@@ -549,7 +558,7 @@ fn (mut app App) handle_requests(mut reader io.BufferedReader) {
 			.did_open {
 				app.on_did_open(request)
 				// Publish diagnostics immediately on open (P0-07 item 10).
-				if params := json.decode(DidOpenTextDocumentParams, request.params) {
+				if params := json2.decode[DidOpenTextDocumentParams](request.params) {
 					uri := params.text_document.uri
 					if doc_content := app.open_files[uri] {
 						app.write_notification(app.build_diagnostics_notification(uri, doc_content))
@@ -559,7 +568,7 @@ fn (mut app App) handle_requests(mut reader io.BufferedReader) {
 			.did_close {
 				app.on_did_close(request)
 				// Clear published diagnostics for the closed document (P0-07 item 9).
-				if params := json.decode(DidCloseTextDocumentParams, request.params) {
+				if params := json2.decode[DidCloseTextDocumentParams](request.params) {
 					app.write_notification(Notification{
 						method: 'textDocument/publishDiagnostics'
 						params: PublishDiagnosticsParams{
@@ -699,6 +708,16 @@ fn (mut app App) handle_requests(mut reader io.BufferedReader) {
 
 fn request_content_has_id(content string) bool {
 	return extract_raw_id(content) != none
+}
+
+// raw_id_to_int converts a raw JSON id token to an int for internal use. String
+// ids (and absent ids) collapse to 0; the exact id is preserved separately via
+// the raw id and echoed verbatim in responses.
+fn raw_id_to_int(raw string) int {
+	if raw == '' || raw.starts_with('"') {
+		return 0
+	}
+	return raw.int()
 }
 
 // json_is_ws reports whether a byte is JSON insignificant whitespace.
@@ -899,7 +918,7 @@ fn (mut app App) write_response(response Response) {
 }
 
 fn encode_response_payload(response Response) string {
-	mut content := json.encode(response)
+	mut content := json2.encode(response, escape_unicode: true)
 	content = strip_response_sum_type_tags(content)
 	if response.result is string {
 		if (response.result as string) == 'null' {
@@ -922,7 +941,7 @@ fn strip_response_sum_type_tags(content string) string {
 }
 
 fn (mut app App) write_notification(notification Notification) {
-	content := json.encode(notification)
+	content := json2.encode(notification, escape_unicode: true)
 	headers := $if windows {
 		// windows text stdio will output `\r\n` for every `\n`
 		'Content-Length: ${content.len}\n\n'
@@ -953,7 +972,7 @@ fn (mut app App) write_error_response(response ErrorResponse) {
 }
 
 fn encode_error_response_payload(response ErrorResponse) string {
-	content := json.encode(response)
+	content := json2.encode(response, escape_unicode: true)
 	if response.error.code == jsonrpc_err_parse_error {
 		return content.replace('"id":0', '"id":null')
 	}
@@ -1164,7 +1183,7 @@ fn make_internal_error_response(id int, message string) ErrorResponse {
 fn validate_request_params(method Method, params_json string) ?string {
 	return match method {
 		.initialize {
-			params := json.decode(InitializeParams, params_json) or {
+			params := json2.decode[InitializeParams](params_json) or {
 				return 'Invalid initialize params: ${err.msg()}'
 			}
 			if folders := params.workspace_folders {
@@ -1178,7 +1197,7 @@ fn validate_request_params(method Method, params_json string) ?string {
 		}
 		.completion, .signature_help, .definition, .hover, .declaration, .type_definition,
 		.implementation, .prepare_rename, .document_highlight {
-			params := json.decode(TextDocumentPositionParams, params_json) or {
+			params := json2.decode[TextDocumentPositionParams](params_json) or {
 				return 'Invalid textDocument/position params: ${err.msg()}'
 			}
 			if params.text_document.uri == '' {
@@ -1187,7 +1206,7 @@ fn validate_request_params(method Method, params_json string) ?string {
 			none
 		}
 		.references {
-			params := json.decode(ReferenceParams, params_json) or {
+			params := json2.decode[ReferenceParams](params_json) or {
 				return 'Invalid references params: ${err.msg()}'
 			}
 			if params.text_document.uri == '' {
@@ -1196,7 +1215,7 @@ fn validate_request_params(method Method, params_json string) ?string {
 			none
 		}
 		.rename {
-			params := json.decode(RenameParams, params_json) or {
+			params := json2.decode[RenameParams](params_json) or {
 				return 'Invalid rename params: ${err.msg()}'
 			}
 			if params.text_document.uri == '' {
@@ -1208,13 +1227,13 @@ fn validate_request_params(method Method, params_json string) ?string {
 			none
 		}
 		.workspace_symbol {
-			json.decode(WorkspaceSymbolParams, params_json) or {
+			json2.decode[WorkspaceSymbolParams](params_json) or {
 				return 'Invalid workspace/symbol params: ${err.msg()}'
 			}
 			none
 		}
 		.formatting {
-			params := json.decode(DocumentFormattingParams, params_json) or {
+			params := json2.decode[DocumentFormattingParams](params_json) or {
 				return 'Invalid formatting params: ${err.msg()}'
 			}
 			if params.text_document.uri == '' {
@@ -1223,7 +1242,7 @@ fn validate_request_params(method Method, params_json string) ?string {
 			none
 		}
 		.document_symbols {
-			params := json.decode(DocumentSymbolParams, params_json) or {
+			params := json2.decode[DocumentSymbolParams](params_json) or {
 				return 'Invalid documentSymbol params: ${err.msg()}'
 			}
 			if params.text_document.uri == '' {
@@ -1232,7 +1251,7 @@ fn validate_request_params(method Method, params_json string) ?string {
 			none
 		}
 		.inlay_hint {
-			params := json.decode(InlayHintParams, params_json) or {
+			params := json2.decode[InlayHintParams](params_json) or {
 				return 'Invalid inlayHint params: ${err.msg()}'
 			}
 			if params.text_document.uri == '' {
@@ -1241,7 +1260,7 @@ fn validate_request_params(method Method, params_json string) ?string {
 			none
 		}
 		.code_action {
-			params := json.decode(CodeActionParams, params_json) or {
+			params := json2.decode[CodeActionParams](params_json) or {
 				return 'Invalid codeAction params: ${err.msg()}'
 			}
 			if params.text_document.uri == '' {
@@ -1250,7 +1269,7 @@ fn validate_request_params(method Method, params_json string) ?string {
 			none
 		}
 		.semantic_tokens {
-			params := json.decode(SemanticTokensParams, params_json) or {
+			params := json2.decode[SemanticTokensParams](params_json) or {
 				return 'Invalid semanticTokens/full params: ${err.msg()}'
 			}
 			if params.text_document.uri == '' {
@@ -1259,7 +1278,7 @@ fn validate_request_params(method Method, params_json string) ?string {
 			none
 		}
 		.folding_range {
-			params := json.decode(FoldingRangeParams, params_json) or {
+			params := json2.decode[FoldingRangeParams](params_json) or {
 				return 'Invalid foldingRange params: ${err.msg()}'
 			}
 			if params.text_document.uri == '' {
@@ -1268,7 +1287,7 @@ fn validate_request_params(method Method, params_json string) ?string {
 			none
 		}
 		.callhierarchy_prepare {
-			params := json.decode(PrepareCallHierarchyParams, params_json) or {
+			params := json2.decode[PrepareCallHierarchyParams](params_json) or {
 				return 'Invalid prepareCallHierarchy params: ${err.msg()}'
 			}
 			if params.text_document.uri == '' {
@@ -1277,7 +1296,7 @@ fn validate_request_params(method Method, params_json string) ?string {
 			none
 		}
 		.callhierarchy_incoming {
-			params := json.decode(CallHierarchyIncomingCallsParams, params_json) or {
+			params := json2.decode[CallHierarchyIncomingCallsParams](params_json) or {
 				return 'Invalid incomingCalls params: ${err.msg()}'
 			}
 			if params.item.uri == '' {
@@ -1286,7 +1305,7 @@ fn validate_request_params(method Method, params_json string) ?string {
 			none
 		}
 		.callhierarchy_outgoing {
-			params := json.decode(CallHierarchyOutgoingCallsParams, params_json) or {
+			params := json2.decode[CallHierarchyOutgoingCallsParams](params_json) or {
 				return 'Invalid outgoingCalls params: ${err.msg()}'
 			}
 			if params.item.uri == '' {
@@ -1295,7 +1314,7 @@ fn validate_request_params(method Method, params_json string) ?string {
 			none
 		}
 		.selection_range {
-			params := json.decode(SelectionRangeParams, params_json) or {
+			params := json2.decode[SelectionRangeParams](params_json) or {
 				return 'Invalid selectionRange params: ${err.msg()}'
 			}
 			if params.text_document.uri == '' {
@@ -1304,7 +1323,7 @@ fn validate_request_params(method Method, params_json string) ?string {
 			none
 		}
 		.semantic_tokens_range {
-			params := json.decode(SemanticTokensRangeParams, params_json) or {
+			params := json2.decode[SemanticTokensRangeParams](params_json) or {
 				return 'Invalid semanticTokens/range params: ${err.msg()}'
 			}
 			if params.text_document.uri == '' {
@@ -1313,7 +1332,7 @@ fn validate_request_params(method Method, params_json string) ?string {
 			none
 		}
 		.range_formatting {
-			params := json.decode(DocumentRangeFormattingParams, params_json) or {
+			params := json2.decode[DocumentRangeFormattingParams](params_json) or {
 				return 'Invalid rangeFormatting params: ${err.msg()}'
 			}
 			if params.text_document.uri == '' {
@@ -1322,7 +1341,7 @@ fn validate_request_params(method Method, params_json string) ?string {
 			none
 		}
 		.linked_editing_range {
-			params := json.decode(TextDocumentPositionParams, params_json) or {
+			params := json2.decode[TextDocumentPositionParams](params_json) or {
 				return 'Invalid linkedEditingRange params: ${err.msg()}'
 			}
 			if params.text_document.uri == '' {
@@ -1331,7 +1350,7 @@ fn validate_request_params(method Method, params_json string) ?string {
 			none
 		}
 		.inline_value {
-			params := json.decode(InlineValueParams, params_json) or {
+			params := json2.decode[InlineValueParams](params_json) or {
 				return 'Invalid inlineValue params: ${err.msg()}'
 			}
 			if params.text_document.uri == '' {
@@ -1340,7 +1359,7 @@ fn validate_request_params(method Method, params_json string) ?string {
 			none
 		}
 		.code_lens {
-			params := json.decode(CodeLensParams, params_json) or {
+			params := json2.decode[CodeLensParams](params_json) or {
 				return 'Invalid codeLens params: ${err.msg()}'
 			}
 			if params.text_document.uri == '' {
@@ -1349,19 +1368,19 @@ fn validate_request_params(method Method, params_json string) ?string {
 			none
 		}
 		.code_lens_resolve {
-			json.decode(CodeLens, params_json) or {
+			json2.decode[CodeLens](params_json) or {
 				return 'Invalid codeLens/resolve params: ${err.msg()}'
 			}
 			none
 		}
 		.execute_command {
-			json.decode(ExecuteCommandParams, params_json) or {
+			json2.decode[ExecuteCommandParams](params_json) or {
 				return 'Invalid executeCommand params: ${err.msg()}'
 			}
 			none
 		}
 		.on_type_formatting {
-			params := json.decode(OnTypeFormattingParams, params_json) or {
+			params := json2.decode[OnTypeFormattingParams](params_json) or {
 				return 'Invalid onTypeFormatting params: ${err.msg()}'
 			}
 			if params.text_document.uri == '' {
@@ -1378,7 +1397,7 @@ fn validate_request_params(method Method, params_json string) ?string {
 fn validate_notification_params(method Method, params_json string) ?string {
 	return match method {
 		.did_open {
-			params := json.decode(DidOpenTextDocumentParams, params_json) or {
+			params := json2.decode[DidOpenTextDocumentParams](params_json) or {
 				return 'Invalid didOpen params: ${err.msg()}'
 			}
 			if params.text_document.uri == '' {
@@ -1387,7 +1406,7 @@ fn validate_notification_params(method Method, params_json string) ?string {
 			none
 		}
 		.did_change {
-			params := json.decode(DidChangeTextDocumentParams, params_json) or {
+			params := json2.decode[DidChangeTextDocumentParams](params_json) or {
 				return 'Invalid didChange params: ${err.msg()}'
 			}
 			if params.text_document.uri == '' {
@@ -1396,7 +1415,7 @@ fn validate_notification_params(method Method, params_json string) ?string {
 			none
 		}
 		.did_close {
-			params := json.decode(DidCloseTextDocumentParams, params_json) or {
+			params := json2.decode[DidCloseTextDocumentParams](params_json) or {
 				return 'Invalid didClose params: ${err.msg()}'
 			}
 			if params.text_document.uri == '' {
@@ -1405,7 +1424,7 @@ fn validate_notification_params(method Method, params_json string) ?string {
 			none
 		}
 		.did_save {
-			params := json.decode(DidSaveTextDocumentParams, params_json) or {
+			params := json2.decode[DidSaveTextDocumentParams](params_json) or {
 				return 'Invalid didSave params: ${err.msg()}'
 			}
 			if params.text_document.uri == '' {
@@ -1414,7 +1433,7 @@ fn validate_notification_params(method Method, params_json string) ?string {
 			none
 		}
 		.did_change_watched_files {
-			params := json.decode(DidChangeWatchedFilesParams, params_json) or {
+			params := json2.decode[DidChangeWatchedFilesParams](params_json) or {
 				return 'Invalid didChangeWatchedFiles params: ${err.msg()}'
 			}
 			for change in params.changes {
@@ -1493,7 +1512,7 @@ fn (mut app App) send_show_message(msg string, level int) {
 		type_:   level
 		message: msg
 	}
-	app.write_raw_notification('window/showMessage', json.encode(params))
+	app.write_raw_notification('window/showMessage', json2.encode(params, escape_unicode: true))
 }
 
 // send_log_message pushes a window/logMessage notification to the client.
@@ -1503,7 +1522,7 @@ fn (mut app App) send_log_message(msg string, level int) {
 		type_:   level
 		message: msg
 	}
-	app.write_raw_notification('window/logMessage', json.encode(params))
+	app.write_raw_notification('window/logMessage', json2.encode(params, escape_unicode: true))
 }
 
 // begin_progress sends window/workDoneProgress/create to the client and then
@@ -1519,14 +1538,15 @@ fn (mut app App) begin_progress(title string) string {
 	create_params := ProgressCreateParams{
 		token: token
 	}
-	app.write_raw_request(app.next_request_id, 'window/workDoneProgress/create',
-		json.encode(create_params))
+	app.write_raw_request(app.next_request_id, 'window/workDoneProgress/create', json2.encode(create_params,
+		escape_unicode: true
+	))
 	app.next_request_id++
 	// Send the begin payload.
 	begin := WorkDoneProgressBegin{
 		title: title
 	}
-	progress_json := '{"token":"${token}","value":${json.encode(begin)}}'
+	progress_json := '{"token":"${token}","value":${json2.encode(begin, escape_unicode: true)}}'
 	app.write_raw_notification('$/progress', progress_json)
 	return token
 }
@@ -1540,7 +1560,7 @@ fn (mut app App) report_progress(token string, message string, percentage int) {
 		message:    message
 		percentage: percentage
 	}
-	progress_json := '{"token":"${token}","value":${json.encode(report)}}'
+	progress_json := '{"token":"${token}","value":${json2.encode(report, escape_unicode: true)}}'
 	app.write_raw_notification('$/progress', progress_json)
 }
 
@@ -1552,7 +1572,7 @@ fn (mut app App) end_progress(token string, message string) {
 	end := WorkDoneProgressEnd{
 		message: message
 	}
-	progress_json := '{"token":"${token}","value":${json.encode(end)}}'
+	progress_json := '{"token":"${token}","value":${json2.encode(end, escape_unicode: true)}}'
 	app.write_raw_notification('$/progress', progress_json)
 }
 
@@ -1586,7 +1606,7 @@ fn (mut app App) on_initialized(_ Request) {
 		}
 	}
 	app.next_request_id++
-	content := json.encode(reg)
+	content := json2.encode(reg, escape_unicode: true)
 	headers := $if windows {
 		'Content-Length: ${content.len}\n\n'
 	} $else {

--- a/main.v
+++ b/main.v
@@ -615,7 +615,14 @@ fn (mut app App) handle_requests(mut reader io.BufferedReader) {
 			}
 			.did_open {
 				app.on_did_open(request)
-				// Publish diagnostics immediately on open (P0-07 item 10).
+				// Publish diagnostics on open (P0-07 item 10). This compiles inline in
+				// the request loop, so opening many files serially blocks other
+				// requests until each compile returns. Moving it off the loop is the
+				// async-diagnostics scheduler (P0-04), which is blocked by the
+				// synchronous test harness and V's non-thread-safe shared state; until
+				// then each compile is bounded by compiler_timeout_ms so a single
+				// invocation cannot hang the loop indefinitely, and diag_cache avoids
+				// recompiling unchanged content.
 				if params := json2.decode[DidOpenTextDocumentParams](request.params) {
 					uri := params.text_document.uri
 					if doc_content := app.open_files[uri] {

--- a/main.v
+++ b/main.v
@@ -19,6 +19,7 @@ mut:
 	open_files_versions                         map[string]int    // Per-URI document version from the client
 	temp_dir                                    string            // Temporary directory for multi-file compilation
 	workspace_roots                             []string          // Workspace root directories from initialize
+	removed_workspace_roots                     []string          // Roots explicitly removed by the client
 	capture_output                              bool              // Test hook: capture outbound transport messages instead of writing
 	captured_output                             []string          // Test hook buffer for outbound transport messages
 	supports_dynamic_watched_files_registration bool              // Client supports dynamic workspace watcher registration

--- a/main.v
+++ b/main.v
@@ -1284,6 +1284,10 @@ fn validate_request_params(method Method, params_json string) ?string {
 			if !is_valid_v_identifier_name(params.new_name) {
 				return 'Invalid newName'
 			}
+			// Renaming to a V keyword or builtin would produce uncompilable code.
+			if params.new_name in v_keywords || params.new_name in v_builtins {
+				return 'newName `${params.new_name}` is a reserved V keyword or builtin'
+			}
 			none
 		}
 		.workspace_symbol {

--- a/main.v
+++ b/main.v
@@ -776,10 +776,10 @@ fn raw_id_to_int(raw string) int {
 }
 
 // raw_id_is_valid reports whether a raw JSON id token is a legal JSON-RPC id: a
-// string or a number. Objects, arrays, and booleans are rejected. An absent or
-// null id is represented by an empty token and is handled by the caller.
+// string, a number, or null. Objects, arrays, and booleans are rejected. An
+// absent id is represented by an empty token and is handled by the caller.
 fn raw_id_is_valid(raw string) bool {
-	if raw == '' || raw[0] == `"` {
+	if raw == '' || raw == 'null' || raw[0] == `"` {
 		return true
 	}
 	c := raw[0]
@@ -863,10 +863,13 @@ fn skip_json_value(content string, start int) int {
 }
 
 // extract_raw_id returns the raw JSON representation of the top-level `id`
-// member (e.g. `5` or `"abc"`), preserving its exact type so it can be echoed
-// verbatim in the response. Returns none when `id` is absent or JSON null.
-// This is how the server supports both numeric and string request/cancellation
-// IDs (P0-02) even though the typed decoder collapses string ids to 0.
+// member (e.g. `5`, `"abc"`, or `null`), preserving its exact type so it can be
+// echoed verbatim in the response. Returns none ONLY when `id` is absent: a
+// present JSON null yields the literal token `null` so the message is treated as
+// a request (JSON-RPC permits null ids) and answered with `"id":null`, rather
+// than being misclassified as a notification. This is how the server supports
+// numeric, string, and null request/cancellation IDs (P0-02) even though the
+// typed decoder collapses string ids to 0.
 fn extract_raw_id(content string) ?string {
 	mut i := content.index('{') or { return none }
 	i++
@@ -894,9 +897,8 @@ fn extract_raw_id(content string) ?string {
 			i++
 		}
 		if key == 'id' {
-			if content[i..].starts_with('null') {
-				return none
-			}
+			// A present null id is returned as the literal `null` (not none) so it
+			// is distinguished from an absent id and treated as a request.
 			end := skip_json_value(content, i)
 			return content[i..end].trim_space()
 		}

--- a/main.v
+++ b/main.v
@@ -28,7 +28,10 @@ mut:
 	diagnostics_enabled                         bool = true // toggled via workspace/didChangeConfiguration
 	diag_cache                                  map[string]DiagCacheEntry // Per-URI cached diagnostics
 	open_files_generation                       int                       // Incremented on every workspace file mutation
+	project_generations                         map[string]int            // Per-project-dir revision, for scoped cache invalidation
 	cancelled_requests                          map[int]bool              // Request ids cancelled via $/cancelRequest
+	cancelled_raw_ids                           map[string]bool           // String/raw request ids cancelled via $/cancelRequest
+	current_request_raw_id                      string                    // Raw JSON id of the request being processed (echoed verbatim)
 	tcp_conn                                    ?&net.TcpConn             // Non-nil when serving a TCP client
 	is_shutdown                                 bool                      // True after shutdown request was acknowledged
 	exit_was_requested                          bool                      // True when the exit notification was received
@@ -47,10 +50,6 @@ struct JsonError {
 
 struct JsonVarAC {
 	details []Detail
-}
-
-struct RequestIdEnvelope {
-	id ?int
 }
 
 // DiagCacheEntry stores a cached diagnostic result for one file.
@@ -75,10 +74,21 @@ fn find_v_dir() string {
 	return os.dir(os.real_path(v_exe))
 }
 
+// logging_enabled gates all diagnostic logging. Logging is OFF by default:
+// the old behavior wrote every received/sent JSON payload (which can contain
+// full source text and secrets) to stderr AND re-opened/appended/closed a
+// shared unrotated file on every one of the ~160 call sites (P1-13). Set the
+// VLS_LOG environment variable to any non-empty value to enable logging to
+// ${TMPDIR}/vls_out.txt for debugging.
+const logging_enabled = os.getenv('VLS_LOG') != ''
+const log_file_path = os.join_path(os.temp_dir(), 'vls_out.txt')
+
 fn log(s string) {
+	if !logging_enabled {
+		return
+	}
 	eprintln(s)
-	temp_dir := os.temp_dir()
-	mut output := os.open_append(os.join_path(temp_dir, 'vls_out.txt')) or { return }
+	mut output := os.open_append(log_file_path) or { return }
 	output.writeln(s) or {
 		output.close()
 		return
@@ -91,16 +101,33 @@ fn main() {
 	log('VLS preferences: is_vls=${v_prefs.is_vls}')
 
 	// Check for --port PORT argument to start as a TCP multi-client server.
+	// TCP binds to loopback (127.0.0.1) by default; binding to any other
+	// interface requires the explicit --unsafe-allow-remote opt-in because the
+	// transport is unauthenticated (P0-06).
 	args := os.args
 	mut port := ''
+	mut host := '127.0.0.1'
+	mut allow_remote := false
 	for i, arg in args {
-		if arg == '--port' && i + 1 < args.len {
-			port = args[i + 1]
-			break
+		match arg {
+			'--port' {
+				if i + 1 < args.len {
+					port = args[i + 1]
+				}
+			}
+			'--host' {
+				if i + 1 < args.len {
+					host = args[i + 1]
+				}
+			}
+			'--unsafe-allow-remote' {
+				allow_remote = true
+			}
+			else {}
 		}
 	}
 	if port != '' {
-		run_tcp_server(port)
+		run_tcp_server(host, port, allow_remote)
 		return
 	}
 
@@ -115,7 +142,7 @@ fn main() {
 		open_files: map[string]string{}
 		temp_dir:   temp_dir
 	}
-	mut reader := io.new_buffered_reader(reader: os.stdin(), cap: 1)
+	mut reader := io.new_buffered_reader(reader: os.stdin(), cap: transport_buffer_cap)
 	app.handle_requests(mut reader)
 	log('VLS exiting.')
 	os.rmdir_all(temp_dir) or {
@@ -127,16 +154,32 @@ fn main() {
 	}
 }
 
-// run_tcp_server listens on the given TCP port and spawns a goroutine for each
+// is_loopback_host reports whether `host` refers to the local machine only.
+fn is_loopback_host(host string) bool {
+	return host in ['127.0.0.1', '::1', 'localhost', '']
+}
+
+// run_tcp_server listens on the given host/port and spawns a goroutine for each
 // incoming client connection.  Each client gets its own App instance so all
-// state is fully isolated.
-fn run_tcp_server(port string) {
-	log('VLS TCP server starting on :${port}...')
-	mut listener := net.listen_tcp(.ip, ':${port}') or {
-		log('Failed to start TCP listener on port ${port}: ${err}')
+// state is fully isolated.  Non-loopback binds require an explicit opt-in
+// because the transport has no authentication or TLS (P0-06).
+fn run_tcp_server(host string, port string, allow_remote bool) {
+	if !is_loopback_host(host) && !allow_remote {
+		msg :=
+			'VLS: refusing to bind TCP to non-loopback host "${host}" without --unsafe-allow-remote. ' +
+			'The TCP transport is unauthenticated and unencrypted; exposing it on a network is unsafe.'
+		log(msg)
+		eprintln(msg)
 		return
 	}
-	log('VLS TCP server listening on :${port}')
+	bind_host := if host == '' { '127.0.0.1' } else { host }
+	addr := '${bind_host}:${port}'
+	log('VLS TCP server starting on ${addr}...')
+	mut listener := net.listen_tcp(.ip, addr) or {
+		log('Failed to start TCP listener on ${addr}: ${err}')
+		return
+	}
+	log('VLS TCP server listening on ${addr}')
 	for {
 		mut conn := listener.accept() or {
 			log('TCP accept error: ${err}')
@@ -162,7 +205,7 @@ fn handle_tcp_client(mut conn net.TcpConn) {
 		temp_dir:   temp_dir
 		tcp_conn:   &conn
 	}
-	mut reader := io.new_buffered_reader(reader: conn, cap: 1)
+	mut reader := io.new_buffered_reader(reader: conn, cap: transport_buffer_cap)
 	app.handle_requests(mut reader)
 	log('TCP client disconnected')
 	os.rmdir_all(temp_dir) or {
@@ -186,9 +229,17 @@ fn (mut app App) write_data(data string) {
 	}
 }
 
+// Transport framing limits (P0-11). These bound how much memory an untrusted
+// client (local or over TCP) can force the server to allocate.
+const transport_buffer_cap = 64 * 1024 // buffered reader capacity
+const max_content_length = 64 * 1024 * 1024 // 64 MiB max JSON-RPC body
+const max_header_bytes = 64 * 1024 // total header section size cap
+const max_charset = 'utf-8' // LSP content is always UTF-8
+
 fn read_request(mut reader io.BufferedReader) !string {
 	mut len := -1
 	mut header_error := ''
+	mut header_bytes := 0
 	for {
 		line := reader.read_line() or {
 			if err is io.Eof {
@@ -196,6 +247,10 @@ fn read_request(mut reader io.BufferedReader) !string {
 			}
 			$if debug { log('read_request: error reading header line: ${err}') }
 			return err
+		}
+		header_bytes += line.len + 2 // account for the stripped CRLF
+		if header_bytes > max_header_bytes {
+			return error('invalid header: header section exceeds ${max_header_bytes} bytes')
 		}
 		trimmed_line := line.trim_space()
 		if trimmed_line == '' {
@@ -209,6 +264,10 @@ fn read_request(mut reader io.BufferedReader) !string {
 				header_error = 'invalid header: invalid Content-Length'
 				continue
 			}
+			if parsed_len > max_content_length {
+				header_error = 'invalid header: Content-Length ${parsed_len} exceeds maximum ${max_content_length}'
+				continue
+			}
 			if len != -1 && len != parsed_len {
 				header_error = 'invalid header: conflicting Content-Length headers'
 				continue
@@ -216,6 +275,20 @@ fn read_request(mut reader io.BufferedReader) !string {
 			len = parsed_len
 			continue
 		}
+		if lower.starts_with('content-type:') {
+			// LSP content is always UTF-8. Reject any explicitly declared
+			// non-UTF-8 charset instead of silently misdecoding bytes.
+			if charset_is_unsupported(trimmed_line.all_after(':')) {
+				header_error = 'invalid header: unsupported charset (only ${max_charset} is allowed)'
+				continue
+			}
+			continue
+		}
+	}
+	// Surface a header error before doing anything else, so a malformed
+	// Content-Length can never silently desynchronize the stream.
+	if header_error != '' {
+		return error(header_error)
 	}
 	if len < 0 {
 		return ''
@@ -233,10 +306,17 @@ fn read_request(mut reader io.BufferedReader) !string {
 		}
 		total_bytes_read += bytes_read_now
 	}
-	if header_error != '' {
-		return error(header_error)
-	}
 	return buf.bytestr()
+}
+
+// charset_is_unsupported reports whether a Content-Type header value declares a
+// charset other than UTF-8. LSP §3 mandates UTF-8 for all message content; the
+// historical `utf8` spelling is also accepted.
+fn charset_is_unsupported(content_type string) bool {
+	lower := content_type.to_lower()
+	idx := lower.index('charset=') or { return false }
+	charset := lower[idx + 'charset='.len..].trim_space().trim_right(';').trim_space()
+	return charset != 'utf-8' && charset != 'utf8'
 }
 
 fn parse_content_length_header(s string) !int {
@@ -249,16 +329,23 @@ fn parse_content_length_header(s string) !int {
 			return error('non-numeric Content-Length')
 		}
 	}
-	n := t.int()
-	if n < 0 {
-		return error('negative Content-Length')
+	// Guard against overflow of the 32-bit int parse before using the value.
+	if t.len > 18 {
+		return error('Content-Length too large')
 	}
-	return n
+	n := t.i64()
+	if n < 0 || n > max_content_length {
+		return error('Content-Length out of range')
+	}
+	return int(n)
 }
 
 // handle_requests is the main request handler loop for both stdio and TCP modes.
 fn (mut app App) handle_requests(mut reader io.BufferedReader) {
 	for {
+		// Reset the per-request raw id so a stale id can never leak into an
+		// error response emitted before a new message is fully read.
+		app.current_request_raw_id = ''
 		content := read_request(mut reader) or {
 			if err is io.Eof {
 				log('Client closed connection. Exiting.')
@@ -275,7 +362,18 @@ fn (mut app App) handle_requests(mut reader io.BufferedReader) {
 			continue
 		}
 		log('\n\nRECV: ${content}')
+		// A message with an id + result/error but no method is a response to a
+		// server-initiated request (progress create, capability registration).
+		// Consume it without dispatching so it never hits the method router or
+		// produces a spurious MethodNotFound error (P0-02).
+		if is_client_response_message(content) {
+			log('Consumed client response to a server-initiated request: ${content}')
+			continue
+		}
 		has_id := request_content_has_id(content)
+		// Preserve the exact id (numeric or string) so responses echo it
+		// verbatim; string ids would otherwise collapse to 0 (P0-02).
+		app.current_request_raw_id = extract_raw_id(content) or { '' }
 		request := json.decode(Request, content) or {
 			log('Failed to decode JSON request: ${err.msg()}. Content: "${content}"')
 			app.write_error_response(make_parse_error_response(err.msg()))
@@ -285,7 +383,20 @@ fn (mut app App) handle_requests(mut reader io.BufferedReader) {
 		log('\n\nRECV (pretty): ${pretty}')
 		method := Method.from_string(request.method)
 		log('method="${method}" request.method="${request.method}" ${method == .completion}')
-		if method_requires_response(method) && request.id in app.cancelled_requests {
+		// Enforce request/notification direction (P0-03): a message with an id
+		// sent to a notification-only method is an InvalidRequest; a message
+		// without an id sent to a request-only method is dropped rather than
+		// processed into a response with a bogus id.
+		if has_id && method_is_notification_only(method) {
+			app.write_error_response(make_invalid_request_error_response(request.id,
+				'Method ${request.method} is a notification and cannot be sent as a request'))
+			continue
+		}
+		if !has_id && method_requires_response(method) {
+			log('Dropping notification-shaped message for request-only method ${request.method}')
+			continue
+		}
+		if method_requires_response(method) && app.request_is_cancelled(request.id) {
 			app.write_error_response(make_cancelled_error_response(request.id))
 			app.consume_cancelled_request(request.id)
 			continue
@@ -370,17 +481,24 @@ fn (mut app App) handle_requests(mut reader io.BufferedReader) {
 					id:     request.id
 					result: Capabilities{
 						capabilities: Capability{
+							// NOTE: Placeholder/stub capabilities are intentionally NOT
+							// advertised (P1-07 / Stage 0): on-type formatting (always
+							// empty), inline values (wrong abstraction), linked editing
+							// (wrong abstraction), file-operation hooks (no-ops), the
+							// run/test executeCommand + codeLens stubs, and willSave
+							// (never dispatched). Advertising only working features gives
+							// a better editor experience than exposing broken UI.
 							text_document_sync:                 TextDocumentSyncOptions{
 								open_close:           true
 								change:               2 // Incremental
 								save:                 SaveOptions{
 									include_text: true
 								}
-								will_save:            true
+								will_save:            false
 								will_save_wait_until: true
 							}
 							completion_provider:                CompletionProvider{
-								trigger_characters: ['.', ' ']
+								trigger_characters: ['.']
 							}
 							signature_help_provider:            SignatureHelpOptions{
 								trigger_characters: ['(', ',']
@@ -394,21 +512,11 @@ fn (mut app App) handle_requests(mut reader io.BufferedReader) {
 							rename_provider:                    RenameOptions{
 								prepare_provider: true
 							}
-							execute_command_provider:           ExecuteCommandOptions{
-								commands: ['vls.runFile', 'vls.runTests']
-							}
 							document_formatting_provider:       true
 							document_symbol_provider:           true
 							workspace_symbol_provider:          true
 							inlay_hint_provider:                true
 							code_action_provider:               true
-							code_lens_provider:                 CodeLensOptions{}
-							inline_value_provider:              true
-							linked_editing_range_provider:      true
-							on_type_formatting_provider:        OnTypeFormattingOptions{
-								first_trigger_character: '}'
-								more_trigger_characters: ['\n']
-							}
 							semantic_tokens_provider:           SemanticTokensOptions{
 								legend: SemanticTokensLegend{
 									token_types:     semantic_token_types()
@@ -423,35 +531,6 @@ fn (mut app App) handle_requests(mut reader io.BufferedReader) {
 							selection_range_provider:           true
 							document_range_formatting_provider: true
 							workspace:                          WorkspaceCapability{
-								file_operations:   WorkspaceFileOperations{
-									will_create: FileOperationRegistrationOptions{
-										filters: [
-											FileOperationFilter{
-												pattern: FileOperationPattern{
-													glob: '**/*.v'
-												}
-											},
-										]
-									}
-									will_rename: FileOperationRegistrationOptions{
-										filters: [
-											FileOperationFilter{
-												pattern: FileOperationPattern{
-													glob: '**/*.v'
-												}
-											},
-										]
-									}
-									will_delete: FileOperationRegistrationOptions{
-										filters: [
-											FileOperationFilter{
-												pattern: FileOperationPattern{
-													glob: '**/*.v'
-												}
-											},
-										]
-									}
-								}
 								workspace_folders: WorkspaceFoldersServerCapability{
 									supported:            true
 									change_notifications: true
@@ -469,9 +548,26 @@ fn (mut app App) handle_requests(mut reader io.BufferedReader) {
 			}
 			.did_open {
 				app.on_did_open(request)
+				// Publish diagnostics immediately on open (P0-07 item 10).
+				if params := json.decode(DidOpenTextDocumentParams, request.params) {
+					uri := params.text_document.uri
+					if doc_content := app.open_files[uri] {
+						app.write_notification(app.build_diagnostics_notification(uri, doc_content))
+					}
+				}
 			}
 			.did_close {
 				app.on_did_close(request)
+				// Clear published diagnostics for the closed document (P0-07 item 9).
+				if params := json.decode(DidCloseTextDocumentParams, request.params) {
+					app.write_notification(Notification{
+						method: 'textDocument/publishDiagnostics'
+						params: PublishDiagnosticsParams{
+							uri:         params.text_document.uri
+							diagnostics: []
+						}
+					})
+				}
 			}
 			.did_save {
 				notification := app.on_did_save(request) or { continue }
@@ -602,15 +698,195 @@ fn (mut app App) handle_requests(mut reader io.BufferedReader) {
 }
 
 fn request_content_has_id(content string) bool {
-	envelope := json.decode(RequestIdEnvelope, content) or {
-		// Fallback for malformed payloads where full decode is impossible.
-		return content.contains('"id":')
+	return extract_raw_id(content) != none
+}
+
+// json_is_ws reports whether a byte is JSON insignificant whitespace.
+fn json_is_ws(c u8) bool {
+	return c == ` ` || c == `\t` || c == `\n` || c == `\r`
+}
+
+// read_json_string_token reads a JSON string starting at `content[i]` (which
+// must be a double quote) and returns the decoded key text plus the index just
+// past the closing quote.
+fn read_json_string_token(content string, start int) (string, int) {
+	mut i := start + 1 // past opening quote
+	mut sb := []u8{}
+	for i < content.len {
+		c := content[i]
+		if c == `\\` && i + 1 < content.len {
+			nxt := content[i + 1]
+			esc := match nxt {
+				`n` { u8(`\n`) }
+				`t` { u8(`\t`) }
+				`r` { u8(`\r`) }
+				else { nxt }
+			}
+			sb << esc
+			i += 2
+			continue
+		}
+		if c == `"` {
+			return sb.bytestr(), i + 1
+		}
+		sb << c
+		i++
 	}
-	return envelope.id != none
+	return sb.bytestr(), i
+}
+
+// skip_json_value returns the index just past a complete JSON value beginning at
+// `content[i]` (object, array, string, number, or keyword).
+fn skip_json_value(content string, start int) int {
+	mut i := start
+	n := content.len
+	if i >= n {
+		return i
+	}
+	c := content[i]
+	if c == `"` {
+		_, next := read_json_string_token(content, i)
+		return next
+	}
+	if c == `{` || c == `[` {
+		mut depth := 0
+		for i < n {
+			ch := content[i]
+			if ch == `"` {
+				_, next := read_json_string_token(content, i)
+				i = next
+				continue
+			}
+			if ch == `{` || ch == `[` {
+				depth++
+			} else if ch == `}` || ch == `]` {
+				depth--
+				if depth == 0 {
+					return i + 1
+				}
+			}
+			i++
+		}
+		return i
+	}
+	// number / true / false / null
+	for i < n && content[i] != `,` && content[i] != `}` && content[i] != `]`
+		&& !json_is_ws(content[i]) {
+		i++
+	}
+	return i
+}
+
+// extract_raw_id returns the raw JSON representation of the top-level `id`
+// member (e.g. `5` or `"abc"`), preserving its exact type so it can be echoed
+// verbatim in the response. Returns none when `id` is absent or JSON null.
+// This is how the server supports both numeric and string request/cancellation
+// IDs (P0-02) even though the typed decoder collapses string ids to 0.
+fn extract_raw_id(content string) ?string {
+	mut i := content.index('{') or { return none }
+	i++
+	n := content.len
+	for i < n {
+		for i < n && (json_is_ws(content[i]) || content[i] == `,`) {
+			i++
+		}
+		if i >= n || content[i] == `}` {
+			break
+		}
+		if content[i] != `"` {
+			break
+		}
+		key, after_key := read_json_string_token(content, i)
+		i = after_key
+		for i < n && json_is_ws(content[i]) {
+			i++
+		}
+		if i >= n || content[i] != `:` {
+			break
+		}
+		i++
+		for i < n && json_is_ws(content[i]) {
+			i++
+		}
+		if key == 'id' {
+			if content[i..].starts_with('null') {
+				return none
+			}
+			end := skip_json_value(content, i)
+			return content[i..end].trim_space()
+		}
+		i = skip_json_value(content, i)
+	}
+	return none
+}
+
+// content_has_member reports whether the top-level JSON object declares `member`.
+fn content_has_member(content string, member string) bool {
+	mut i := content.index('{') or { return false }
+	i++
+	n := content.len
+	for i < n {
+		for i < n && (json_is_ws(content[i]) || content[i] == `,`) {
+			i++
+		}
+		if i >= n || content[i] == `}` {
+			break
+		}
+		if content[i] != `"` {
+			break
+		}
+		key, after_key := read_json_string_token(content, i)
+		i = after_key
+		for i < n && json_is_ws(content[i]) {
+			i++
+		}
+		if i >= n || content[i] != `:` {
+			break
+		}
+		i++
+		for i < n && json_is_ws(content[i]) {
+			i++
+		}
+		if key == member {
+			return true
+		}
+		i = skip_json_value(content, i)
+	}
+	return false
+}
+
+// is_client_response_message reports whether an inbound message is a response to
+// a server-initiated request: it carries an `id` and a `result` or `error`
+// member but no `method`. Such messages must be consumed, not dispatched as
+// method calls (P0-02).
+fn is_client_response_message(content string) bool {
+	if content_has_member(content, 'method') {
+		return false
+	}
+	has_id := content.contains('"id"')
+	return has_id && (content_has_member(content, 'result') || content_has_member(content, 'error'))
+}
+
+// inject_raw_id rewrites the first `"id":<value>` in an encoded response so the
+// response echoes the request's id with its original type. For numeric ids this
+// is a no-op; for string ids it replaces the placeholder `0` written by the
+// typed encoder with the quoted string.
+fn inject_raw_id(encoded string, raw_id string) string {
+	if raw_id == '' {
+		return encoded
+	}
+	key := '"id":'
+	idx := encoded.index(key) or { return encoded }
+	val_start := idx + key.len
+	mut val_end := val_start
+	for val_end < encoded.len && encoded[val_end] != `,` && encoded[val_end] != `}` {
+		val_end++
+	}
+	return encoded[..val_start] + raw_id + encoded[val_end..]
 }
 
 fn (mut app App) write_response(response Response) {
-	content := encode_response_payload(response)
+	content := inject_raw_id(encode_response_payload(response), app.current_request_raw_id)
 	headers := $if windows {
 		// windows text stdio will output `\r\n` for every `\n`
 		'Content-Length: ${content.len}\n\n'
@@ -659,7 +935,12 @@ fn (mut app App) write_notification(notification Notification) {
 }
 
 fn (mut app App) write_error_response(response ErrorResponse) {
-	content := encode_error_response_payload(response)
+	// Parse errors have a null id per spec; never echo a (possibly stale) raw id
+	// for those. Other errors echo the request's id verbatim.
+	mut content := encode_error_response_payload(response)
+	if response.error.code != jsonrpc_err_parse_error {
+		content = inject_raw_id(content, app.current_request_raw_id)
+	}
 	headers := $if windows {
 		// windows text stdio will output `\r\n` for every `\n`
 		'Content-Length: ${content.len}\n\n'
@@ -680,9 +961,13 @@ fn encode_error_response_payload(response ErrorResponse) string {
 }
 
 fn v_error_to_lsp_diagnostic(e JsonError) LSPDiagnostic {
-	start_line := e.line_nr - 1 // LSP is 0-indexed, V parser is 1-indexed
-	start_char := e.col - 1 // LSP is 0-indexed, V parser is 1-indexed
-	end_char := start_char + e.len
+	// LSP is 0-indexed, the V parser is 1-indexed. LSP positions must be
+	// non-negative, so clamp values the compiler may report as 0/negative
+	// instead of emitting invalid negative positions (P1-09).
+	start_line := if e.line_nr - 1 > 0 { e.line_nr - 1 } else { 0 }
+	start_char := if e.col - 1 > 0 { e.col - 1 } else { 0 }
+	len := if e.len > 0 { e.len } else { 0 }
+	end_char := start_char + len
 	severity := match e.level {
 		'warning' { 2 }
 		'notice' { 3 }
@@ -749,6 +1034,46 @@ fn method_requires_response(method Method) bool {
 		}
 		else {
 			false
+		}
+	}
+}
+
+// method_is_notification_only reports whether `method` is a client→server
+// notification that must never receive a response (LSP method contract). `exit`
+// is deliberately excluded so the shutdown/exit lifecycle stays robust
+// regardless of whether a client mistakenly attaches an id.
+fn method_is_notification_only(method Method) bool {
+	return match method {
+		.initialized, .did_open, .did_change, .did_close, .did_save, .did_change_watched_files,
+		.workspace_did_change_configuration, .workspace_did_change_workspace_folders, .set_trace,
+		.cancel_request, .will_save {
+			true
+		}
+		else {
+			false
+		}
+	}
+}
+
+// request_is_cancelled reports whether the request currently being processed was
+// cancelled, checking both numeric and string/raw ids.
+fn (app &App) request_is_cancelled(id int) bool {
+	if id in app.cancelled_requests {
+		return true
+	}
+	if app.current_request_raw_id != '' && app.current_request_raw_id in app.cancelled_raw_ids {
+		return true
+	}
+	return false
+}
+
+fn make_invalid_request_error_response(id int, message string) ErrorResponse {
+	msg := if message != '' { message } else { 'Invalid request' }
+	return ErrorResponse{
+		id:    id
+		error: ResponseError{
+			code:    jsonrpc_err_invalid_request
+			message: msg
 		}
 	}
 }
@@ -1290,9 +1615,32 @@ fn (mut app App) write_response_or_cancelled(id int, response Response) {
 }
 
 fn (mut app App) consume_cancelled_request(id int) bool {
+	mut was_cancelled := false
 	if id in app.cancelled_requests {
 		app.cancelled_requests.delete(id)
-		return true
+		was_cancelled = true
 	}
-	return false
+	if app.current_request_raw_id != '' && app.current_request_raw_id in app.cancelled_raw_ids {
+		app.cancelled_raw_ids.delete(app.current_request_raw_id)
+		was_cancelled = true
+	}
+	return was_cancelled
+}
+
+// bump_generation records a mutation to `uri`, advancing both the global
+// counter and the per-project-directory revision. Diagnostic caching keys off
+// the per-project revision so that editing one file only invalidates cached
+// diagnostics for files in the same project directory, not every open document
+// (P1-06).
+fn (mut app App) bump_generation(uri string) {
+	app.open_files_generation++
+	dir := os.dir(uri_to_path(uri))
+	app.project_generations[dir] = app.project_generations[dir] + 1
+}
+
+// project_generation returns the current revision for the project directory
+// that owns `uri`.
+fn (app &App) project_generation(uri string) int {
+	dir := os.dir(uri_to_path(uri))
+	return app.project_generations[dir]
 }

--- a/main.v
+++ b/main.v
@@ -36,6 +36,7 @@ mut:
 	symbol_index                                map[string]IndexEntry // Persistent per-URI symbol index (see index.v)
 	indexed_dirs                                map[string]bool       // Project dirs already walked into the index
 	ref_occurrences                             map[string]OccEntry   // Per-URI identifier occurrences for references (see index.v)
+	vlib_fn_cache                               map[string]map[string]string // Per-vlib-module fn→return-type index (immutable during a session)
 	tcp_conn                                    ?&net.TcpConn         // Non-nil when serving a TCP client
 	is_shutdown                                 bool                  // True after shutdown request was acknowledged
 	exit_was_requested                          bool                  // True when the exit notification was received

--- a/main.v
+++ b/main.v
@@ -347,10 +347,74 @@ fn read_request(mut reader io.BufferedReader) !string {
 // charset other than UTF-8. LSP §3 mandates UTF-8 for all message content; the
 // historical `utf8` spelling is also accepted.
 fn charset_is_unsupported(content_type string) bool {
-	lower := content_type.to_lower()
-	idx := lower.index('charset=') or { return false }
-	charset := lower[idx + 'charset='.len..].trim_space().trim_right(';').trim_space()
-	return charset != 'utf-8' && charset != 'utf8'
+	parameters := split_mime_parameters(content_type)
+	for parameter in parameters[1..] {
+		eq := parameter.index('=') or { continue }
+		if parameter[..eq].trim_space().to_lower() != 'charset' {
+			continue
+		}
+		charset := unquote_mime_parameter(parameter[eq + 1..]).to_lower()
+		if charset != 'utf-8' && charset != 'utf8' {
+			return true
+		}
+	}
+	return false
+}
+
+// split_mime_parameters separates a media type and its parameters without
+// treating semicolons inside a quoted-string as delimiters.
+fn split_mime_parameters(content_type string) []string {
+	mut parameters := []string{}
+	mut start := 0
+	mut quoted := false
+	mut escaped := false
+	for i, ch in content_type {
+		if escaped {
+			escaped = false
+			continue
+		}
+		if quoted && ch == `\\` {
+			escaped = true
+			continue
+		}
+		if ch == `"` {
+			quoted = !quoted
+			continue
+		}
+		if ch == `;` && !quoted {
+			parameters << content_type[start..i].trim_space()
+			start = i + 1
+		}
+	}
+	parameters << content_type[start..].trim_space()
+	return parameters
+}
+
+// unquote_mime_parameter parses a MIME quoted-string parameter value, including
+// quoted-pair escapes. Malformed quoted values remain invalid charset values.
+fn unquote_mime_parameter(raw string) string {
+	value := raw.trim_space()
+	if value.len < 2 || value[0] != `"` || value[value.len - 1] != `"` {
+		return value
+	}
+	mut decoded := []u8{cap: value.len - 2}
+	mut escaped := false
+	for ch in value[1..value.len - 1] {
+		if escaped {
+			decoded << ch
+			escaped = false
+			continue
+		}
+		if ch == `\\` {
+			escaped = true
+			continue
+		}
+		decoded << ch
+	}
+	if escaped {
+		return value
+	}
+	return decoded.bytestr()
 }
 
 fn parse_content_length_header(s string) !int {

--- a/main.v
+++ b/main.v
@@ -529,7 +529,7 @@ fn (mut app App) handle_requests(mut reader io.BufferedReader) {
 							// run/test executeCommand + codeLens stubs, and willSave
 							// (never dispatched). Advertising only working features gives
 							// a better editor experience than exposing broken UI.
-							text_document_sync:                 TextDocumentSyncOptions{
+							text_document_sync:           TextDocumentSyncOptions{
 								open_close:           true
 								change:               2 // Incremental
 								save:                 SaveOptions{
@@ -538,27 +538,27 @@ fn (mut app App) handle_requests(mut reader io.BufferedReader) {
 								will_save:            false
 								will_save_wait_until: true
 							}
-							completion_provider:                CompletionProvider{
+							completion_provider:          CompletionProvider{
 								trigger_characters: ['.']
 							}
-							signature_help_provider:            SignatureHelpOptions{
+							signature_help_provider:      SignatureHelpOptions{
 								trigger_characters: ['(', ',']
 							}
-							definition_provider:                true
-							declaration_provider:               true
-							type_definition_provider:           true
-							implementation_provider:            true
-							hover_provider:                     true
-							references_provider:                true
-							rename_provider:                    RenameOptions{
+							definition_provider:          true
+							declaration_provider:         true
+							type_definition_provider:     true
+							implementation_provider:      true
+							hover_provider:               true
+							references_provider:          true
+							rename_provider:              RenameOptions{
 								prepare_provider: true
 							}
-							document_formatting_provider:       true
-							document_symbol_provider:           true
-							workspace_symbol_provider:          true
-							inlay_hint_provider:                true
-							code_action_provider:               true
-							semantic_tokens_provider:           SemanticTokensOptions{
+							document_formatting_provider: true
+							document_symbol_provider:     true
+							workspace_symbol_provider:    true
+							inlay_hint_provider:          true
+							code_action_provider:         true
+							semantic_tokens_provider:     SemanticTokensOptions{
 								legend: SemanticTokensLegend{
 									token_types:     semantic_token_types()
 									token_modifiers: semantic_token_modifiers()
@@ -566,11 +566,15 @@ fn (mut app App) handle_requests(mut reader io.BufferedReader) {
 								full:   true
 								range:  true
 							}
-							folding_range_provider:             true
-							call_hierarchy_provider:            true
-							document_highlight_provider:        true
-							selection_range_provider:           true
-							document_range_formatting_provider: true
+							folding_range_provider:       true
+							call_hierarchy_provider:      true
+							document_highlight_provider:  true
+							selection_range_provider:     true
+							// Range formatting is NOT advertised: v fmt only formats whole
+							// files, so a correct range implementation needs a
+							// character-accurate, EOL-preserving diff restricted to the
+							// requested range, which is not yet implemented (P0-08).
+							document_range_formatting_provider: false
 							position_encoding:                  position_encoding_string(app.position_encoding)
 							workspace:                          WorkspaceCapability{
 								workspace_folders: WorkspaceFoldersServerCapability{

--- a/main.v
+++ b/main.v
@@ -35,15 +35,17 @@ mut:
 	cancelled_raw_ids                           map[string]bool           // String/raw request ids cancelled via $/cancelRequest
 	current_request_raw_id                      string                    // Raw JSON id of the request being processed (echoed verbatim)
 	position_encoding                           PositionEncoding = .utf16 // Negotiated LSP position encoding (default UTF-16)
-	symbol_index                                map[string]IndexEntry // Persistent per-URI symbol index (see index.v)
-	indexed_dirs                                map[string]bool       // Project dirs already walked into the index
-	indexed_dir_walk_ms                         map[string]i64        // Last walk time per dir, for watcher-less refresh
-	ref_occurrences                             map[string]OccEntry   // Per-URI identifier occurrences for references (see index.v)
+	symbol_index                                map[string]IndexEntry        // Persistent per-URI symbol index (see index.v)
+	indexed_dirs                                map[string]bool              // Project dirs already walked into the index
+	indexed_dir_walk_ms                         map[string]i64               // Last walk time per dir, for watcher-less refresh
+	ref_occurrences                             map[string]OccEntry          // Per-URI identifier occurrences for references (see index.v)
+	index_skipped_uris                          map[string]bool              // Disk files omitted from the bounded index
+	index_incomplete_scopes                     map[string]bool              // Index walks that could not finish
 	vlib_fn_cache                               map[string]map[string]string // Per-vlib-module fn→return-type index (immutable during a session)
-	tcp_conn                                    ?&net.TcpConn         // Non-nil when serving a TCP client
-	is_shutdown                                 bool                  // True after shutdown request was acknowledged
-	exit_was_requested                          bool                  // True when the exit notification was received
-	received_initialize                         bool                  // True after initialize request was processed
+	tcp_conn                                    ?&net.TcpConn                // Non-nil when serving a TCP client
+	is_shutdown                                 bool                         // True after shutdown request was acknowledged
+	exit_was_requested                          bool                         // True when the exit notification was received
+	received_initialize                         bool                         // True after initialize request was processed
 	next_request_id                             int = 1 // Counter for server-initiated request ids
 }
 
@@ -417,7 +419,8 @@ fn (mut app App) handle_requests(mut reader io.BufferedReader) {
 		// determined — rather than dispatching and echoing a bogus id (P0-02).
 		if app.current_request_raw_id != '' && !raw_id_is_valid(app.current_request_raw_id) {
 			app.current_request_raw_id = 'null'
-			app.write_error_response(make_invalid_request_error_response(0, 'Request id must be a string, number, or null'))
+			app.write_error_response(make_invalid_request_error_response(0,
+				'Request id must be a string, number, or null'))
 			continue
 		}
 		// Decode the body WITHOUT the id field: json2 aborts the whole decode on

--- a/main.v
+++ b/main.v
@@ -804,11 +804,24 @@ fn read_json_string_token(content string, start int) (string, int) {
 		c := content[i]
 		if c == `\\` && i + 1 < content.len {
 			nxt := content[i + 1]
+			if nxt == `u` {
+				// `\uXXXX` unicode escape (with surrogate-pair support). Decode to a
+				// codepoint and append its UTF-8 bytes so an escaped member name like
+				// `id` decodes to `id` rather than a literal `u...` — otherwise
+				// extract_raw_id would miss the `id` key (JSON permits escaped keys).
+				if cp, adv := decode_json_unicode_escape(content, i) {
+					sb << utf32_to_str(u32(cp)).bytes()
+					i += adv
+					continue
+				}
+			}
 			esc := match nxt {
 				`n` { u8(`\n`) }
 				`t` { u8(`\t`) }
 				`r` { u8(`\r`) }
-				else { nxt }
+				`b` { u8(0x08) }
+				`f` { u8(0x0c) }
+				else { nxt } // `\"`, `\\`, `\/`, and any other: keep the char verbatim
 			}
 			sb << esc
 			i += 2
@@ -821,6 +834,49 @@ fn read_json_string_token(content string, start int) (string, int) {
 		i++
 	}
 	return sb.bytestr(), i
+}
+
+// decode_json_unicode_escape decodes a `\uXXXX` escape (and a following low
+// surrogate for astral codepoints) starting at `content[i]` (the backslash).
+// Returns the Unicode codepoint and the number of bytes consumed, or none when
+// the escape is malformed or a high surrogate is unpaired.
+fn decode_json_unicode_escape(content string, i int) ?(int, int) {
+	if i + 6 > content.len {
+		return none
+	}
+	hi := hex4_to_int(content[i + 2..i + 6]) or { return none }
+	if hi >= 0xD800 && hi <= 0xDBFF {
+		// High surrogate: must be followed by a `\uXXXX` low surrogate.
+		if i + 12 <= content.len && content[i + 6] == `\\` && content[i + 7] == `u` {
+			lo := hex4_to_int(content[i + 8..i + 12]) or { return none }
+			if lo >= 0xDC00 && lo <= 0xDFFF {
+				return 0x10000 + ((hi - 0xD800) << 10) + (lo - 0xDC00), 12
+			}
+		}
+		return none
+	}
+	return hi, 6
+}
+
+// hex4_to_int parses exactly four hexadecimal digits into an int, or none.
+fn hex4_to_int(s string) ?int {
+	if s.len != 4 {
+		return none
+	}
+	mut v := 0
+	for c in s {
+		d := if c >= `0` && c <= `9` {
+			int(c - `0`)
+		} else if c >= `a` && c <= `f` {
+			int(c - `a`) + 10
+		} else if c >= `A` && c <= `F` {
+			int(c - `A`) + 10
+		} else {
+			return none
+		}
+		v = v * 16 + d
+	}
+	return v
 }
 
 // skip_json_value returns the index just past a complete JSON value beginning at

--- a/main.v
+++ b/main.v
@@ -35,6 +35,7 @@ mut:
 	position_encoding                           PositionEncoding = .utf16 // Negotiated LSP position encoding (default UTF-16)
 	symbol_index                                map[string]IndexEntry // Persistent per-URI symbol index (see index.v)
 	indexed_dirs                                map[string]bool       // Project dirs already walked into the index
+	ref_occurrences                             map[string]OccEntry   // Per-URI identifier occurrences for references (see index.v)
 	tcp_conn                                    ?&net.TcpConn         // Non-nil when serving a TCP client
 	is_shutdown                                 bool                  // True after shutdown request was acknowledged
 	exit_was_requested                          bool                  // True when the exit notification was received

--- a/main.v
+++ b/main.v
@@ -1251,17 +1251,14 @@ fn method_is_notification_only(method Method) bool {
 }
 
 // request_is_cancelled reports whether the request currently being processed was
-// cancelled. A string-id request is matched ONLY by its exact raw id, so it can
-// never be falsely cancelled by a numeric cancel of id 0 (P0-02).
+// cancelled. When its raw id is available, every id type is matched by that
+// exact token so numeric values are never narrowed into a colliding int.
 fn (app &App) request_is_cancelled(id int) bool {
 	raw := app.current_request_raw_id
-	if raw.starts_with('"') {
+	if raw != '' {
 		return raw in app.cancelled_raw_ids
 	}
-	if id in app.cancelled_requests {
-		return true
-	}
-	return raw != '' && raw in app.cancelled_raw_ids
+	return id in app.cancelled_requests
 }
 
 fn make_invalid_request_error_response(id int, message string) ErrorResponse {
@@ -1797,8 +1794,8 @@ fn (mut app App) write_response_or_cancelled(id int, response Response) {
 fn (mut app App) consume_cancelled_request(id int) bool {
 	raw := app.current_request_raw_id
 	mut was_cancelled := false
-	if raw.starts_with('"') {
-		// String-id request: consume only its exact raw id.
+	if raw != '' {
+		// Consume every request by its exact raw id when it is available.
 		if raw in app.cancelled_raw_ids {
 			app.cancelled_raw_ids.delete(raw)
 			was_cancelled = true
@@ -1807,10 +1804,6 @@ fn (mut app App) consume_cancelled_request(id int) bool {
 	}
 	if id in app.cancelled_requests {
 		app.cancelled_requests.delete(id)
-		was_cancelled = true
-	}
-	if raw != '' && raw in app.cancelled_raw_ids {
-		app.cancelled_raw_ids.delete(raw)
 		was_cancelled = true
 	}
 	return was_cancelled

--- a/main.v
+++ b/main.v
@@ -1016,7 +1016,11 @@ fn is_client_response_message(content string) bool {
 	if content_has_member(content, 'method') {
 		return false
 	}
-	has_id := content.contains('"id"')
+	// Detect the id through the escape-decoding parser (request_content_has_id),
+	// not a raw `"id"` substring: a response whose id key is unicode-escaped
+	// (e.g. {"id":1,"result":null}) must still be recognized and consumed, not
+	// dispatched as an empty method (P0-02).
+	has_id := request_content_has_id(content)
 	return has_id && (content_has_member(content, 'result') || content_has_member(content, 'error'))
 }
 

--- a/main.v
+++ b/main.v
@@ -474,15 +474,6 @@ fn (mut app App) handle_requests(mut reader io.BufferedReader) {
 			continue
 		}
 		log('\n\nRECV: ${content}')
-		// A message with an id + result/error but no method is a response to a
-		// server-initiated request (progress create, capability registration).
-		// Consume it without dispatching so it never hits the method router or
-		// produces a spurious MethodNotFound error (P0-02).
-		if is_client_response_message(content) {
-			app.note_server_request_response(content)
-			log('Consumed client response to a server-initiated request: ${content}')
-			continue
-		}
 		has_id := request_content_has_id(content)
 		// Preserve the exact id (numeric or string) so responses echo it
 		// verbatim; string ids would otherwise collapse to 0 (P0-02).
@@ -503,7 +494,18 @@ fn (mut app App) handle_requests(mut reader io.BufferedReader) {
 		// id (0 for non-numeric ids), while the exact id is echoed via the raw id.
 		body := json2.decode[RequestBody](content) or {
 			log('Failed to decode JSON request: ${err.msg()}. Content: "${content}"')
+			app.current_request_raw_id = 'null'
 			app.write_error_response(make_parse_error_response(err.msg()))
+			continue
+		}
+		// A message with an id + result/error but no method is a response to a
+		// server-initiated request (progress create, capability registration).
+		// Classify and record it only after the typed decode above validated the
+		// complete JSON payload, so malformed acknowledgements cannot activate
+		// capabilities or disappear without a parse error (P0-02).
+		if is_client_response_message(content) {
+			app.note_server_request_response(content)
+			log('Consumed client response to a server-initiated request: ${content}')
 			continue
 		}
 		request := Request{

--- a/semantic_tokens.v
+++ b/semantic_tokens.v
@@ -272,6 +272,32 @@ fn classify_v_identifier(word string) int {
 	return -1
 }
 
+// convert_tokens_to_encoding rewrites each token's byte-based `start`/`length`
+// into the client's negotiated position encoding, so semantic-token positions
+// are consistent with the advertised encoding for non-ASCII lines (P2-01).
+fn convert_tokens_to_encoding(tokens []SemToken, lines []string, enc PositionEncoding) []SemToken {
+	if enc == .utf8 {
+		// The tokenizer already works in byte offsets.
+		return tokens
+	}
+	mut out := []SemToken{cap: tokens.len}
+	for tok in tokens {
+		if tok.line < 0 || tok.line >= lines.len {
+			out << tok
+			continue
+		}
+		line := lines[tok.line]
+		enc_start := byte_to_encoded_col(line, tok.start, enc)
+		enc_end := byte_to_encoded_col(line, tok.start + tok.length, enc)
+		out << SemToken{
+			...tok
+			start:  enc_start
+			length: enc_end - enc_start
+		}
+	}
+	return out
+}
+
 // encode_semantic_tokens converts absolute-position SemTokens into the
 // delta-encoded integer array required by the LSP SemanticTokens protocol.
 // Tokens must already be ordered by (line, start) ascending.
@@ -306,12 +332,17 @@ fn (mut app App) handle_semantic_tokens(request Request) Response {
 	uri := params.text_document.uri
 	content := app.open_files[uri] or { os.read_file(uri_to_path(uri)) or { '' } }
 	if content == '' {
+		// An empty document has an empty token set, not a null result (P2-01).
 		return Response{
 			id:     request.id
-			result: 'null'
+			result: SemanticTokens{
+				data: []
+			}
 		}
 	}
-	raw_tokens := tokenize_v_source(content)
+	lines := content.split_into_lines()
+	raw_tokens := convert_tokens_to_encoding(tokenize_v_source(content), lines,
+		app.position_encoding)
 	encoded := encode_semantic_tokens(raw_tokens)
 	return Response{
 		id:     request.id
@@ -337,10 +368,14 @@ fn (mut app App) handle_semantic_tokens_range(request Request) Response {
 	if content == '' {
 		return Response{
 			id:     request.id
-			result: 'null'
+			result: SemanticTokens{
+				data: []
+			}
 		}
 	}
-	raw_tokens := tokenize_v_source(content)
+	lines := content.split_into_lines()
+	raw_tokens := convert_tokens_to_encoding(tokenize_v_source(content), lines,
+		app.position_encoding)
 	start_line := params.range.start.line
 	end_line := params.range.end.line
 	range_tokens := raw_tokens.filter(it.line >= start_line && it.line <= end_line)

--- a/semantic_tokens.v
+++ b/semantic_tokens.v
@@ -377,8 +377,17 @@ fn (mut app App) handle_semantic_tokens_range(request Request) Response {
 	raw_tokens := convert_tokens_to_encoding(tokenize_v_source(content), lines,
 		app.position_encoding)
 	start_line := params.range.start.line
+	start_char := params.range.start.char
 	end_line := params.range.end.line
-	range_tokens := raw_tokens.filter(it.line >= start_line && it.line <= end_line)
+	end_char := params.range.end.char
+	// semanticTokens/range must return only tokens inside the requested range, so
+	// bound by character on the boundary lines too — not just by line. A token at
+	// (line, start) is kept when its start position is >= the range start and <
+	// the range end in (line, char) order; this excludes tokens before the start
+	// character on the first line and at/after the end character on the last line.
+	range_tokens := raw_tokens.filter((it.line > start_line
+		|| (it.line == start_line && it.start >= start_char)) && (it.line < end_line
+		|| (it.line == end_line && it.start < end_char)))
 	encoded := encode_semantic_tokens(range_tokens)
 	return Response{
 		id:     request.id

--- a/semantic_tokens.v
+++ b/semantic_tokens.v
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a GPL license that can be found in the LICENSE file.
 module main
 
-import json
+import json2
 import os
 
 // Semantic token type indices — must match the order returned by semantic_token_types().
@@ -296,7 +296,7 @@ fn encode_semantic_tokens(raw_tokens []SemToken) []int {
 // handle_semantic_tokens handles the textDocument/semanticTokens/full LSP request,
 // returning semantic highlighting data for the entire document.
 fn (mut app App) handle_semantic_tokens(request Request) Response {
-	params := json.decode(SemanticTokensParams, request.params) or {
+	params := json2.decode[SemanticTokensParams](request.params) or {
 		$if debug { log('Failed to decode SemanticTokensParams: ${err}') }
 		return Response{
 			id:     request.id
@@ -325,7 +325,7 @@ fn (mut app App) handle_semantic_tokens(request Request) Response {
 // It tokenizes the full document but only encodes tokens within the requested range,
 // which reduces payload size for large files.
 fn (mut app App) handle_semantic_tokens_range(request Request) Response {
-	params := json.decode(SemanticTokensRangeParams, request.params) or {
+	params := json2.decode[SemanticTokensRangeParams](request.params) or {
 		$if debug { log('Failed to decode SemanticTokensRangeParams: ${err}') }
 		return Response{
 			id:     request.id


### PR DESCRIPTION
This branch works through a static architecture/correctness/security audit of
the language server. It is a large but coherent body of work; commits are
grouped by theme below and each is self-contained (build stays green, all
`_test.v` suites pass at every step).

## Protocol / JSON-RPC
- Correct JSON-RPC envelope handling and string request ids (ids echoed
  verbatim; string ids no longer collide with numeric `0` in cancellation).
- CRLF-safe, close-aware message framing with explicit size limits.
- Full migration off the deprecated `json` module to `json2`.

## Position encoding
- UTF-16 position codec (the V compiler reports byte columns) with utf8/utf16/
  utf32 support, negotiated at `initialize`.
- All emitted positions (symbols, call hierarchy, inlay hints, highlights) are
  re-encoded consistently with the negotiated encoding.

## Security / process execution
- Compiler is invoked via an argv-based, shell-free process path.
- TCP transport is bound loopback-only.
- Compiler runs under a timeout so a hung invocation cannot wedge the server.

## Diagnostics
- **Capture compiler stderr** — `v -check -json-errors` / `-line-info` write
  their JSON to stderr, so returning stdout alone silently dropped every
  diagnostic. Both streams are now merged.
- Regression tests assert diagnostics carry real compiler errors, and that
  definition/signature-help resolve real content (not just a response id) so
  this class of bug cannot hide again.

## Indexing / navigation
- Persistent incremental symbol index backing workspace/document symbols,
  hover docs, call-hierarchy prepare, and module completions.
- Reference-occurrence index driving scope-safe references and rename
  (validated against a compiler anchor), plus read/write document highlights.
- Stale index entries are dropped when a workspace folder is removed;
  symlink-cycle protection in the index walk.

## Document sync & safe edits
- Versioned document sync; invalid incremental edits are refused without
  advancing the document version.
- `didSave` never marks an unopened document open; never falls back to a global
  buffer for another document.
- Range formatting is no longer advertised (it was unsafe); full-format end is
  computed from byte offsets; keyword rename targets are rejected.

## Performance
- Inlay hints cache a per-module vlib fn→return-type index instead of walking
  and re-reading vlib from disk on every request.

## Testing
`v .` builds clean and `v test .` passes all six `_test.v` suites. Test
coverage was expanded substantially (index, references, encoding, and
content-asserting integration tests for compiler-backed features).