### PR TITLE
fix: process streaming stdio requests

### DIFF
--- a/lsp_test.v
+++ b/lsp_test.v
@@ -6,6 +6,35 @@ import json2
 import io
 import os
 
+fn test_stdio_reader_processes_frame_before_eof() {
+	mut transport := os.pipe() or {
+		assert false, 'failed to create stdin test pipe: ${err}'
+		return
+	}
+	saved_stdin := os.fd_dup(0)
+	assert saved_stdin >= 0
+	defer {
+		os.fd_dup2(saved_stdin, 0)
+		os.fd_close(saved_stdin)
+		transport.close()
+	}
+
+	assert os.fd_dup2(transport.read_fd, 0) >= 0
+	payload := '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}'
+	frame := 'Content-Length: ${payload.len}\r\n\r\n${payload}'
+	transport.write(frame.bytes()) or {
+		assert false, 'failed to write stdin test frame: ${err}'
+		return
+	}
+
+	mut reader := new_stdin_buffered_reader()
+	content := read_request(mut reader) or {
+		assert false, 'failed to read stdin test frame: ${err}'
+		return
+	}
+	assert content == payload
+}
+
 fn test_method_from_string_initialize() {
 	assert Method.from_string('initialize') == .initialize
 }

--- a/main.v
+++ b/main.v
@@ -107,6 +107,26 @@ fn log(s string) {
 	output.close()
 }
 
+// StdinReader reads standard input through its raw descriptor so streaming
+// clients are not blocked by the full-buffer behaviour of C fread.
+struct StdinReader {}
+
+fn (_ StdinReader) read(mut buffer []u8) !int {
+	data, bytes_read := os.fd_read(0, buffer.len)
+	if bytes_read < 0 {
+		return error('failed to read from stdin')
+	}
+	if bytes_read == 0 {
+		return io.Eof{}
+	}
+	return copy(mut buffer, data.bytes())
+}
+
+// new_stdin_buffered_reader creates the streaming reader used by stdio mode.
+fn new_stdin_buffered_reader() &io.BufferedReader {
+	return io.new_buffered_reader(reader: StdinReader{}, cap: transport_buffer_cap)
+}
+
 fn main() {
 	log('VLS started. Reading from stdin...')
 	log('VLS preferences: is_vls=${v_prefs.is_vls}')
@@ -153,7 +173,10 @@ fn main() {
 		open_files: map[string]string{}
 		temp_dir:   temp_dir
 	}
-	mut reader := io.new_buffered_reader(reader: os.stdin(), cap: transport_buffer_cap)
+	// os.File.read uses C fread, which waits for the entire buffer on an open
+	// pipe. LSP clients keep stdin open, so use the raw descriptor-backed pipe
+	// reader to consume each request as soon as it arrives.
+	mut reader := new_stdin_buffered_reader()
 	app.handle_requests(mut reader)
 	log('VLS exiting.')
 	os.rmdir_all(temp_dir) or {


### PR DESCRIPTION
## Summary

- read stdio through a raw file descriptor instead of `os.File`/`fread`
- keep the existing bounded `io.BufferedReader` for LSP framing
- add a regression test that delivers a complete LSP frame while stdin remains open

## Problem

`os.File.read` delegates to C `fread`. When VLS used a 64 KiB buffered reader on an open
stdio pipe, `fread` waited for the buffer to fill or for EOF. LSP clients keep stdin open, so
VS Code could write `initialize` but VLS would not process it.

## Validation

- `v .`
- `v test .` (6/6 test files)
- VS Code Extension Host: initialize, document symbols, restart, and reconnect