### PR TITLE
Fix/windows stdio editor support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ vls
 **/out/
 **/*.tsbuildinfo
 **/*.vsix
+vls.exe

--- a/call_hierarchy.v
+++ b/call_hierarchy.v
@@ -163,7 +163,8 @@ fn (mut app App) handle_call_hierarchy_outgoing(request Request) Response {
 		if called_name == self_name {
 			continue // skip direct recursion
 		}
-		callee := app.find_fn_declaration(called_name, search_dirs, request.id, uri.ends_with('_test.v'))
+		callee := app.find_fn_declaration(called_name, search_dirs, request.id,
+			uri.ends_with('_test.v'))
 		if callee.name == '' {
 			continue
 		}

--- a/handlers.v
+++ b/handlers.v
@@ -42,6 +42,7 @@ fn (mut app App) operation_at_pos(method Method, request Request) Response {
 	line_nr := params.position.line + 1
 	col := params.position.char
 	path := params.text_document.uri
+	content := app.open_files[path] or { '' }
 	// The V compiler consumes byte columns, so convert the client's character
 	// offset (in the negotiated encoding) to a byte offset within the cursor line
 	// before building the -line-info string (P0-01).
@@ -49,7 +50,7 @@ fn (mut app App) operation_at_pos(method Method, request Request) Response {
 
 	// Intercept completion on import lines
 	if method == .completion {
-		if content := app.open_files[path] {
+		if content != '' {
 			lines := content.split_into_lines()
 			if line_nr - 1 < lines.len {
 				current_line := lines[line_nr - 1]
@@ -65,6 +66,17 @@ fn (mut app App) operation_at_pos(method Method, request Request) Response {
 							}
 						}
 					}
+				}
+			}
+		}
+		if items := get_local_member_completions(content, params.position.line, col,
+			app.position_encoding)
+		{
+			return Response{
+				id:     request.id
+				result: CompletionList{
+					is_incomplete: false
+					items:         items
 				}
 			}
 		}
@@ -94,7 +106,6 @@ fn (mut app App) operation_at_pos(method Method, request Request) Response {
 		// If it is not '.', the user is not doing member access, so augment
 		// the compiler result with V keywords and builtins.
 		cursor_line := params.position.line
-		content := app.open_files[path] or { '' }
 		lines := content.split_into_lines()
 		trigger_char := if cursor_line < lines.len && col > 0 {
 			line := lines[cursor_line]
@@ -213,6 +224,168 @@ fn get_word_before_dot(line string, dot_col int, enc PositionEncoding) string {
 		start--
 	}
 	return line[start..dot_byte]
+}
+
+// get_local_member_completions resolves members declared in the current buffer.
+// It avoids starting the V compiler for the common `receiver.` case.
+fn get_local_member_completions(content string, line_nr int, col int, enc PositionEncoding) ?[]Detail {
+	if content == '' {
+		return none
+	}
+	lines := content.split_into_lines()
+	if line_nr < 0 || line_nr >= lines.len || col <= 0 {
+		return none
+	}
+	receiver := get_word_before_dot(lines[line_nr], col - 1, enc)
+	if receiver == '' {
+		return none
+	}
+	receiver_type := infer_local_receiver_type(lines, line_nr, receiver)
+	if receiver_type == '' {
+		return none
+	}
+	items := parse_local_type_members(content, receiver_type)
+	if items.len == 0 {
+		return none
+	}
+	return items
+}
+
+fn infer_local_receiver_type(lines []string, cursor_line int, receiver string) string {
+	for line_idx := cursor_line; line_idx >= 0; line_idx-- {
+		line := lines[line_idx].trim_space()
+		if line == '' || line.starts_with('//') {
+			continue
+		}
+		if inferred := infer_receiver_type_from_declaration(line, receiver) {
+			return inferred
+		}
+		stripped := if line.starts_with('pub ') { line[4..] } else { line }
+		if stripped.starts_with('fn ') {
+			break
+		}
+	}
+	return ''
+}
+
+fn infer_receiver_type_from_declaration(line string, receiver string) ?string {
+	assignment_markers := ['${receiver} := &', '${receiver} := ']
+	for marker in assignment_markers {
+		marker_idx := line.index(marker) or { continue }
+		if marker_idx > 0 && is_ident_char(line[marker_idx - 1]) {
+			continue
+		}
+		mut rest := line[marker_idx + marker.len..].trim_space()
+		if brace_idx := rest.index('{') {
+			rest = rest[..brace_idx]
+		}
+		type_name := rest.trim_space().trim_left('&')
+		if type_name != '' && !type_name.contains(' ') && !type_name.contains('(') {
+			return type_name
+		}
+	}
+
+	fn_idx := line.index('fn (') or { return none }
+	receiver_start := fn_idx + 4
+	receiver_end := line.index_after(')', receiver_start) or { return none }
+	parts := line[receiver_start..receiver_end].fields().filter(it != 'mut')
+	if parts.len < 2 || parts[0] != receiver {
+		return none
+	}
+	return parts[1].trim_left('&')
+}
+
+fn parse_local_type_members(content string, receiver_type string) []Detail {
+	lines := content.split_into_lines()
+	mut items := []Detail{}
+	mut seen := map[string]bool{}
+	mut in_struct := false
+	for line_idx, raw_line in lines {
+		line := raw_line.trim_space()
+		stripped := if line.starts_with('pub ') { line[4..] } else { line }
+		if stripped.starts_with('struct ') {
+			name := first_word(stripped[7..])
+			in_struct = name == receiver_type && line.contains('{') && !line.contains('}')
+			continue
+		}
+		if in_struct {
+			if line == '}' {
+				in_struct = false
+				continue
+			}
+			if line == '' || line.starts_with('//')
+				|| line in ['mut:', 'pub:', 'pub mut:', '__global:'] {
+				continue
+			}
+			field_label := local_field_label(line)
+			if field_label != '' && field_label !in seen {
+				items << Detail{
+					kind:          5
+					label:         field_label
+					detail:        line
+					documentation: extract_doc_comment(lines, line_idx)
+				}
+				seen[field_label] = true
+			}
+			continue
+		}
+		method := parse_local_method_completion(line, receiver_type, lines, line_idx) or {
+			continue
+		}
+		if method.label !in seen {
+			items << method
+			seen[method.label] = true
+		}
+	}
+	return items
+}
+
+fn local_field_label(line string) string {
+	first := first_word(line)
+	if first == '' {
+		return ''
+	}
+	if !first.contains('.') && !first.contains('[') {
+		return first
+	}
+	mut label := first.all_after_last('.')
+	if bracket := label.index('[') {
+		label = label[..bracket]
+	}
+	return label
+}
+
+fn parse_local_method_completion(line string, receiver_type string, lines []string, line_idx int) ?Detail {
+	stripped := if line.starts_with('pub fn ') {
+		line[7..]
+	} else if line.starts_with('fn ') {
+		line[3..]
+	} else {
+		return none
+	}
+	if !stripped.starts_with('(') {
+		return none
+	}
+	receiver_end := stripped.index(')') or { return none }
+	receiver_parts := stripped[1..receiver_end].fields().filter(it != 'mut')
+	if receiver_parts.len < 2 || receiver_parts[1].trim_left('&') != receiver_type {
+		return none
+	}
+	after_receiver := stripped[receiver_end + 1..].trim_space()
+	paren_idx := after_receiver.index('(') or { return none }
+	method_name := after_receiver[..paren_idx].trim_space()
+	if method_name == '' {
+		return none
+	}
+	insert := build_fn_snippet(method_name, after_receiver[paren_idx..])
+	return Detail{
+		kind:               2
+		label:              method_name
+		detail:             line.all_before('{').trim_space()
+		documentation:      extract_doc_comment(lines, line_idx)
+		insert_text:        insert
+		insert_text_format: if insert.contains('$') { 2 } else { 1 }
+	}
 }
 
 // parse_import_aliases returns alias -> module path for simple V import statements.
@@ -477,7 +650,8 @@ fn (mut app App) build_diagnostics_notification(uri string, content string) Noti
 	}
 }
 
-// Returns instant red wavy errors
+// on_did_change updates the authoritative buffer without invoking the compiler.
+// Diagnostics run on open/save so typing, completion, and inlay hints stay responsive.
 fn (mut app App) on_did_change(request Request) ?Notification {
 	params := json2.decode[DidChangeTextDocumentParams](request.params) or {
 		$if debug { log('Failed to decode DidChangeTextDocumentParams: ${err}') }
@@ -535,9 +709,7 @@ fn (mut app App) on_did_change(request Request) ?Notification {
 	}
 	app.bump_generation(uri)
 	app.invalidate_index_uri(uri) // symbols re-parsed lazily on next query
-	notification := app.build_diagnostics_notification(uri, content)
-	$if debug { log('returning notification: ${notification}') }
-	return notification
+	return none
 }
 
 // encode_diagnostic_range re-encodes a diagnostic's byte-based character
@@ -2981,7 +3153,7 @@ fn (mut app App) handle_selection_range(request Request) Response {
 // on_did_change_configuration handles the workspace/didChangeConfiguration notification.
 // It applies settings that affect server behaviour:
 //   vls.inlayHints  – enable or disable inlay type hints
-//   vls.diagnostics – enable or disable live compile-time diagnostics
+//   vls.diagnostics – enable or disable open/save compile-time diagnostics
 fn (mut app App) on_did_change_configuration(request Request) {
 	resolved := resolve_workspace_settings(request.params)
 	if resolved.has_inlay_hints {

--- a/handlers.v
+++ b/handlers.v
@@ -69,9 +69,24 @@ fn (mut app App) operation_at_pos(method Method, request Request) Response {
 				}
 			}
 		}
-		if items := get_local_member_completions(content, params.position.line, col,
+		if local_members := get_local_member_completions(content, params.position.line, col,
 			app.position_encoding)
 		{
+			mut items := local_members.items.clone()
+			mut seen_labels := map[string]bool{}
+			for item in items {
+				seen_labels[item.label] = true
+			}
+			working_dir := os.dir(uri_to_path(path))
+			if working_dir != '' {
+				for item in app.collect_module_type_member_completions(path, working_dir,
+					local_members.receiver_type) {
+					if item.label !in seen_labels {
+						items << item
+						seen_labels[item.label] = true
+					}
+				}
+			}
 			return Response{
 				id:     request.id
 				result: CompletionList{
@@ -226,9 +241,14 @@ fn get_word_before_dot(line string, dot_col int, enc PositionEncoding) string {
 	return line[start..dot_byte]
 }
 
+struct LocalMemberCompletions {
+	receiver_type string
+	items         []Detail
+}
+
 // get_local_member_completions resolves members declared in the current buffer.
 // It avoids starting the V compiler for the common `receiver.` case.
-fn get_local_member_completions(content string, line_nr int, col int, enc PositionEncoding) ?[]Detail {
+fn get_local_member_completions(content string, line_nr int, col int, enc PositionEncoding) ?LocalMemberCompletions {
 	if content == '' {
 		return none
 	}
@@ -248,7 +268,10 @@ fn get_local_member_completions(content string, line_nr int, col int, enc Positi
 	if items.len == 0 {
 		return none
 	}
-	return items
+	return LocalMemberCompletions{
+		receiver_type: receiver_type
+		items:         items
+	}
 }
 
 fn infer_local_receiver_type(lines []string, cursor_line int, receiver string) string {
@@ -340,6 +363,23 @@ fn parse_local_type_members(content string, receiver_type string) []Detail {
 	return items
 }
 
+// parse_type_method_completions indexes methods by their receiver type.
+// Fields stay in the declaring file, while methods may be declared in siblings.
+fn parse_type_method_completions(content string) map[string][]Detail {
+	lines := content.split_into_lines()
+	mut methods_by_type := map[string][]Detail{}
+	for line_idx, line in lines {
+		receiver_type := local_method_receiver_type(line) or { continue }
+		method := parse_local_method_completion(line, receiver_type, lines, line_idx) or {
+			continue
+		}
+		mut methods := methods_by_type[receiver_type] or { []Detail{} }
+		methods << method
+		methods_by_type[receiver_type] = methods
+	}
+	return methods_by_type
+}
+
 fn local_field_label(line string) string {
 	first := first_word(line)
 	if first == '' {
@@ -363,14 +403,11 @@ fn parse_local_method_completion(line string, receiver_type string, lines []stri
 	} else {
 		return none
 	}
-	if !stripped.starts_with('(') {
+	declared_receiver_type := local_method_receiver_type(line) or { return none }
+	if declared_receiver_type != receiver_type {
 		return none
 	}
 	receiver_end := stripped.index(')') or { return none }
-	receiver_parts := stripped[1..receiver_end].fields().filter(it != 'mut')
-	if receiver_parts.len < 2 || receiver_parts[1].trim_left('&') != receiver_type {
-		return none
-	}
 	after_receiver := stripped[receiver_end + 1..].trim_space()
 	paren_idx := after_receiver.index('(') or { return none }
 	method_name := after_receiver[..paren_idx].trim_space()
@@ -386,6 +423,25 @@ fn parse_local_method_completion(line string, receiver_type string, lines []stri
 		insert_text:        insert
 		insert_text_format: if insert.contains('$') { 2 } else { 1 }
 	}
+}
+
+fn local_method_receiver_type(line string) ?string {
+	stripped := if line.starts_with('pub fn ') {
+		line[7..]
+	} else if line.starts_with('fn ') {
+		line[3..]
+	} else {
+		return none
+	}
+	if !stripped.starts_with('(') {
+		return none
+	}
+	receiver_end := stripped.index(')') or { return none }
+	receiver_parts := stripped[1..receiver_end].fields().filter(it != 'mut')
+	if receiver_parts.len < 2 {
+		return none
+	}
+	return receiver_parts[1].trim_left('&')
 }
 
 // parse_import_aliases returns alias -> module path for simple V import statements.
@@ -2876,6 +2932,21 @@ fn (mut app App) collect_module_fn_completions(current_file_uri string, working_
 	}
 	app.ensure_dir_shallow_indexed(working_dir)
 	return app.query_module_fn_completions(current_module, current_file_uri, working_dir)
+}
+
+// collect_module_type_member_completions returns methods declared in sibling
+// files of the current module without invoking the compiler on each keystroke.
+fn (mut app App) collect_module_type_member_completions(current_file_uri string, working_dir string, receiver_type string) []Detail {
+	current_content := app.open_files[current_file_uri] or {
+		os.read_file(uri_to_path(current_file_uri)) or { '' }
+	}
+	current_module := get_module_name(current_content)
+	for uri, _ in app.open_files {
+		app.reindex_uri(uri)
+	}
+	app.ensure_dir_shallow_indexed(working_dir)
+	return app.query_module_type_method_completions(current_module, receiver_type,
+		current_file_uri, working_dir)
 }
 
 // parse_module_fn_completions extracts free-function declarations (`pub fn` and `fn`)

--- a/handlers.v
+++ b/handlers.v
@@ -709,6 +709,11 @@ fn (mut app App) on_did_change(request Request) ?Notification {
 	}
 	app.bump_generation(uri)
 	app.invalidate_index_uri(uri) // symbols re-parsed lazily on next query
+	$if debug {
+		notification := app.build_diagnostics_notification(uri, content)
+		log('returning notification: ${notification}')
+		return notification
+	}
 	return none
 }
 

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -3687,6 +3687,12 @@ fn test_semantic_tokens_classify_imported_namespace_calls() {
 	assert tokens.any(it.line == 8 && it.start == 5 && it.type_idx == sem_tok_method)
 }
 
+fn test_semantic_tokens_keep_inline_method_calls_as_functions() {
+	tokens := tokenize_v_source('fn (a A) run() { helper() }\n')
+	assert tokens.any(it.line == 0 && it.start == 9 && it.type_idx == sem_tok_method)
+	assert tokens.any(it.line == 0 && it.start == 17 && it.type_idx == sem_tok_function)
+}
+
 fn test_semantic_tokens_classify_receivers_parameters_and_reused_variables() {
 	content := 'module main\n\npub fn (app &App) index(mut ctx Context) {\n' +
 		'\tx := 1\n\tdump(x)\n\tapp.run(ctx)\n}\n'

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -3544,10 +3544,11 @@ fn test_operation_at_pos_dot_completion_includes_aliased_import_module_members()
 fn test_local_member_completion_avoids_compiler_for_current_buffer_type() {
 	content := 'module main\n\nstruct App {\n\tname string\n\tshared_values shared []int\n}\n\n' +
 		'fn (app &App) run(port int) bool {\n\tapp.\n\treturn true\n}\n'
-	items := get_local_member_completions(content, 8, 5, .utf16) or {
+	members := get_local_member_completions(content, 8, 5, .utf16) or {
 		assert false, 'expected local member completions'
 		return
 	}
+	items := members.items
 	assert items.map(it.label) == ['name', 'shared_values', 'run']
 	assert items[2].kind == 2
 	assert items[2].insert_text or { '' } == 'run(\${1:port})$0'
@@ -3557,6 +3558,84 @@ fn test_local_member_completion_does_not_leak_variable_from_previous_function() 
 	content := 'module main\n\nstruct App {\n\tname string\n}\n\n' +
 		'fn first() {\n\tapp := App{}\n\tprintln(app.name)\n}\n\n' + 'fn second() {\n\tapp.\n}\n'
 	assert get_local_member_completions(content, 12, 5, .utf16) == none
+}
+
+fn test_local_member_completion_includes_disk_sibling_methods() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+
+	test_dir := os.join_path(app.temp_dir, 'local_member_disk_sibling')
+	must_mkdir_all(test_dir)
+	main_file := os.join_path(test_dir, 'main.v')
+	methods_file := os.join_path(test_dir, 'methods.v')
+	content := 'module main\n\nstruct App {\n\tname string\n}\n\nfn main() {\n\tapp := App{}\n\tapp.\n}\n'
+	must_write_file(main_file, content)
+	must_write_file(methods_file, 'module main\n\nfn (app &App) start() {}\n')
+	uri := path_to_uri(main_file)
+	app.open_files[uri] = content
+
+	response := app.operation_at_pos(.completion, Request{
+		id:     9010
+		method: 'textDocument/completion'
+		params: json2.encode(TextDocumentPositionParams{
+			text_document: TextDocumentIdentifier{
+				uri: uri
+			}
+			position:      Position{
+				line: 8
+				char: 5
+			}
+		},
+			escape_unicode: true
+		)
+	})
+
+	assert response.result is CompletionList
+	labels := (response.result as CompletionList).items.map(it.label)
+	assert 'name' in labels
+	assert 'start' in labels
+}
+
+fn test_local_member_completion_prefers_open_sibling_methods() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+
+	test_dir := os.join_path(app.temp_dir, 'local_member_open_sibling')
+	must_mkdir_all(test_dir)
+	main_file := os.join_path(test_dir, 'main.v')
+	methods_file := os.join_path(test_dir, 'methods.v')
+	content := 'module main\n\nstruct App {\n\tname string\n}\n\nfn main() {\n\tapp := App{}\n\tapp.\n}\n'
+	must_write_file(main_file, content)
+	must_write_file(methods_file, 'module main\n\nfn (app &App) disk_start() {}\n')
+	uri := path_to_uri(main_file)
+	methods_uri := path_to_uri(methods_file)
+	app.open_files[uri] = content
+	app.open_files[methods_uri] = 'module main\n\nfn (app &App) memory_start() {}\n'
+
+	response := app.operation_at_pos(.completion, Request{
+		id:     9011
+		method: 'textDocument/completion'
+		params: json2.encode(TextDocumentPositionParams{
+			text_document: TextDocumentIdentifier{
+				uri: uri
+			}
+			position:      Position{
+				line: 8
+				char: 5
+			}
+		},
+			escape_unicode: true
+		)
+	})
+
+	assert response.result is CompletionList
+	labels := (response.result as CompletionList).items.map(it.label)
+	assert 'memory_start' in labels
+	assert 'disk_start' !in labels
 }
 
 fn test_semantic_tokens_returns_data_for_known_content() {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -3675,6 +3675,18 @@ fn test_semantic_tokens_classify_functions_methods_and_properties() {
 	assert tokens.any(it.line == 1 && it.start == 15 && it.type_idx == sem_tok_property)
 }
 
+fn test_semantic_tokens_classify_imported_namespace_calls() {
+	content := 'module main\n\nimport os\nimport net.http as http\n\nfn main() {\n' +
+		'\tos.read_file("a")\n\thttp.get("https://example.com")\n\tapp.start()\n}\n'
+	tokens := tokenize_v_source(content)
+	assert tokens.any(it.line == 6 && it.start == 1 && it.type_idx == sem_tok_namespace)
+	assert tokens.any(it.line == 6 && it.start == 4 && it.type_idx == sem_tok_function)
+	assert tokens.any(it.line == 7 && it.start == 1 && it.type_idx == sem_tok_namespace)
+	assert tokens.any(it.line == 7 && it.start == 6 && it.type_idx == sem_tok_function)
+	assert tokens.any(it.line == 8 && it.start == 1 && it.type_idx == sem_tok_variable)
+	assert tokens.any(it.line == 8 && it.start == 5 && it.type_idx == sem_tok_method)
+}
+
 fn test_semantic_tokens_classify_receivers_parameters_and_reused_variables() {
 	content := 'module main\n\npub fn (app &App) index(mut ctx Context) {\n' +
 		'\tx := 1\n\tdump(x)\n\tapp.run(ctx)\n}\n'

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -380,7 +380,7 @@ fn test_on_did_change_empty_text() {
 		cleanup_test_app(app)
 	}
 
-	// Request with empty text (deletion) should be processed and return diagnostics
+	// Empty text is processed without compiling diagnostics on the edit path.
 	request := Request{
 		params: json2.encode(Params{
 			content_changes: [ContentChange{
@@ -392,16 +392,11 @@ fn test_on_did_change_empty_text() {
 	}
 
 	result := app.on_did_change(request)
-	if notif := result {
-		assert notif.method == 'textDocument/publishDiagnostics'
-		assert notif.params.uri == ''
-		assert notif.params.diagnostics.len == 0
-	} else {
-		assert false, 'expected a notification'
-	}
+	assert result == none
+	assert app.text == ''
 }
 
-fn test_on_did_change_returns_notification() {
+fn test_on_did_change_updates_buffer_without_diagnostics_notification() {
 	mut app := create_test_app()
 	defer {
 		cleanup_test_app(app)
@@ -439,11 +434,8 @@ fn test_on_did_change_returns_notification() {
 
 	result := app.on_did_change(request)
 
-	// Should return a notification
-	if notif := result {
-		assert notif.method == 'textDocument/publishDiagnostics'
-		assert notif.params.uri == uri
-	}
+	assert result == none
+	assert app.open_files[uri] == content
 }
 
 fn test_on_did_change_multiple_changes() {
@@ -3549,6 +3541,24 @@ fn test_operation_at_pos_dot_completion_includes_aliased_import_module_members()
 	assert 'ping' in labels
 }
 
+fn test_local_member_completion_avoids_compiler_for_current_buffer_type() {
+	content := 'module main\n\nstruct App {\n\tname string\n\tshared_values shared []int\n}\n\n' +
+		'fn (app &App) run(port int) bool {\n\tapp.\n\treturn true\n}\n'
+	items := get_local_member_completions(content, 8, 5, .utf16) or {
+		assert false, 'expected local member completions'
+		return
+	}
+	assert items.map(it.label) == ['name', 'shared_values', 'run']
+	assert items[2].kind == 2
+	assert items[2].insert_text or { '' } == 'run(\${1:port})$0'
+}
+
+fn test_local_member_completion_does_not_leak_variable_from_previous_function() {
+	content := 'module main\n\nstruct App {\n\tname string\n}\n\n' +
+		'fn first() {\n\tapp := App{}\n\tprintln(app.name)\n}\n\n' + 'fn second() {\n\tapp.\n}\n'
+	assert get_local_member_completions(content, 12, 5, .utf16) == none
+}
+
 fn test_semantic_tokens_returns_data_for_known_content() {
 	mut app := create_test_app()
 	defer {
@@ -3575,6 +3585,51 @@ fn test_semantic_tokens_returns_data_for_known_content() {
 	tokens := resp.result as SemanticTokens
 	// A V file with keywords/strings should yield at least some tokens.
 	assert tokens.data.len > 0
+}
+
+fn test_semantic_tokens_classify_functions_methods_and_properties() {
+	tokens := tokenize_v_source('fn run() {\n\tapp.start(app.name)\n}\n')
+	assert tokens.any(it.line == 0 && it.start == 3 && it.type_idx == sem_tok_function)
+	assert tokens.any(it.line == 1 && it.start == 1 && it.type_idx == sem_tok_variable)
+	assert tokens.any(it.line == 1 && it.start == 5 && it.type_idx == sem_tok_method)
+	assert tokens.any(it.line == 1 && it.start == 11 && it.type_idx == sem_tok_variable)
+	assert tokens.any(it.line == 1 && it.start == 15 && it.type_idx == sem_tok_property)
+}
+
+fn test_semantic_tokens_classify_receivers_parameters_and_reused_variables() {
+	content := 'module main\n\npub fn (app &App) index(mut ctx Context) {\n' +
+		'\tx := 1\n\tdump(x)\n\tapp.run(ctx)\n}\n'
+	tokens := tokenize_v_source(content)
+	assert tokens.any(it.line == 2 && it.start == 8 && it.type_idx == sem_tok_variable)
+	assert tokens.any(it.line == 2 && it.start == 28 && it.type_idx == sem_tok_variable)
+	assert tokens.any(it.line == 3 && it.start == 1 && it.type_idx == sem_tok_variable)
+	assert tokens.any(it.line == 4 && it.start == 6 && it.type_idx == sem_tok_variable)
+	assert tokens.any(it.line == 5 && it.start == 1 && it.type_idx == sem_tok_variable)
+	assert tokens.any(it.line == 5 && it.start == 9 && it.type_idx == sem_tok_variable)
+}
+
+fn test_semantic_tokens_apply_readonly_modifier_without_coloring_properties() {
+	content := 'fn main() {\n\tpeople := Person{}\n\tpeople.name = "Andre"\n' +
+		'\tmut others := []Person{}\n\tothers << people\n}\n'
+	tokens := tokenize_v_source(content)
+	people_tokens := tokens.filter(it.type_idx == sem_tok_variable
+		&& content.split_into_lines()[it.line][it.start..it.start + it.length] == 'people')
+	assert people_tokens.len == 3
+	assert people_tokens.all(it.mod_bits == sem_mod_readonly)
+	assert tokens.any(it.line == 2 && it.start == 8 && it.type_idx == sem_tok_property
+		&& it.mod_bits == 0)
+	assert tokens.any(it.line == 4 && it.start == 1 && it.type_idx == sem_tok_variable
+		&& it.mod_bits == 0)
+}
+
+fn test_semantic_tokens_keep_readonly_modifier_scoped_to_function() {
+	content := 'fn read(app &App) {\n\tdump(app)\n}\n\nfn main() {\n\tmut app := &App{}\n' +
+		'\tdump(app)\n}\n'
+	tokens := tokenize_v_source(content)
+	assert tokens.any(it.line == 1 && it.start == 6 && it.type_idx == sem_tok_variable
+		&& it.mod_bits == sem_mod_readonly)
+	assert tokens.any(it.line == 6 && it.start == 6 && it.type_idx == sem_tok_variable
+		&& it.mod_bits == 0)
 }
 
 fn test_semantic_tokens_returns_empty_object_for_empty_file() {
@@ -3630,7 +3685,7 @@ fn test_semantic_tokens_range_filters_by_character() {
 		cleanup_test_app(app)
 	}
 	uri := 'file:///tmp/semrange.v'
-	// Line 0 has two string tokens: `"b"` at column 5 and `"c"` at column 11.
+	// Line 0 has a variable token at column 0 and strings at columns 5 and 11.
 	app.open_files[uri] = 'a := "b" + "c"\n'
 
 	full_params := json2.encode(SemanticTokensRangeParams{
@@ -3655,10 +3710,10 @@ fn test_semantic_tokens_range_filters_by_character() {
 		params: full_params
 	})
 	ftok := full.result as SemanticTokens
-	// The full-line request includes the token that starts at column 5.
+	// The full-line request starts with the variable declaration at column 0.
 	assert ftok.data.len >= 5
 	assert ftok.data[0] == 0
-	assert ftok.data[1] == 5
+	assert ftok.data[1] == 0
 
 	// Narrow the range to columns [8,50): the column-5 token must be excluded, so
 	// the first returned token starts at or after column 8 (the `"c"` at 11) and

--- a/index.v
+++ b/index.v
@@ -20,9 +20,10 @@ import time
 struct IndexEntry {
 	fingerprint    int // content.hash(); used to skip re-parsing unchanged files
 	module_name    string
-	doc_symbols    []DocumentSymbol  // hierarchical symbols (as parse_document_symbols returns)
-	docs           map[string]string // simple symbol name -> leading vdoc comment
-	fn_completions []Detail          // free-function completion items for this file
+	doc_symbols    []DocumentSymbol    // hierarchical symbols (as parse_document_symbols returns)
+	docs           map[string]string   // simple symbol name -> leading vdoc comment
+	fn_completions []Detail            // free-function completion items for this file
+	type_methods   map[string][]Detail // receiver type -> method completion items
 }
 
 // build_index_entry parses `content` into an IndexEntry. Symbol ranges are
@@ -48,6 +49,7 @@ fn build_index_entry(content string, enc PositionEncoding) IndexEntry {
 		doc_symbols:    doc_syms
 		docs:           docs
 		fn_completions: parse_module_fn_completions(content)
+		type_methods:   parse_type_method_completions(content)
 	}
 }
 
@@ -824,6 +826,31 @@ fn (app &App) query_module_fn_completions(module_name string, exclude_uri string
 			continue
 		}
 		items << entry.fn_completions
+	}
+	return items
+}
+
+// query_module_type_method_completions returns same-module methods declared in
+// sibling files. The caller merges these with members from the current buffer.
+fn (app &App) query_module_type_method_completions(module_name string, receiver_type string, exclude_uri string, dir string) []Detail {
+	d := dir.replace('\\', '/').trim_right('/')
+	mut items := []Detail{}
+	mut uris := app.symbol_index.keys()
+	uris.sort()
+	for uri in uris {
+		if uri == exclude_uri || uri.ends_with('_test.v') {
+			continue
+		}
+		if d != '' && os.dir(uri_to_path(uri)).replace('\\', '/').trim_right('/') != d {
+			continue
+		}
+		entry := app.symbol_index[uri] or { continue }
+		if module_name != '' && entry.module_name != module_name {
+			continue
+		}
+		if methods := entry.type_methods[receiver_type] {
+			items << methods
+		}
 	}
 	return items
 }

--- a/integration_test.v
+++ b/integration_test.v
@@ -155,8 +155,8 @@ fn test_integration_stdio_initialize_completion_and_hover() {
 
 	assert initialize_response.contains('"completionProvider"')
 	assert initialize_response.contains('"hoverProvider":true')
-	assert completion_response.contains('"label":"join_path"')
-	assert hover_response.contains('join_path')
+	assert completion_response.contains('"label":"join_path"'), 'missing join_path completion: ${completion_response}'
+	assert hover_response.contains('join_path'), 'missing join_path hover: ${hover_response}'
 	assert shutdown_response.contains('"result":null')
 	assert app.is_shutdown
 	assert app.exit_was_requested

--- a/integration_test.v
+++ b/integration_test.v
@@ -24,6 +24,33 @@ fn integration_test_frame_message(payload string) string {
 	return 'Content-Length: ${payload.len}\r\n\r\n${payload}'
 }
 
+fn integration_test_parse_strict_frames(output string) ![]string {
+	mut frames := []string{}
+	mut remaining := output
+	for remaining.len > 0 {
+		header_end := remaining.index('\r\n\r\n') or {
+			return error('missing CRLF header separator')
+		}
+		header := remaining[..header_end]
+		if !header.starts_with('Content-Length:') {
+			return error('missing Content-Length header')
+		}
+		content_length := parse_content_length_header(header.all_after(':'))!
+		body_start := header_end + 4
+		body_end := body_start + content_length
+		if body_end > remaining.len {
+			return error('truncated LSP frame body')
+		}
+		frames << remaining[body_start..body_end]
+		remaining = remaining[body_end..]
+	}
+	return frames
+}
+
+fn integration_test_slurp_fd(fd int, output chan string) {
+	output <- os.fd_slurp(fd).join('')
+}
+
 fn create_integration_test_env() (&App, string) {
 	temp_dir := os.join_path(os.temp_dir(), 'vls_integration_test_${os.getpid()}')
 	integration_test_must_mkdir_all(temp_dir)
@@ -42,6 +69,97 @@ fn create_integration_test_env() (&App, string) {
 fn cleanup_integration_test_env(_ &App, project_dir string) {
 	parent := os.dir(project_dir)
 	os.rmdir_all(parent) or {}
+}
+
+fn test_integration_stdio_initialize_completion_and_hover() {
+	mut app, project_dir := create_integration_test_env()
+	defer {
+		cleanup_integration_test_env(app, project_dir)
+	}
+	test_file := os.join_path(project_dir, 'main.v')
+	content := 'module main\n\nimport os\n\nfn main() {\n\t_ := os.join_path("a", "b")\n}\n'
+	integration_test_must_write_file(test_file, content)
+	uri := path_to_uri(test_file)
+	encoded_uri := json2.encode(uri, escape_unicode: true)
+	encoded_root_uri := json2.encode(path_to_uri(project_dir), escape_unicode: true)
+	encoded_content := json2.encode(content, escape_unicode: true)
+	payloads := [
+		'{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"rootUri":${encoded_root_uri},"capabilities":{}}}',
+		'{"jsonrpc":"2.0","method":"initialized","params":{}}',
+		'{"jsonrpc":"2.0","method":"workspace/didChangeConfiguration","params":{"settings":{"vls":{"diagnostics":false}}}}',
+		'{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{"uri":${encoded_uri},"languageId":"v","version":1,"text":${encoded_content}}}}',
+		'{"jsonrpc":"2.0","id":2,"method":"textDocument/completion","params":{"textDocument":{"uri":${encoded_uri}},"position":{"line":5,"character":9}}}',
+		'{"jsonrpc":"2.0","id":3,"method":"textDocument/hover","params":{"textDocument":{"uri":${encoded_uri}},"position":{"line":5,"character":12}}}',
+		'{"jsonrpc":"2.0","id":4,"method":"shutdown","params":null}',
+		'{"jsonrpc":"2.0","method":"exit","params":null}',
+	]
+	mut input := ''
+	for payload in payloads {
+		input += integration_test_frame_message(payload)
+	}
+
+	mut transport := os.pipe() or {
+		assert false, 'failed to create stdio test pipe: ${err}'
+		return
+	}
+	saved_stdin := os.fd_dup(0)
+	assert saved_stdin >= 0
+	defer {
+		os.fd_dup2(saved_stdin, 0)
+		os.fd_close(saved_stdin)
+		transport.close()
+	}
+	transport.write(input.bytes()) or {
+		assert false, 'failed to write stdio test input: ${err}'
+		return
+	}
+	os.fd_close(transport.write_fd)
+	transport.write_fd = -1
+	assert os.fd_dup2(transport.read_fd, 0) >= 0
+
+	mut capture := os.stdio_capture() or {
+		assert false, 'failed to capture stdio test output: ${err}'
+		return
+	}
+	defer {
+		capture.stop()
+		capture.close()
+	}
+	stdout_output := chan string{cap: 1}
+	spawn integration_test_slurp_fd(capture.stdout.read_fd, stdout_output)
+	mut reader := new_stdin_buffered_reader()
+	app.handle_requests(mut reader)
+	capture.stop()
+	stdout := <-stdout_output
+	capture.close()
+
+	frames := integration_test_parse_strict_frames(stdout) or {
+		assert false, 'failed to parse strict LSP frames: ${err}'
+		return
+	}
+	mut initialize_response := ''
+	mut completion_response := ''
+	mut hover_response := ''
+	mut shutdown_response := ''
+	for frame in frames {
+		if frame.contains('"id":1') {
+			initialize_response = frame
+		} else if frame.contains('"id":2') {
+			completion_response = frame
+		} else if frame.contains('"id":3') {
+			hover_response = frame
+		} else if frame.contains('"id":4') {
+			shutdown_response = frame
+		}
+	}
+
+	assert initialize_response.contains('"completionProvider"')
+	assert initialize_response.contains('"hoverProvider":true')
+	assert completion_response.contains('"label":"join_path"')
+	assert hover_response.contains('join_path')
+	assert shutdown_response.contains('"result":null')
+	assert app.is_shutdown
+	assert app.exit_was_requested
 }
 
 fn test_integration_initialize_capabilities() {

--- a/integration_test.v
+++ b/integration_test.v
@@ -662,7 +662,7 @@ fn test_integration_diagnostics_empty_file() {
 		)
 	})
 
-	// Empty content should be processed and return diagnostics for the empty file
+	// Empty content should update the buffer without compiling on the edit path.
 	result := app.on_did_change(Request{
 		params: json2.encode(Params{
 			text_document:   TextDocumentIdentifier{
@@ -676,12 +676,8 @@ fn test_integration_diagnostics_empty_file() {
 		)
 	})
 
-	if notif := result {
-		assert notif.method == 'textDocument/publishDiagnostics'
-		assert notif.params.uri == uri
-	} else {
-		assert false, 'expected a notification for empty file'
-	}
+	assert result == none
+	assert app.open_files[uri] == ''
 }
 
 fn test_integration_completion_request() {

--- a/lsp.v
+++ b/lsp.v
@@ -757,7 +757,7 @@ struct CodeActionParams {
 struct CodeActionContext {
 	diagnostics  []LSPDiagnostic
 	only         ?[]string
-	trigger_kind ?int      @[json: 'triggerKind']
+	trigger_kind ?int @[json: 'triggerKind']
 }
 
 // DocumentHighlight represents a highlighted occurrence of a symbol in a document.

--- a/lsp_test.v
+++ b/lsp_test.v
@@ -35,6 +35,19 @@ fn test_stdio_reader_processes_frame_before_eof() {
 	assert content == payload
 }
 
+fn test_send_framed_uses_lsp_crlf_separator() {
+	payload := '{"jsonrpc":"2.0","id":1,"result":null}'
+	mut app := &App{
+		capture_output: true
+	}
+
+	app.send_framed(payload)
+
+	assert app.captured_output == [
+		'Content-Length: ${payload.len}\r\n\r\n${payload}',
+	]
+}
+
 fn test_method_from_string_initialize() {
 	assert Method.from_string('initialize') == .initialize
 }

--- a/main.v
+++ b/main.v
@@ -272,25 +272,9 @@ fn (mut app App) write_data(data string) {
 	}
 }
 
-// send_framed prepends a Content-Length header to `content` and writes the
-// message. LSP requires CRLF-delimited headers. A TCP connection is a raw byte
-// stream, so it always gets literal `\r\n\r\n`; only Windows *stdio* uses `\n\n`,
-// relying on text-mode stdout to translate each `\n` into `\r\n` on the wire
-// (P0-11). This prevents Windows TCP from emitting LF-only framing.
+// send_framed prepends the CRLF-delimited Content-Length header required by LSP.
 fn (mut app App) send_framed(content string) {
-	mut is_tcp := false
-	if _ := app.tcp_conn {
-		is_tcp = true
-	}
-	header := if is_tcp {
-		'Content-Length: ${content.len}\r\n\r\n'
-	} else {
-		$if windows {
-			'Content-Length: ${content.len}\n\n'
-		} $else {
-			'Content-Length: ${content.len}\r\n\r\n'
-		}
-	}
+	header := 'Content-Length: ${content.len}\r\n\r\n'
 	full_message := '${header}${content}'
 	log('SEND: ${full_message}')
 	app.write_data(full_message)

--- a/semantic_tokens.v
+++ b/semantic_tokens.v
@@ -91,16 +91,20 @@ fn tokenize_v_source(content string) []SemToken {
 	mut state := TokenizeState{}
 	mut tokens := []SemToken{}
 	lines := content.split_into_lines()
+	mut import_aliases := map[string]bool{}
+	for alias, _ in parse_import_aliases(content) {
+		import_aliases[alias] = true
+	}
 	readonly_variables, line_scopes := collect_readonly_variables(lines)
 	for line_idx, line in lines {
-		tokenize_v_line(line, line_idx, line_scopes[line_idx], readonly_variables, mut state, mut
-			tokens)
+		tokenize_v_line(line, line_idx, line_scopes[line_idx], readonly_variables, import_aliases, mut
+			state, mut tokens)
 	}
 	return tokens
 }
 
 // tokenize_v_line scans one source line and appends recognised tokens to `tokens`.
-fn tokenize_v_line(line string, line_idx int, variable_scope int, readonly_variables map[string]bool, mut state TokenizeState, mut tokens []SemToken) {
+fn tokenize_v_line(line string, line_idx int, variable_scope int, readonly_variables map[string]bool, import_aliases map[string]bool, mut state TokenizeState, mut tokens []SemToken) {
 	n := line.len
 	mut col := 0
 
@@ -257,7 +261,7 @@ fn tokenize_v_line(line string, line_idx int, variable_scope int, readonly_varia
 				}
 			}
 			word := line[start..col]
-			tok_type := classify_v_identifier_at(line, start, col, word)
+			tok_type := classify_v_identifier_at(line, start, col, word, import_aliases)
 			if tok_type >= 0 {
 				tokens << SemToken{
 					line:     line_idx
@@ -402,14 +406,17 @@ fn mark_variable_binding(name string, is_mut bool, variable_scope int, mut reado
 	}
 }
 
-fn classify_v_identifier_at(line string, start int, end int, word string) int {
-	base_type := classify_v_identifier(word)
-	if base_type >= 0 {
-		return base_type
-	}
+fn classify_v_identifier_at(line string, start int, end int, word string, import_aliases map[string]bool) int {
 	prefix := line[..start].trim_space()
 	if prefix == 'module' || prefix == 'import' || prefix.starts_with('import ') {
 		return sem_tok_namespace
+	}
+	if word in import_aliases {
+		return sem_tok_namespace
+	}
+	base_type := classify_v_identifier(word)
+	if base_type >= 0 {
+		return base_type
 	}
 	mut prev := start - 1
 	for prev >= 0 && (line[prev] == ` ` || line[prev] == `\t`) {
@@ -421,6 +428,10 @@ fn classify_v_identifier_at(line string, start int, end int, word string) int {
 	}
 	if next < line.len && line[next] == `(` {
 		if prev >= 0 && line[prev] == `.` {
+			receiver := identifier_before_dot(line, prev)
+			if receiver in import_aliases {
+				return sem_tok_function
+			}
 			return sem_tok_method
 		}
 		if line[..start].contains('fn (') {
@@ -432,6 +443,17 @@ fn classify_v_identifier_at(line string, start int, end int, word string) int {
 		return sem_tok_property
 	}
 	return sem_tok_variable
+}
+
+fn identifier_before_dot(line string, dot int) string {
+	if dot <= 0 || dot > line.len || line[dot] != `.` {
+		return ''
+	}
+	mut start := dot
+	for start > 0 && is_ident_char(line[start - 1]) {
+		start--
+	}
+	return line[start..dot]
 }
 
 // classify_v_identifier returns the semantic token type index for an identifier,

--- a/semantic_tokens.v
+++ b/semantic_tokens.v
@@ -600,9 +600,9 @@ fn (mut app App) handle_semantic_tokens_range(request Request) Response {
 	// (line, start) is kept when its start position is >= the range start and <
 	// the range end in (line, char) order; this excludes tokens before the start
 	// character on the first line and at/after the end character on the last line.
-	range_tokens := raw_tokens.filter((it.line > start_line
-		|| (it.line == start_line && it.start >= start_char)) && (it.line < end_line
-		|| (it.line == end_line && it.start < end_char)))
+	range_tokens := raw_tokens.filter(
+		(it.line > start_line || (it.line == start_line && it.start >= start_char))
+		&& (it.line < end_line || (it.line == end_line && it.start < end_char)))
 	encoded := encode_semantic_tokens(range_tokens)
 	return Response{
 		id:     request.id

--- a/semantic_tokens.v
+++ b/semantic_tokens.v
@@ -434,7 +434,7 @@ fn classify_v_identifier_at(line string, start int, end int, word string, import
 			}
 			return sem_tok_method
 		}
-		if line[..start].contains('fn (') {
+		if is_method_declaration_identifier(line, start) {
 			return sem_tok_method
 		}
 		return sem_tok_function
@@ -443,6 +443,18 @@ fn classify_v_identifier_at(line string, start int, end int, word string, import
 		return sem_tok_property
 	}
 	return sem_tok_variable
+}
+
+fn is_method_declaration_identifier(line string, start int) bool {
+	fn_offset := line.index('fn (') or { return false }
+	receiver_open := fn_offset + 3
+	receiver_close_offset := line[receiver_open + 1..].index(')') or { return false }
+	receiver_close := receiver_open + 1 + receiver_close_offset
+	mut name_start := receiver_close + 1
+	for name_start < line.len && (line[name_start] == ` ` || line[name_start] == `\t`) {
+		name_start++
+	}
+	return start == name_start
 }
 
 fn identifier_before_dot(line string, dot int) string {

--- a/semantic_tokens.v
+++ b/semantic_tokens.v
@@ -12,6 +12,11 @@ const sem_tok_string = 2
 const sem_tok_number = 3
 const sem_tok_type = 4 // structs, enums, interfaces; uppercase-named identifiers
 const sem_tok_function = 5
+const sem_tok_method = 6
+const sem_tok_property = 7
+const sem_tok_variable = 8
+const sem_tok_namespace = 9
+const sem_mod_readonly = 1 << 1
 
 // vfmt off
 const digit_chars = [`0`, `1`, `2`, `3`, `4`, `5`, `6`, `7`, `8`, `9`]!
@@ -44,12 +49,22 @@ const identifier_chars = [
 	`0`, `1`, `2`, `3`, `4`, `5`, `6`, `7`, `8`, `9`,
 	`_`,
 ]!
+
+const v_builtin_types = [
+	'any', 'bool', 'byteptr', 'charptr',
+	'f32', 'f64',
+	'i8', 'i16', 'int', 'i64', 'isize',
+	'rune', 'string',
+	'u8', 'u16', 'u32', 'u64', 'usize',
+	'voidptr'
+]!
 // vfmt on
 
 // semantic_token_types returns the ordered list of token-type names that forms
 // the server's SemanticTokensLegend. Indices must match the sem_tok_* constants.
 fn semantic_token_types() []string {
-	return ['keyword', 'comment', 'string', 'number', 'type', 'function']
+	return ['keyword', 'comment', 'string', 'number', 'type', 'function', 'method', 'property',
+		'variable', 'namespace']
 }
 
 // semantic_token_modifiers returns the ordered list of modifier names.
@@ -76,14 +91,16 @@ fn tokenize_v_source(content string) []SemToken {
 	mut state := TokenizeState{}
 	mut tokens := []SemToken{}
 	lines := content.split_into_lines()
+	readonly_variables, line_scopes := collect_readonly_variables(lines)
 	for line_idx, line in lines {
-		tokenize_v_line(line, line_idx, mut state, mut tokens)
+		tokenize_v_line(line, line_idx, line_scopes[line_idx], readonly_variables, mut state, mut
+			tokens)
 	}
 	return tokens
 }
 
 // tokenize_v_line scans one source line and appends recognised tokens to `tokens`.
-fn tokenize_v_line(line string, line_idx int, mut state TokenizeState, mut tokens []SemToken) {
+fn tokenize_v_line(line string, line_idx int, variable_scope int, readonly_variables map[string]bool, mut state TokenizeState, mut tokens []SemToken) {
 	n := line.len
 	mut col := 0
 
@@ -240,13 +257,20 @@ fn tokenize_v_line(line string, line_idx int, mut state TokenizeState, mut token
 				}
 			}
 			word := line[start..col]
-			tok_type := classify_v_identifier(word)
+			tok_type := classify_v_identifier_at(line, start, col, word)
 			if tok_type >= 0 {
 				tokens << SemToken{
 					line:     line_idx
 					start:    start
 					length:   col - start
 					type_idx: tok_type
+					mod_bits: if tok_type == sem_tok_variable
+						&& (variable_binding_key(variable_scope, word) in readonly_variables
+						|| variable_binding_key(0, word) in readonly_variables) {
+						sem_mod_readonly
+					} else {
+						0
+					}
 				}
 			}
 			continue
@@ -254,6 +278,160 @@ fn tokenize_v_line(line string, line_idx int, mut state TokenizeState, mut token
 
 		col++
 	}
+}
+
+fn collect_readonly_variables(lines []string) (map[string]bool, []int) {
+	mut readonly := map[string]bool{}
+	mut mutable := map[string]bool{}
+	mut line_scopes := []int{cap: lines.len}
+	mut in_const_block := false
+	mut variable_scope := 0
+	mut next_scope := 1
+	mut brace_depth := 0
+	mut function_base_depth := 0
+	mut function_body_started := false
+	for raw_line in lines {
+		line := raw_line.all_before('//').trim_space()
+		stripped := if line.starts_with('pub ') { line[4..] } else { line }
+		if stripped.starts_with('fn ') {
+			variable_scope = next_scope
+			next_scope++
+			function_base_depth = brace_depth
+			function_body_started = false
+		}
+		line_scopes << variable_scope
+		if line == '' {
+			continue
+		}
+		if line == 'const (' {
+			in_const_block = true
+			continue
+		}
+		if in_const_block {
+			if line == ')' {
+				in_const_block = false
+				continue
+			}
+			if eq := line.index('=') {
+				mark_variable_binding(line[..eq].trim_space(), false, variable_scope, mut readonly, mut
+					mutable)
+			}
+			continue
+		}
+		if line.starts_with('const ') {
+			if eq := line.index('=') {
+				mark_variable_binding(line[6..eq].trim_space(), false, variable_scope, mut
+					readonly, mut mutable)
+			}
+		}
+		if assign := line.index(' := ') {
+			lhs := line[..assign].trim_space()
+			is_mut := lhs.starts_with('mut ')
+			names := if is_mut { lhs[4..] } else { lhs }
+			for name in names.split(',') {
+				fields := name.fields()
+				if fields.len > 0 {
+					mark_variable_binding(fields.last(), is_mut, variable_scope, mut readonly, mut
+						mutable)
+				}
+			}
+		}
+		collect_fn_parameter_bindings(line, variable_scope, mut readonly, mut mutable)
+		if variable_scope != 0 {
+			if line.contains('{') {
+				function_body_started = true
+			}
+			brace_depth += line.count('{') - line.count('}')
+			if function_body_started && brace_depth <= function_base_depth {
+				variable_scope = 0
+				function_body_started = false
+			}
+		} else {
+			brace_depth += line.count('{') - line.count('}')
+		}
+	}
+	for key, _ in mutable {
+		readonly.delete(key)
+	}
+	return readonly, line_scopes
+}
+
+fn collect_fn_parameter_bindings(line string, variable_scope int, mut readonly map[string]bool, mut mutable map[string]bool) {
+	stripped := if line.starts_with('pub fn ') {
+		line[7..]
+	} else if line.starts_with('fn ') {
+		line[3..]
+	} else {
+		return
+	}
+	mut search_start := 0
+	for search_start < stripped.len {
+		open_offset := stripped[search_start..].index('(') or { return }
+		open := search_start + open_offset
+		close_offset := stripped[open + 1..].index(')') or { return }
+		close := open + 1 + close_offset
+		for raw_parameter in stripped[open + 1..close].split(',') {
+			parts := raw_parameter.trim_space().fields()
+			if parts.len < 2 {
+				continue
+			}
+			is_mut := parts[0] == 'mut'
+			name_idx := if is_mut { 1 } else { 0 }
+			if name_idx < parts.len - 1 {
+				mark_variable_binding(parts[name_idx], is_mut, variable_scope, mut readonly, mut
+					mutable)
+			}
+		}
+		search_start = close + 1
+	}
+}
+
+fn variable_binding_key(variable_scope int, name string) string {
+	return '${variable_scope}:${name}'
+}
+
+fn mark_variable_binding(name string, is_mut bool, variable_scope int, mut readonly map[string]bool, mut mutable map[string]bool) {
+	if name == '' || name == '_' {
+		return
+	}
+	key := variable_binding_key(variable_scope, name)
+	if is_mut {
+		mutable[key] = true
+	} else {
+		readonly[key] = true
+	}
+}
+
+fn classify_v_identifier_at(line string, start int, end int, word string) int {
+	base_type := classify_v_identifier(word)
+	if base_type >= 0 {
+		return base_type
+	}
+	prefix := line[..start].trim_space()
+	if prefix == 'module' || prefix == 'import' || prefix.starts_with('import ') {
+		return sem_tok_namespace
+	}
+	mut prev := start - 1
+	for prev >= 0 && (line[prev] == ` ` || line[prev] == `\t`) {
+		prev--
+	}
+	mut next := end
+	for next < line.len && (line[next] == ` ` || line[next] == `\t`) {
+		next++
+	}
+	if next < line.len && line[next] == `(` {
+		if prev >= 0 && line[prev] == `.` {
+			return sem_tok_method
+		}
+		if line[..start].contains('fn (') {
+			return sem_tok_method
+		}
+		return sem_tok_function
+	}
+	if prev >= 0 && line[prev] == `.` {
+		return sem_tok_property
+	}
+	return sem_tok_variable
 }
 
 // classify_v_identifier returns the semantic token type index for an identifier,
@@ -264,6 +442,9 @@ fn classify_v_identifier(word string) int {
 	}
 	if word in v_builtins {
 		return sem_tok_function
+	}
+	if word in v_builtin_types {
+		return sem_tok_type
 	}
 	// V naming convention: types start with an uppercase letter.
 	if word != '' && word[0] in up_alpha_chars {


### PR DESCRIPTION
## Summary

Fix Windows stdio communication with VS Code and improve editor responsiveness
and semantic highlighting.

## Problem

The Windows stdio transport emitted LSP headers using `\n\n`. The VS Code LSP
client expects the protocol-defined `\r\n\r\n` separator, causing initialization
to stall and preventing completion, hover, and other language features.

Diagnostics were also being compiled synchronously on every `didChange`, making
completion and inlay hints noticeably slow while typing.

Semantic tokens did not properly distinguish variables, properties, methods,
and readonly bindings.

## Changes

- Always emit LSP `Content-Length` headers with the required CRLF separator.
- Add an exact-byte framing regression test.
- Add a real stdio integration test covering:
  - `initialize`
  - `initialized`
  - `didOpen`
  - completion
  - hover
  - `shutdown`
  - `exit`
- Avoid synchronous diagnostics compilation on every document change.
- Keep diagnostics on document open and save.
- Preserve diagnostic generation and logging in `-d debug` builds.
- Improve local completion responsiveness.
- Improve semantic token classification for variables, properties, methods,
  and readonly bindings.
- Ignore the generated Windows `vls.exe`.

## Compatibility

Linux and macOS already emitted `\r\n\r\n`, so their transport bytes are
unchanged. The framing behavior change only affects Windows stdio.

The stdio integration test is platform-independent and uses strict CRLF parsing.

## Validation

- Windows focused stdio tests: 2/2 passed.
- Windows full suite: 5/6 passed.
- The remaining failure is the existing `interop_test.v:208` Windows path
  normalization issue and is unrelated to this change.
- Linux full suite under WSL: 6/6 passed.
- Verified the emitted header terminates with `0d0a0d0a`.
- Completion after `didChange` improved from approximately 1108 ms to 1 ms in
  the test project.

## macOS

The same platform-independent tests are included for the repository CI matrix.
Local macOS execution was not available.