### PR TITLE
Migrate VLS to the default V3 backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,8 @@ jobs:
         uses: actions/checkout@v5
         with:
           repository: vlang/v
-          # integration_test.v asserts compiler-internal locations from this revision.
-          ref: ad0a6df9f2064659f666c84f60759a5646fd9734
+          # Pin the V3-default compiler revision for reproducible integration coverage.
+          ref: 1a1d7f09d579dcdc8773a29384a10f2e02436591
       - name: Checkout VLS
         uses: actions/checkout@v5
         with:
@@ -41,7 +41,15 @@ jobs:
       - name: Run all tests, including the vlang/v workspace tests
         env:
           VLS_VLANG_V_REPO: ${{ github.workspace }}
+          V_MACOS_V3_NO_FALLBACK: "1"
         run: v test vls/
 
+      - name: Compile project with V3
+        if: runner.os != 'Windows'
+        env:
+          V_MACOS_V3_NO_FALLBACK: "1"
+        run: v -new-compiler vls/
+
       - name: Compile project
+        if: runner.os == 'Windows'
         run: v vls/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,13 +42,13 @@ jobs:
         env:
           VLS_VLANG_V_REPO: ${{ github.workspace }}
           V_MACOS_V3_NO_FALLBACK: "1"
-        run: v test vls/
+        run: v -no-memory-limit test vls/
 
       - name: Compile project with V3
         if: runner.os != 'Windows'
         env:
           V_MACOS_V3_NO_FALLBACK: "1"
-        run: v -new-compiler vls/
+        run: v -no-memory-limit -new-compiler vls/
 
       - name: Compile project
         if: runner.os == 'Windows'

--- a/call_hierarchy.v
+++ b/call_hierarchy.v
@@ -163,7 +163,8 @@ fn (mut app App) handle_call_hierarchy_outgoing(request Request) Response {
 		if called_name == self_name {
 			continue // skip direct recursion
 		}
-		callee := app.find_fn_declaration(called_name, search_dirs, request.id, uri.ends_with('_test.v'))
+		callee := app.find_fn_declaration(called_name, search_dirs, request.id,
+			uri.ends_with('_test.v'))
 		if callee.name == '' {
 			continue
 		}

--- a/handlers.v
+++ b/handlers.v
@@ -2079,7 +2079,7 @@ fn (app &App) active_indexed_source_file_names(dir string, active_test_file_name
 // in `dir`. Methods and fields are intentionally excluded because resolving
 // them safely requires receiver type information.
 fn (mut app App) find_indexed_source_definition(dir string, symbol string, active_test_file_name string, require_public bool, expected_module string) ?Location {
-	if dir == '' || dir == '/' || !os.is_dir(dir) {
+	if dir == '' || dir == '/' || !os.is_dir(dir) || expected_module == '' {
 		return none
 	}
 	app.ensure_dir_shallow_indexed(dir)
@@ -2104,7 +2104,7 @@ fn (mut app App) find_indexed_source_definition(dir string, symbol string, activ
 			continue
 		}
 		entry := app.symbol_index[uri] or { continue }
-		if expected_module != '' && entry.module_name != expected_module {
+		if entry.module_name != expected_module {
 			continue
 		}
 		source := app.index_source_for(uri) or { continue }

--- a/handlers.v
+++ b/handlers.v
@@ -1712,6 +1712,65 @@ fn source_occurrence_is_method_declaration(line string, start_byte int) bool {
 	return receiver.starts_with('(') && receiver.ends_with(')')
 }
 
+fn source_occurrence_is_interface_method_signature(lines []string, target_line int, start_byte int, end_byte int) bool {
+	if target_line < 0 || target_line >= lines.len || start_byte < 0 || end_byte <= start_byte
+		|| end_byte > lines[target_line].len {
+		return false
+	}
+	line := lines[target_line]
+	mut suffix_byte := end_byte
+	for suffix_byte < line.len && (line[suffix_byte] == ` ` || line[suffix_byte] == `\t`) {
+		suffix_byte++
+	}
+	if suffix_byte >= line.len || line[suffix_byte] != `(` {
+		return false
+	}
+	mut brace_depth := 0
+	mut interface_depth := 0
+	mut pending_interface := false
+	mut scan_state := ImportScanState{}
+	for line_idx, raw_line in lines {
+		if line_idx > target_line {
+			break
+		}
+		if line_idx == target_line {
+			if interface_depth > 0 {
+				return true
+			}
+			mut prefix := raw_line[..start_byte].trim_space()
+			if prefix.starts_with('pub ') {
+				prefix = prefix[4..].trim_space()
+			}
+			return (pending_interface || prefix.starts_with('interface ')) && prefix.contains('{')
+		}
+		code := source_line_import_code(raw_line, mut scan_state)
+		if interface_depth == 0 && !pending_interface {
+			mut declaration := code.trim_space()
+			if declaration.starts_with('pub ') {
+				declaration = declaration[4..].trim_space()
+			}
+			pending_interface = declaration.starts_with('interface ')
+		}
+		for c in code {
+			if c == `{` {
+				brace_depth++
+				if pending_interface {
+					interface_depth = brace_depth
+					pending_interface = false
+				}
+			} else if c == `}` {
+				if interface_depth == brace_depth {
+					interface_depth = 0
+				}
+				if brace_depth > 0 {
+					brace_depth--
+				}
+			}
+		}
+	}
+	return false
+}
+
 fn source_occurrence_is_attribute(lines []string, target_line int, start_byte int) bool {
 	if target_line < 0 || target_line >= lines.len || start_byte < 0
 		|| start_byte > lines[target_line].len {
@@ -2066,6 +2125,9 @@ fn (mut app App) resolve_indexed_definition(uri string, position Position) ?Loca
 		return none
 	}
 	if source_occurrence_is_method_declaration(line, start_byte) {
+		return none
+	}
+	if source_occurrence_is_interface_method_signature(lines, position.line, start_byte, end_byte) {
 		return none
 	}
 	if source_occurrence_has_dot_suffix(line, end_byte) && symbol in parse_import_aliases(content) {

--- a/handlers.v
+++ b/handlers.v
@@ -1381,6 +1381,40 @@ fn source_declaration_is_public(uri string, sym DocumentSymbol, app &App) bool {
 	return lines[sym.range.start.line].trim_space().starts_with('pub ')
 }
 
+// source_occurrences_have_potential_local_binding conservatively recognizes
+// local declarations that can shadow a top-level or imported symbol. False
+// positives only defer to compiler-backed lookup; false negatives could return
+// the wrong indexed declaration, so type-suffixed names are treated as possible
+// parameters even when a function signature spans multiple lines.
+fn source_occurrences_have_potential_local_binding(lines []string, occurrences []TokenOccurrence, enc PositionEncoding) bool {
+	for occurrence in occurrences {
+		if occurrence.line < 0 || occurrence.line >= lines.len {
+			continue
+		}
+		line := lines[occurrence.line]
+		start_byte := encoded_col_to_byte(line, occurrence.start_char, enc)
+		end_byte := encoded_col_to_byte(line, occurrence.end_char, enc)
+		if start_byte < 0 || end_byte <= start_byte || end_byte > line.len {
+			continue
+		}
+		if is_for_binding_highlight(line, start_byte, end_byte) {
+			return true
+		}
+		mut suffix_byte := end_byte
+		for suffix_byte < line.len && (line[suffix_byte] == ` ` || line[suffix_byte] == `\t`) {
+			suffix_byte++
+		}
+		if suffix_byte < line.len && line[suffix_byte..].starts_with(':=') {
+			return true
+		}
+		if suffix_byte > end_byte && suffix_byte < line.len
+			&& (is_ident_char(line[suffix_byte]) || line[suffix_byte] in [`[`, `?`, `&`, `.`]) {
+			return true
+		}
+	}
+	return false
+}
+
 // find_indexed_source_definition finds one unambiguous top-level declaration
 // in `dir`. Methods and fields are intentionally excluded because resolving
 // them safely requires receiver type information.
@@ -1456,9 +1490,18 @@ fn (mut app App) resolve_indexed_definition(uri string, position Position) ?Loca
 	if start_byte > 0 && line[start_byte - 1] == `.` {
 		dot_col := byte_to_encoded_col(line, start_byte - 1, app.position_encoding)
 		alias := get_word_before_dot(line, dot_col, app.position_encoding)
+		alias_occurrences := app.occurrences_for(uri)[alias] or { return none }
+		if source_occurrences_have_potential_local_binding(lines, alias_occurrences,
+			app.position_encoding)
+		{
+			return none
+		}
 		module_path := parse_import_aliases(content)[alias] or { return none }
 		module_dir := app.resolve_indexed_import_module_dir(module_path, os.dir(uri_to_path(uri)))
 		return app.find_indexed_source_definition(module_dir, symbol, false, true)
+	}
+	if source_occurrences_have_potential_local_binding(lines, occurrences, app.position_encoding) {
+		return none
 	}
 	return app.find_indexed_source_definition(os.dir(uri_to_path(uri)), symbol,
 		uri.ends_with('_test.v'), false)

--- a/handlers.v
+++ b/handlers.v
@@ -2261,8 +2261,10 @@ fn (mut app App) resolve_indexed_definition(uri string, position Position) ?Loca
 	if source_occurrence_is_sql_expression(lines, position.line, start_byte) {
 		return none
 	}
-	if source_occurrence_has_dot_suffix(line, end_byte) && symbol in parse_import_aliases(content) {
-		return none
+	if source_occurrence_has_dot_suffix(line, end_byte) {
+		if symbol == 'C' || symbol == 'JS' || symbol in parse_import_aliases(content) {
+			return none
+		}
 	}
 	if_occurrences := file_occurrences['if'] or { []TokenOccurrence{} }
 	if source_occurrence_has_colon_suffix(line, end_byte)

--- a/handlers.v
+++ b/handlers.v
@@ -1493,44 +1493,14 @@ fn source_declaration_is_compile_time_conditional(content string, declaration_li
 	mut brace_depth := 0
 	mut conditional_depths := []int{}
 	mut pending_conditional := false
-	mut in_block_comment := false
-	mut quote := u8(0)
-	for line_idx, line in lines {
+	mut scan_state := ImportScanState{}
+	for line_idx, raw_line in lines {
 		if line_idx == declaration_line {
 			return conditional_depths.len > 0
 		}
+		line := source_line_import_code(raw_line, mut scan_state)
 		mut col := 0
 		for col < line.len {
-			if in_block_comment {
-				comment_end := line[col..].index('*/') or { break }
-				col += comment_end + 2
-				in_block_comment = false
-				continue
-			}
-			if quote != 0 {
-				if line[col] == `\\` && col + 1 < line.len {
-					col += 2
-					continue
-				}
-				if line[col] == quote {
-					quote = 0
-				}
-				col++
-				continue
-			}
-			if col + 1 < line.len && line[col] == `/` && line[col + 1] == `/` {
-				break
-			}
-			if col + 1 < line.len && line[col] == `/` && line[col + 1] == `*` {
-				in_block_comment = true
-				col += 2
-				continue
-			}
-			if line[col] == `'` || line[col] == `"` || line[col] == 96 {
-				quote = line[col]
-				col++
-				continue
-			}
 			if line[col] == `$` {
 				directive_len := if line[col..].starts_with('$if') {
 					3

--- a/handlers.v
+++ b/handlers.v
@@ -1716,6 +1716,62 @@ fn source_occurrence_has_at_prefix(line string, start_byte int) bool {
 	return start_byte > 0 && start_byte <= line.len && line[start_byte - 1] == `@`
 }
 
+fn source_occurrence_is_sql_expression(lines []string, target_line int, start_byte int) bool {
+	if target_line < 0 || target_line >= lines.len || start_byte < 0
+		|| start_byte > lines[target_line].len {
+		return false
+	}
+	mut brace_depth := 0
+	mut sql_depths := []int{}
+	mut sql_prefix_tokens := 0
+	mut scan_state := ImportScanState{}
+	for line_idx, raw_line in lines {
+		if line_idx > target_line {
+			break
+		}
+		fragment := if line_idx == target_line { raw_line[..start_byte] } else { raw_line }
+		line := source_line_import_code(fragment, mut scan_state)
+		mut col := 0
+		for col < line.len {
+			if is_ident_char(line[col]) {
+				identifier_start := col
+				col++
+				for col < line.len && is_ident_char(line[col]) {
+					col++
+				}
+				identifier := line[identifier_start..col]
+				if identifier == 'sql' {
+					sql_prefix_tokens = 1
+				} else if sql_prefix_tokens == 1 {
+					sql_prefix_tokens = 2
+				} else if sql_prefix_tokens == 2 {
+					sql_prefix_tokens = 0
+				}
+				continue
+			}
+			if line[col] == `{` {
+				brace_depth++
+				if sql_prefix_tokens == 2 {
+					sql_depths << brace_depth
+				}
+				sql_prefix_tokens = 0
+			} else if line[col] == `}` {
+				if sql_depths.len > 0 && sql_depths.last() == brace_depth {
+					sql_depths.delete_last()
+				}
+				if brace_depth > 0 {
+					brace_depth--
+				}
+				sql_prefix_tokens = 0
+			} else if line[col] != ` ` && line[col] != `\t` && line[col] != `\r` {
+				sql_prefix_tokens = 0
+			}
+			col++
+		}
+	}
+	return sql_depths.len > 0
+}
+
 fn source_occurrence_is_interface_method_signature(lines []string, target_line int, start_byte int, end_byte int) bool {
 	if target_line < 0 || target_line >= lines.len || start_byte < 0 || end_byte <= start_byte
 		|| end_byte > lines[target_line].len {
@@ -2137,6 +2193,9 @@ fn (mut app App) resolve_indexed_definition(uri string, position Position) ?Loca
 	if source_occurrence_has_at_prefix(line, start_byte) {
 		return none
 	}
+	if source_occurrence_is_sql_expression(lines, position.line, start_byte) {
+		return none
+	}
 	if source_occurrence_has_dot_suffix(line, end_byte) && symbol in parse_import_aliases(content) {
 		return none
 	}
@@ -2221,8 +2280,9 @@ fn extract_doc_comment(lines []string, decl_line int) string {
 // get_module_name extracts the module name declared in V source content.
 // Returns '' if no module declaration is found.
 fn get_module_name(content string) string {
-	for line in content.split_into_lines() {
-		trimmed := line.trim_space()
+	mut scan_state := ImportScanState{}
+	for raw_line in content.split_into_lines() {
+		trimmed := source_line_import_code(raw_line, mut scan_state).trim_space()
 		if trimmed.starts_with('module ') {
 			name := trimmed[7..].trim_space()
 			if name != '' {

--- a/handlers.v
+++ b/handlers.v
@@ -1484,7 +1484,7 @@ fn (app &App) active_indexed_source_file_names(dir string, include_tests bool) m
 // find_indexed_source_definition finds one unambiguous top-level declaration
 // in `dir`. Methods and fields are intentionally excluded because resolving
 // them safely requires receiver type information.
-fn (mut app App) find_indexed_source_definition(dir string, symbol string, include_tests bool, require_public bool) ?Location {
+fn (mut app App) find_indexed_source_definition(dir string, symbol string, include_tests bool, require_public bool, expected_module string) ?Location {
 	if dir == '' || dir == '/' || !os.is_dir(dir) {
 		return none
 	}
@@ -1513,6 +1513,9 @@ fn (mut app App) find_indexed_source_definition(dir string, symbol string, inclu
 			continue
 		}
 		entry := app.symbol_index[uri] or { continue }
+		if expected_module != '' && entry.module_name != expected_module {
+			continue
+		}
 		for sym in entry.doc_symbols {
 			if !source_definition_kind_is_supported(sym.kind)
 				|| extract_simple_fn_name(sym.name) != symbol {
@@ -1569,13 +1572,14 @@ fn (mut app App) resolve_indexed_definition(uri string, position Position) ?Loca
 		}
 		module_path := parse_import_aliases(content)[alias] or { return none }
 		module_dir := app.resolve_indexed_import_module_dir(module_path, os.dir(uri_to_path(uri)))
-		return app.find_indexed_source_definition(module_dir, symbol, false, true)
+		return app.find_indexed_source_definition(module_dir, symbol, false, true,
+			module_path.all_after_last('.'))
 	}
 	if source_occurrences_have_potential_local_binding(lines, occurrences, app.position_encoding) {
 		return none
 	}
 	return app.find_indexed_source_definition(os.dir(uri_to_path(uri)), symbol,
-		uri.ends_with('_test.v'), false)
+		uri.ends_with('_test.v'), false, get_module_name(content))
 }
 
 // find_declaration_line searches `lines` for a top-level declaration whose name

--- a/handlers.v
+++ b/handlers.v
@@ -1690,8 +1690,8 @@ fn source_occurrence_is_method_declaration(line string, start_byte int) bool {
 	return receiver.starts_with('(') && receiver.ends_with(')')
 }
 
-fn source_occurrence_has_at_prefix(line string, start_byte int) bool {
-	return start_byte > 0 && start_byte <= line.len && line[start_byte - 1] == `@`
+fn source_occurrence_has_compile_time_prefix(line string, start_byte int) bool {
+	return start_byte > 0 && start_byte <= line.len && line[start_byte - 1] in [`@`, `$`]
 }
 
 fn source_occurrence_is_sql_expression(lines []string, target_line int, start_byte int) bool {
@@ -2168,7 +2168,7 @@ fn (mut app App) resolve_indexed_definition(uri string, position Position) ?Loca
 	if source_occurrence_is_interface_method_signature(lines, position.line, start_byte, end_byte) {
 		return none
 	}
-	if source_occurrence_has_at_prefix(line, start_byte) {
+	if source_occurrence_has_compile_time_prefix(line, start_byte) {
 		return none
 	}
 	if source_occurrence_is_sql_expression(lines, position.line, start_byte) {

--- a/handlers.v
+++ b/handlers.v
@@ -229,9 +229,9 @@ fn get_word_before_dot(line string, dot_col int, enc PositionEncoding) string {
 	return line[start..dot_byte]
 }
 
-// parse_import_aliases returns alias -> module path for simple V import statements.
+// parse_import_aliases returns alias -> module path for V import statements.
 // Examples: `import os` => os -> os, `import net.http` => http -> net.http,
-// `import net.http as nh` => nh -> net.http.
+// `import net.http as nh` => nh -> net.http. Grouped imports are supported too.
 fn parse_import_aliases(content string) map[string]string {
 	mut aliases := map[string]string{}
 	for binding in parse_import_bindings(content) {
@@ -295,45 +295,60 @@ fn source_line_import_code(line string, mut state ImportScanState) string {
 	return code.bytestr()
 }
 
+fn parse_import_binding(text string) ?ImportedModuleBinding {
+	parts := text.fields()
+	if parts.len == 0 {
+		return none
+	}
+	module_path := parts[0]
+	if module_path == '' {
+		return none
+	}
+	mut alias := ''
+	if parts.len >= 3 && parts[1] == 'as' {
+		alias = parts[2]
+	} else {
+		module_parts := module_path.split('.')
+		if module_parts.len > 0 {
+			alias = module_parts.last()
+		}
+	}
+	if alias == '' {
+		return none
+	}
+	return ImportedModuleBinding{
+		alias:       alias
+		module_path: module_path
+	}
+}
+
 fn parse_import_bindings(content string) []ImportedModuleBinding {
 	mut bindings := []ImportedModuleBinding{}
 	mut scan_state := ImportScanState{}
+	mut in_import_block := false
 	for raw_line in content.split_into_lines() {
 		line := source_line_import_code(raw_line, mut scan_state)
 		trimmed := line.trim_space()
+		if in_import_block {
+			if trimmed.starts_with(')') {
+				in_import_block = false
+				continue
+			}
+			if binding := parse_import_binding(trimmed) {
+				bindings << binding
+			}
+			continue
+		}
 		if !trimmed.starts_with('import ') {
 			continue
 		}
 		rest := trimmed[7..].trim_space()
-		if rest == '' {
+		if rest == '(' {
+			in_import_block = true
 			continue
 		}
-		if rest.contains(' as ') {
-			parts := rest.split(' as ')
-			if parts.len < 2 {
-				continue
-			}
-			module_path := parts[0].trim_space()
-			alias := parts[1].trim_space()
-			if module_path != '' && alias != '' {
-				bindings << ImportedModuleBinding{
-					alias:       alias
-					module_path: module_path
-				}
-			}
-			continue
-		}
-		module_path := rest.split(' ')[0].trim_space()
-		if module_path == '' {
-			continue
-		}
-		parts := module_path.split('.')
-		alias := if parts.len > 0 { parts.last() } else { '' }
-		if alias != '' {
-			bindings << ImportedModuleBinding{
-				alias:       alias
-				module_path: module_path
-			}
+		if binding := parse_import_binding(rest) {
+			bindings << binding
 		}
 	}
 	return bindings

--- a/handlers.v
+++ b/handlers.v
@@ -70,6 +70,19 @@ fn (mut app App) operation_at_pos(method Method, request Request) Response {
 		}
 	}
 
+	// Resolve declarations from VLS's authoritative source index before using
+	// the established compiler's V1-only `-line-info` compatibility mode. Free
+	// functions and top-level declarations do not require receiver type
+	// inference, so this path is both deterministic and aware of unsaved files.
+	if method in [.definition, .declaration, .type_definition, .implementation] {
+		if location := app.resolve_indexed_definition(path, params.position) {
+			return Response{
+				id:     request.id
+				result: location
+			}
+		}
+	}
+
 	line_info := match method {
 		.completion {
 			'${line_nr}:${byte_col}'
@@ -308,6 +321,33 @@ fn resolve_import_module_dir(module_path string, work_dir string) string {
 	return ''
 }
 
+// resolve_indexed_import_module_dir prefers modules in the active project and
+// workspace over the V installation used to launch VLS. This matters when the
+// workspace is a V checkout: `v.builder` belongs to that checkout's `vlib`, not
+// necessarily to the toolchain on PATH.
+fn (app &App) resolve_indexed_import_module_dir(module_path string, work_dir string) string {
+	rel := module_path.replace('.', os.path_separator)
+	mut roots := []string{}
+	project_root := find_project_root(work_dir)
+	if project_root != '' {
+		roots << project_root
+	}
+	for workspace_root in app.workspace_roots {
+		if workspace_root != ''
+			&& !roots.any(normalized_index_path(it) == normalized_index_path(workspace_root)) {
+			roots << workspace_root
+		}
+	}
+	for root in roots {
+		for candidate in [os.join_path(root, rel), os.join_path(root, 'vlib', rel)] {
+			if os.is_dir(candidate) {
+				return candidate
+			}
+		}
+	}
+	return resolve_import_module_dir(module_path, work_dir)
+}
+
 fn parse_public_module_member_completions(content string) []Detail {
 	mut items := []Detail{}
 	mut in_pub_const_block := false
@@ -436,7 +476,7 @@ fn (mut app App) build_diagnostics_notification(uri string, content string) Noti
 			params: PublishDiagnosticsParams{
 				uri:         uri
 				version:     if uri in app.open_files_versions {
-					?int(app.open_files_versions[uri])
+					?i64(app.open_files_versions[uri])
 				} else {
 					none
 				}
@@ -465,7 +505,7 @@ fn (mut app App) build_diagnostics_notification(uri string, content string) Noti
 	pd_params := PublishDiagnosticsParams{
 		uri:         uri
 		version:     if uri in app.open_files_versions {
-			?int(app.open_files_versions[uri])
+			?i64(app.open_files_versions[uri])
 		} else {
 			none
 		}
@@ -1062,10 +1102,9 @@ fn (mut app App) handle_rename(request Request) Response {
 	}
 	// Build documentChanges list from the same data.
 	for uri, edits in changes {
-		version := if uri in app.open_files_versions {
-			?int(app.open_files_versions[uri])
-		} else {
-			none
+		mut version := ?i64(none)
+		if uri in app.open_files_versions {
+			version = i64(app.open_files_versions[uri])
 		}
 		doc_changes << TextDocumentEdit{
 			text_document: VersionedTextDocumentIdentifier{
@@ -1326,6 +1365,97 @@ fn get_word_at_col(line string, col int, enc PositionEncoding) string {
 		return ''
 	}
 	return line[start..end]
+}
+
+fn source_definition_kind_is_supported(kind int) bool {
+	return kind in [sym_kind_function, sym_kind_struct, sym_kind_enum, sym_kind_interface,
+		sym_kind_constant, sym_kind_class]
+}
+
+fn source_declaration_is_public(uri string, sym DocumentSymbol, app &App) bool {
+	content := app.index_source_for(uri) or { return false }
+	lines := content.split_into_lines()
+	if sym.range.start.line < 0 || sym.range.start.line >= lines.len {
+		return false
+	}
+	return lines[sym.range.start.line].trim_space().starts_with('pub ')
+}
+
+// find_indexed_source_definition finds one unambiguous top-level declaration
+// in `dir`. Methods and fields are intentionally excluded because resolving
+// them safely requires receiver type information.
+fn (mut app App) find_indexed_source_definition(dir string, symbol string, include_tests bool, require_public bool) ?Location {
+	if dir == '' || dir == '/' || !os.is_dir(dir) {
+		return none
+	}
+	app.ensure_dir_shallow_indexed(dir)
+	normalized_dir := normalized_index_path(dir)
+	// The shallow disk walk deliberately skips open buffers. Refresh those
+	// entries explicitly so direct callers and unsaved files remain authoritative.
+	for open_uri, _ in app.open_files {
+		if normalized_index_path(os.dir(uri_to_path(open_uri))) == normalized_dir {
+			app.reindex_uri(open_uri)
+		}
+	}
+	mut matches := []Location{}
+	mut uris := app.symbol_index.keys()
+	uris.sort()
+	for uri in uris {
+		if !include_tests && uri.ends_with('_test.v') {
+			continue
+		}
+		if normalized_index_path(os.dir(uri_to_path(uri))) != normalized_dir {
+			continue
+		}
+		entry := app.symbol_index[uri] or { continue }
+		for sym in entry.doc_symbols {
+			if !source_definition_kind_is_supported(sym.kind)
+				|| extract_simple_fn_name(sym.name) != symbol {
+				continue
+			}
+			if require_public && !source_declaration_is_public(uri, sym, app) {
+				continue
+			}
+			matches << Location{
+				uri:   uri
+				range: sym.selection_range
+			}
+		}
+	}
+	if matches.len != 1 {
+		return none
+	}
+	return matches[0]
+}
+
+// resolve_indexed_definition handles declaration lookup that does not need
+// receiver type inference. Qualified names are constrained to their imported
+// module, while bare names are constrained to the current V module directory.
+fn (mut app App) resolve_indexed_definition(uri string, position Position) ?Location {
+	content := app.index_source_for(uri) or { return none }
+	lines := content.split_into_lines()
+	if position.line < 0 || position.line >= lines.len || position.char < 0 {
+		return none
+	}
+	line := lines[position.line]
+	start, end := find_word_bounds_at_col(line, position.char, app.position_encoding)
+	if start < 0 || end <= start {
+		return none
+	}
+	symbol := substr_by_char_bounds(line, start, end, app.position_encoding)
+	if symbol == '' {
+		return none
+	}
+	start_byte := encoded_col_to_byte(line, start, app.position_encoding)
+	if start_byte > 0 && line[start_byte - 1] == `.` {
+		dot_col := byte_to_encoded_col(line, start_byte - 1, app.position_encoding)
+		alias := get_word_before_dot(line, dot_col, app.position_encoding)
+		module_path := parse_import_aliases(content)[alias] or { return none }
+		module_dir := app.resolve_indexed_import_module_dir(module_path, os.dir(uri_to_path(uri)))
+		return app.find_indexed_source_definition(module_dir, symbol, false, true)
+	}
+	return app.find_indexed_source_definition(os.dir(uri_to_path(uri)), symbol,
+		uri.ends_with('_test.v'), false)
 }
 
 // find_declaration_line searches `lines` for a top-level declaration whose name

--- a/handlers.v
+++ b/handlers.v
@@ -1562,6 +1562,17 @@ fn source_occurrence_has_colon_suffix(line string, end_byte int) bool {
 	return suffix_byte < line.len && line[suffix_byte] == `:`
 }
 
+fn source_occurrence_has_dot_suffix(line string, end_byte int) bool {
+	if end_byte < 0 || end_byte > line.len {
+		return false
+	}
+	mut suffix_byte := end_byte
+	for suffix_byte < line.len && (line[suffix_byte] == ` ` || line[suffix_byte] == `\t`) {
+		suffix_byte++
+	}
+	return suffix_byte < line.len && line[suffix_byte] == `.`
+}
+
 fn source_occurrence_is_goto_target(line string, start_byte int) bool {
 	if start_byte < 0 || start_byte > line.len {
 		return false
@@ -1974,6 +1985,9 @@ fn (mut app App) resolve_indexed_definition(uri string, position Position) ?Loca
 		return none
 	}
 	if source_occurrence_is_enum_member_declaration(content, symbol, position.line) {
+		return none
+	}
+	if source_occurrence_has_dot_suffix(line, end_byte) && symbol in parse_import_aliases(content) {
 		return none
 	}
 	if_occurrences := file_occurrences['if'] or { []TokenOccurrence{} }

--- a/handlers.v
+++ b/handlers.v
@@ -1751,6 +1751,68 @@ fn source_occurrence_has_compile_time_prefix(line string, start_byte int) bool {
 	return start_byte > 0 && start_byte <= line.len && line[start_byte - 1] in [`@`, `$`]
 }
 
+fn source_line_is_hash_directive(lines []string, target_line int) bool {
+	if target_line < 0 || target_line >= lines.len {
+		return false
+	}
+	mut scan_state := ImportScanState{}
+	for line_idx in 0 .. target_line + 1 {
+		line := source_line_import_code(lines[line_idx], mut scan_state)
+		if line_idx == target_line {
+			return line.trim_space().starts_with('#')
+		}
+	}
+	return false
+}
+
+fn source_occurrence_is_asm_block(lines []string, target_line int, end_byte int) bool {
+	if target_line < 0 || target_line >= lines.len || end_byte < 0
+		|| end_byte > lines[target_line].len {
+		return false
+	}
+	mut brace_depth := 0
+	mut asm_depths := []int{}
+	mut pending_asm := false
+	mut scan_state := ImportScanState{}
+	for line_idx, raw_line in lines {
+		if line_idx > target_line {
+			break
+		}
+		fragment := if line_idx == target_line { raw_line[..end_byte] } else { raw_line }
+		line := source_line_import_code(fragment, mut scan_state)
+		mut col := 0
+		for col < line.len {
+			if is_ident_char(line[col]) {
+				identifier_start := col
+				col++
+				for col < line.len && is_ident_char(line[col]) {
+					col++
+				}
+				if line[identifier_start..col] == 'asm' {
+					pending_asm = true
+				}
+				continue
+			}
+			if line[col] == `{` {
+				brace_depth++
+				if pending_asm {
+					asm_depths << brace_depth
+					pending_asm = false
+				}
+			} else if line[col] == `}` {
+				if asm_depths.len > 0 && asm_depths.last() == brace_depth {
+					asm_depths.delete_last()
+				}
+				if brace_depth > 0 {
+					brace_depth--
+				}
+			}
+			col++
+		}
+	}
+	return pending_asm || asm_depths.len > 0
+}
+
 fn source_occurrence_is_sql_expression(lines []string, target_line int, start_byte int) bool {
 	if target_line < 0 || target_line >= lines.len || start_byte < 0
 		|| start_byte > lines[target_line].len {
@@ -2263,7 +2325,9 @@ fn (mut app App) resolve_indexed_definition(uri string, position Position) ?Loca
 	if source_occurrence_has_compile_time_prefix(line, start_byte) {
 		return none
 	}
-	if source_occurrence_is_sql_expression(lines, position.line, start_byte) {
+	if source_line_is_hash_directive(lines, position.line)
+		|| source_occurrence_is_asm_block(lines, position.line, end_byte)
+		|| source_occurrence_is_sql_expression(lines, position.line, start_byte) {
 		return none
 	}
 	if source_occurrence_has_dot_suffix(line, end_byte) {

--- a/handlers.v
+++ b/handlers.v
@@ -1666,11 +1666,12 @@ fn source_occurrence_is_compile_time_condition(line string, line_idx int, start_
 
 fn source_line_is_module_or_import_declaration(lines []string, target_line int) bool {
 	mut in_import_block := false
+	mut scan_state := ImportScanState{}
 	for line_idx, raw_line in lines {
 		if line_idx > target_line {
 			break
 		}
-		line := raw_line.trim_space()
+		line := source_line_import_code(raw_line, mut scan_state).trim_space()
 		if in_import_block {
 			if line_idx == target_line {
 				return true
@@ -1694,6 +1695,21 @@ fn source_line_is_module_or_import_declaration(lines []string, target_line int) 
 		}
 	}
 	return false
+}
+
+fn source_occurrence_is_method_declaration(line string, start_byte int) bool {
+	if start_byte < 0 || start_byte > line.len {
+		return false
+	}
+	mut prefix := line[..start_byte].trim_space()
+	if prefix.starts_with('pub ') {
+		prefix = prefix[4..].trim_space()
+	}
+	if !prefix.starts_with('fn ') {
+		return false
+	}
+	receiver := prefix[3..].trim_space()
+	return receiver.starts_with('(') && receiver.ends_with(')')
 }
 
 fn source_occurrence_is_attribute(lines []string, target_line int, start_byte int) bool {
@@ -2047,6 +2063,9 @@ fn (mut app App) resolve_indexed_definition(uri string, position Position) ?Loca
 		return none
 	}
 	if source_occurrence_is_enum_member_declaration(content, symbol, position.line) {
+		return none
+	}
+	if source_occurrence_is_method_declaration(line, start_byte) {
 		return none
 	}
 	if source_occurrence_has_dot_suffix(line, end_byte) && symbol in parse_import_aliases(content) {

--- a/handlers.v
+++ b/handlers.v
@@ -1496,7 +1496,7 @@ fn source_occurrence_precedes_local_declaration(line string, end_byte int) bool 
 	return true
 }
 
-fn source_occurrence_is_field_label(line string, end_byte int) bool {
+fn source_occurrence_has_colon_suffix(line string, end_byte int) bool {
 	if end_byte < 0 || end_byte > line.len {
 		return false
 	}
@@ -1505,6 +1505,21 @@ fn source_occurrence_is_field_label(line string, end_byte int) bool {
 		suffix_byte++
 	}
 	return suffix_byte < line.len && line[suffix_byte] == `:`
+}
+
+fn source_occurrence_is_goto_target(line string, start_byte int) bool {
+	if start_byte < 0 || start_byte > line.len {
+		return false
+	}
+	mut keyword_end := start_byte
+	for keyword_end > 0 && (line[keyword_end - 1] == ` ` || line[keyword_end - 1] == `\t`) {
+		keyword_end--
+	}
+	mut keyword_start := keyword_end
+	for keyword_start > 0 && is_ident_char(line[keyword_start - 1]) {
+		keyword_start--
+	}
+	return line[keyword_start..keyword_end] == 'goto'
 }
 
 fn source_line_is_module_or_import_declaration(lines []string, target_line int) bool {
@@ -1712,7 +1727,8 @@ fn (mut app App) resolve_indexed_definition(uri string, position Position) ?Loca
 	}
 	start_byte := encoded_col_to_byte(line, start, app.position_encoding)
 	end_byte := encoded_col_to_byte(line, end, app.position_encoding)
-	if source_occurrence_is_field_label(line, end_byte) {
+	if source_occurrence_has_colon_suffix(line, end_byte)
+		|| source_occurrence_is_goto_target(line, start_byte) {
 		return none
 	}
 	if start_byte > 0 && line[start_byte - 1] == `.` {

--- a/handlers.v
+++ b/handlers.v
@@ -1648,18 +1648,51 @@ fn source_declaration_is_compile_time_conditional(content string, declaration_li
 // comma-separated left side of `:=`. Invalid or ambiguous matches only defer
 // to compiler-backed lookup, so this deliberately favors avoiding false
 // indexed definitions for shadowed locals.
-fn source_occurrence_precedes_local_declaration(line string, end_byte int) bool {
-	if end_byte < 0 || end_byte > line.len {
+fn source_occurrence_precedes_local_declaration(lines []string, line_idx int, end_byte int) bool {
+	if line_idx < 0 || line_idx >= lines.len || end_byte < 0
+		|| end_byte > lines[line_idx].len {
 		return false
 	}
-	declaration_offset := line[end_byte..].index(':=') or { return false }
-	for i := end_byte; i < end_byte + declaration_offset; i++ {
-		c := line[i]
-		if !is_ident_char(c) && c !in [`,`, ` `, `\t`] {
+	mut scan_state := ImportScanState{}
+	for current_line in 0 .. line_idx + 1 {
+		raw_line := lines[current_line]
+		fragment := if current_line == line_idx { raw_line[..end_byte] } else { raw_line }
+		source_line_import_code(fragment, mut scan_state)
+	}
+	mut expects_target := false
+	for current_line in line_idx .. lines.len {
+		raw_line := lines[current_line]
+		fragment := if current_line == line_idx { raw_line[end_byte..] } else { raw_line }
+		code := source_line_import_code(fragment, mut scan_state)
+		mut col := 0
+		for col < code.len {
+			if code[col] in [` `, `\t`, `\r`] {
+				col++
+				continue
+			}
+			if expects_target {
+				if !is_ident_char(code[col]) || (code[col] >= `0` && code[col] <= `9`) {
+					return false
+				}
+				col++
+				for col < code.len && is_ident_char(code[col]) {
+					col++
+				}
+				expects_target = false
+				continue
+			}
+			if code[col] == `,` {
+				expects_target = true
+				col++
+				continue
+			}
+			if col + 1 < code.len && code[col] == `:` && code[col + 1] == `=` {
+				return true
+			}
 			return false
 		}
 	}
-	return true
+	return false
 }
 
 fn source_occurrence_has_colon_suffix(line string, end_byte int) bool {
@@ -2219,7 +2252,7 @@ fn source_occurrences_have_potential_local_binding(lines []string, occurrences [
 			|| source_occurrence_is_for_binding(lines, occurrence.line, start_byte, end_byte) {
 			return true
 		}
-		if source_occurrence_precedes_local_declaration(line, end_byte) {
+		if source_occurrence_precedes_local_declaration(lines, occurrence.line, end_byte) {
 			return true
 		}
 		if source_occurrence_is_generic_parameter(lines, occurrence.line, start_byte, end_byte) {

--- a/handlers.v
+++ b/handlers.v
@@ -5,6 +5,7 @@ module main
 import os
 import json2
 import time
+import v.pref
 
 const v_keywords = ['asm', 'as', 'assert', 'atomic', 'break', 'const', 'continue', 'defer', 'dump',
 	'else', 'enum', 'false', 'fn', 'for', 'go', 'goto', 'if', 'ilike', 'implements', 'import',
@@ -1433,6 +1434,53 @@ fn source_occurrences_have_potential_local_binding(lines []string, occurrences [
 	return false
 }
 
+// active_indexed_source_file_names applies the compiler's native build-file
+// filtering without removing inactive sources from the broader symbol index.
+// Test files are direct compiler inputs, so normalize their `_test` suffix
+// before checking platform and backend eligibility.
+fn (app &App) active_indexed_source_file_names(dir string, include_tests bool) map[string]bool {
+	mut file_names := os.ls(dir) or { return map[string]bool{} }
+	file_names = file_names.filter(it.ends_with('.v'))
+	normalized_dir := normalized_index_path(dir)
+	for uri, _ in app.open_files {
+		path := uri_to_path(uri)
+		if normalized_index_path(os.dir(path)) != normalized_dir {
+			continue
+		}
+		name := os.file_name(path)
+		if name.ends_with('.v') && name !in file_names {
+			file_names << name
+		}
+	}
+	mut source_names := []string{}
+	mut test_names := []string{}
+	for name in file_names {
+		if name.ends_with('_test.v') {
+			test_names << name
+		} else {
+			source_names << name
+		}
+	}
+	build_prefs := pref.Preferences{
+		os:      pref.get_host_os()
+		backend: .c
+		arch:    pref.get_host_arch()
+	}
+	mut active := map[string]bool{}
+	for path in build_prefs.should_compile_filtered_files(dir, source_names) {
+		active[os.file_name(path)] = true
+	}
+	if include_tests {
+		for name in test_names {
+			build_name := name[..name.len - '_test.v'.len] + '.v'
+			if build_prefs.should_compile_filtered_files(dir, [build_name]).len == 1 {
+				active[name] = true
+			}
+		}
+	}
+	return active
+}
+
 // find_indexed_source_definition finds one unambiguous top-level declaration
 // in `dir`. Methods and fields are intentionally excluded because resolving
 // them safely requires receiver type information.
@@ -1449,6 +1497,7 @@ fn (mut app App) find_indexed_source_definition(dir string, symbol string, inclu
 			app.reindex_uri(open_uri)
 		}
 	}
+	active_file_names := app.active_indexed_source_file_names(dir, include_tests)
 	mut matches := []Location{}
 	mut uris := app.symbol_index.keys()
 	uris.sort()
@@ -1456,7 +1505,11 @@ fn (mut app App) find_indexed_source_definition(dir string, symbol string, inclu
 		if !include_tests && uri.ends_with('_test.v') {
 			continue
 		}
-		if normalized_index_path(os.dir(uri_to_path(uri))) != normalized_dir {
+		path := uri_to_path(uri)
+		if normalized_index_path(os.dir(path)) != normalized_dir {
+			continue
+		}
+		if os.file_name(path) !in active_file_names {
 			continue
 		}
 		entry := app.symbol_index[uri] or { continue }

--- a/handlers.v
+++ b/handlers.v
@@ -1776,26 +1776,72 @@ fn source_occurrence_is_enum_member_declaration(content string, symbol string, t
 	return false
 }
 
-fn source_occurrence_is_generic_parameter(line string, start_byte int, end_byte int) bool {
-	if start_byte < 0 || end_byte <= start_byte || end_byte > line.len {
+fn source_occurrence_is_generic_parameter(lines []string, line_idx int, start_byte int, end_byte int) bool {
+	if line_idx < 0 || line_idx >= lines.len || start_byte < 0 || end_byte <= start_byte
+		|| end_byte > lines[line_idx].len {
 		return false
 	}
+	mut open_line := line_idx
 	mut open_byte := start_byte
-	for open_byte > 0 && line[open_byte - 1] != `[` && line[open_byte - 1] != `]` {
-		open_byte--
+	mut found_open := false
+	for {
+		line := lines[open_line]
+		mut col := if open_line == line_idx { start_byte } else { line.len }
+		for col > 0 {
+			col--
+			if line[col] == `]` {
+				return false
+			}
+			if line[col] == `[` {
+				open_byte = col
+				found_open = true
+				break
+			}
+		}
+		if found_open || open_line == 0 {
+			break
+		}
+		open_line--
 	}
-	if open_byte == 0 || line[open_byte - 1] != `[` {
+	if !found_open {
 		return false
 	}
-	open_byte--
+	mut close_line := line_idx
 	mut close_byte := end_byte
-	for close_byte < line.len && line[close_byte] != `[` && line[close_byte] != `]` {
-		close_byte++
+	mut found_close := false
+	for close_line < lines.len {
+		line := lines[close_line]
+		mut col := if close_line == line_idx { end_byte } else { 0 }
+		for col < line.len {
+			if line[col] == `[` {
+				return false
+			}
+			if line[col] == `]` {
+				close_byte = col
+				found_close = true
+				break
+			}
+			col++
+		}
+		if found_close {
+			break
+		}
+		close_line++
 	}
-	if close_byte >= line.len || line[close_byte] != `]` {
+	if !found_close {
 		return false
 	}
-	for parameter in line[open_byte + 1..close_byte].split(',') {
+	mut parameter_lines := []string{}
+	if open_line == close_line {
+		parameter_lines << lines[open_line][open_byte + 1..close_byte]
+	} else {
+		parameter_lines << lines[open_line][open_byte + 1..]
+		for parameter_line in open_line + 1 .. close_line {
+			parameter_lines << lines[parameter_line]
+		}
+		parameter_lines << lines[close_line][..close_byte]
+	}
+	for parameter in parameter_lines.join('\n').split(',') {
 		name := parameter.trim_space()
 		if name == '' || name[0] >= `0` && name[0] <= `9` {
 			return false
@@ -1806,7 +1852,7 @@ fn source_occurrence_is_generic_parameter(line string, start_byte int, end_byte 
 			}
 		}
 	}
-	mut declaration_prefix := line[..open_byte].trim_space()
+	mut declaration_prefix := lines[open_line][..open_byte].trim_space()
 	if declaration_prefix.starts_with('pub ') {
 		declaration_prefix = declaration_prefix[4..].trim_space()
 	}
@@ -1836,7 +1882,7 @@ fn source_occurrences_have_potential_local_binding(lines []string, occurrences [
 		if source_occurrence_precedes_local_declaration(line, end_byte) {
 			return true
 		}
-		if source_occurrence_is_generic_parameter(line, start_byte, end_byte) {
+		if source_occurrence_is_generic_parameter(lines, occurrence.line, start_byte, end_byte) {
 			return true
 		}
 		mut suffix_byte := end_byte

--- a/handlers.v
+++ b/handlers.v
@@ -1373,6 +1373,12 @@ fn source_definition_kind_is_supported(kind int) bool {
 		sym_kind_constant, sym_kind_class]
 }
 
+fn source_declaration_occurrence_is_code(sym DocumentSymbol, occurrences []TokenOccurrence) bool {
+	return occurrences.any(it.line == sym.selection_range.start.line
+		&& it.start_char == sym.selection_range.start.char
+		&& it.end_char == sym.selection_range.end.char)
+}
+
 fn source_declaration_is_public(uri string, sym DocumentSymbol, app &App) bool {
 	content := app.index_source_for(uri) or { return false }
 	lines := content.split_into_lines()
@@ -1600,9 +1606,13 @@ fn (mut app App) find_indexed_source_definition(dir string, symbol string, inclu
 			continue
 		}
 		source := app.index_source_for(uri) or { continue }
+		declaration_occurrences := app.occurrences_for(uri)[symbol] or { continue }
 		for sym in entry.doc_symbols {
 			if !source_definition_kind_is_supported(sym.kind)
 				|| extract_simple_fn_name(sym.name) != symbol {
+				continue
+			}
+			if !source_declaration_occurrence_is_code(sym, declaration_occurrences) {
 				continue
 			}
 			if source_declaration_is_compile_time_conditional(source, sym.range.start.line) {

--- a/handlers.v
+++ b/handlers.v
@@ -1669,6 +1669,20 @@ fn source_line_is_module_or_import_declaration(lines []string, target_line int) 
 	return false
 }
 
+fn source_occurrence_is_enum_member_declaration(content string, symbol string, target_line int) bool {
+	for declaration in parse_document_symbols(content) {
+		if declaration.kind != sym_kind_enum {
+			continue
+		}
+		if declaration.children.any(it.kind == sym_kind_enum_member && it.name == symbol
+			&& it.selection_range.start.line == target_line)
+		{
+			return true
+		}
+	}
+	return false
+}
+
 fn source_occurrence_is_generic_parameter(line string, start_byte int, end_byte int) bool {
 	if start_byte < 0 || end_byte <= start_byte || end_byte > line.len {
 		return false
@@ -1872,9 +1886,10 @@ fn (mut app App) resolve_indexed_definition(uri string, position Position) ?Loca
 	if symbol == '' {
 		return none
 	}
-	// `it` can be introduced implicitly by array operations such as filter/map.
-	// Text-only indexing cannot distinguish that binding from a top-level symbol.
-	if symbol == 'it' {
+	// `it` can be introduced implicitly by array operations such as filter/map,
+	// and `err` is implicit inside `or {}` blocks. Text-only indexing cannot
+	// distinguish either binding from a top-level symbol.
+	if symbol == 'it' || symbol == 'err' {
 		return none
 	}
 	// Reuse the reference tokenizer to reject identifier-shaped text in comments
@@ -1885,6 +1900,9 @@ fn (mut app App) resolve_indexed_definition(uri string, position Position) ?Loca
 		return none
 	}
 	if source_line_is_module_or_import_declaration(lines, position.line) {
+		return none
+	}
+	if source_occurrence_is_enum_member_declaration(content, symbol, position.line) {
 		return none
 	}
 	start_byte := encoded_col_to_byte(line, start, app.position_encoding)

--- a/handlers.v
+++ b/handlers.v
@@ -1712,6 +1712,10 @@ fn source_occurrence_is_method_declaration(line string, start_byte int) bool {
 	return receiver.starts_with('(') && receiver.ends_with(')')
 }
 
+fn source_occurrence_has_at_prefix(line string, start_byte int) bool {
+	return start_byte > 0 && start_byte <= line.len && line[start_byte - 1] == `@`
+}
+
 fn source_occurrence_is_interface_method_signature(lines []string, target_line int, start_byte int, end_byte int) bool {
 	if target_line < 0 || target_line >= lines.len || start_byte < 0 || end_byte <= start_byte
 		|| end_byte > lines[target_line].len {
@@ -2128,6 +2132,9 @@ fn (mut app App) resolve_indexed_definition(uri string, position Position) ?Loca
 		return none
 	}
 	if source_occurrence_is_interface_method_signature(lines, position.line, start_byte, end_byte) {
+		return none
+	}
+	if source_occurrence_has_at_prefix(line, start_byte) {
 		return none
 	}
 	if source_occurrence_has_dot_suffix(line, end_byte) && symbol in parse_import_aliases(content) {

--- a/handlers.v
+++ b/handlers.v
@@ -1604,58 +1604,36 @@ fn source_occurrence_is_goto_target(line string, start_byte int) bool {
 	return line[keyword_start..keyword_end] == 'goto'
 }
 
-fn source_occurrence_is_compile_time_condition(line string, line_idx int, start_byte int, if_occurrences []TokenOccurrence, enc PositionEncoding) bool {
-	if start_byte < 0 || start_byte > line.len {
+fn source_occurrence_is_compile_time_condition(lines []string, line_idx int, start_byte int, if_occurrences []TokenOccurrence, enc PositionEncoding) bool {
+	if line_idx < 0 || line_idx >= lines.len || start_byte < 0 || start_byte > lines[line_idx].len {
 		return false
 	}
 	for occurrence in if_occurrences {
-		if occurrence.line != line_idx {
+		if occurrence.line < 0 || occurrence.line > line_idx || occurrence.line >= lines.len {
 			continue
 		}
-		directive_start := encoded_col_to_byte(line, occurrence.start_char, enc)
-		directive_end := encoded_col_to_byte(line, occurrence.end_char, enc)
-		if directive_start <= 0 || directive_end > start_byte || line[directive_start - 1] != `$` {
+		directive_line := lines[occurrence.line]
+		directive_start := encoded_col_to_byte(directive_line, occurrence.start_char, enc)
+		directive_end := encoded_col_to_byte(directive_line, occurrence.end_char, enc)
+		if directive_start <= 0 || directive_end > directive_line.len
+			|| directive_line[directive_start - 1] != `$`
+			|| (occurrence.line == line_idx && directive_end > start_byte) {
 			continue
 		}
-		mut col := directive_end
 		mut reaches_target := true
-		mut in_block_comment := false
-		for col < start_byte {
-			if in_block_comment {
-				if col + 1 < start_byte && line[col] == `*` && line[col + 1] == `/` {
-					in_block_comment = false
-					col += 2
-					continue
-				}
-				col++
+		mut scan_state := ImportScanState{}
+		for scan_line_idx in occurrence.line .. line_idx + 1 {
+			raw_line := lines[scan_line_idx]
+			fragment_start := if scan_line_idx == occurrence.line { directive_end } else { 0 }
+			fragment_end := if scan_line_idx == line_idx { start_byte } else { raw_line.len }
+			if fragment_start > fragment_end {
 				continue
 			}
-			if col + 1 < start_byte && line[col] == `/` && line[col + 1] == `*` {
-				in_block_comment = true
-				col += 2
-				continue
-			}
-			if line[col] == `"` || line[col] == `'` {
-				quote := line[col]
-				col++
-				for col < start_byte {
-					if line[col] == `\\` {
-						col += 2
-						continue
-					}
-					if line[col] == quote {
-						col++
-						break
-					}
-					col++
-				}
-				continue
-			}
-			if line[col] == `{` {
+			code := source_line_import_code(raw_line[fragment_start..fragment_end], mut scan_state)
+			if code.contains('{') {
 				reaches_target = false
 				break
 			}
-			col++
 		}
 		if reaches_target {
 			return true
@@ -2202,7 +2180,7 @@ fn (mut app App) resolve_indexed_definition(uri string, position Position) ?Loca
 	if_occurrences := file_occurrences['if'] or { []TokenOccurrence{} }
 	if source_occurrence_has_colon_suffix(line, end_byte)
 		|| source_occurrence_is_goto_target(line, start_byte)
-		|| source_occurrence_is_compile_time_condition(line, position.line, start_byte, if_occurrences, app.position_encoding) {
+		|| source_occurrence_is_compile_time_condition(lines, position.line, start_byte, if_occurrences, app.position_encoding) {
 		return none
 	}
 	if start_byte > 0 && line[start_byte - 1] == `.` {

--- a/handlers.v
+++ b/handlers.v
@@ -1381,6 +1381,24 @@ fn source_declaration_is_public(uri string, sym DocumentSymbol, app &App) bool {
 	return lines[sym.range.start.line].trim_space().starts_with('pub ')
 }
 
+// source_occurrence_precedes_local_declaration recognizes every target on the
+// comma-separated left side of `:=`. Invalid or ambiguous matches only defer
+// to compiler-backed lookup, so this deliberately favors avoiding false
+// indexed definitions for shadowed locals.
+fn source_occurrence_precedes_local_declaration(line string, end_byte int) bool {
+	if end_byte < 0 || end_byte > line.len {
+		return false
+	}
+	declaration_offset := line[end_byte..].index(':=') or { return false }
+	for i := end_byte; i < end_byte + declaration_offset; i++ {
+		c := line[i]
+		if !is_ident_char(c) && c !in [`,`, ` `, `\t`] {
+			return false
+		}
+	}
+	return true
+}
+
 // source_occurrences_have_potential_local_binding conservatively recognizes
 // local declarations that can shadow a top-level or imported symbol. False
 // positives only defer to compiler-backed lookup; false negatives could return
@@ -1400,12 +1418,12 @@ fn source_occurrences_have_potential_local_binding(lines []string, occurrences [
 		if is_for_binding_highlight(line, start_byte, end_byte) {
 			return true
 		}
+		if source_occurrence_precedes_local_declaration(line, end_byte) {
+			return true
+		}
 		mut suffix_byte := end_byte
 		for suffix_byte < line.len && (line[suffix_byte] == ` ` || line[suffix_byte] == `\t`) {
 			suffix_byte++
-		}
-		if suffix_byte < line.len && line[suffix_byte..].starts_with(':=') {
-			return true
 		}
 		if suffix_byte > end_byte && suffix_byte < line.len
 			&& (is_ident_char(line[suffix_byte]) || line[suffix_byte] in [`[`, `?`, `&`, `.`]) {

--- a/handlers.v
+++ b/handlers.v
@@ -423,6 +423,12 @@ fn (app &App) resolve_indexed_import_module_dir(module_path string, work_dir str
 			}
 		}
 	}
+	if work_dir != '' {
+		source_relative_dir := os.join_path(work_dir, rel)
+		if os.is_dir(source_relative_dir) {
+			return source_relative_dir
+		}
+	}
 	return resolve_import_module_dir(module_path, work_dir)
 }
 

--- a/handlers.v
+++ b/handlers.v
@@ -2232,6 +2232,31 @@ fn source_occurrence_is_for_binding(lines []string, line_idx int, start_byte int
 	return false
 }
 
+fn source_occurrence_has_type_suffix(lines []string, line_idx int, end_byte int) bool {
+	if line_idx < 0 || line_idx >= lines.len || end_byte < 0
+		|| end_byte > lines[line_idx].len {
+		return false
+	}
+	mut scan_state := ImportScanState{}
+	for current_line in 0 .. line_idx + 1 {
+		raw_line := lines[current_line]
+		fragment := if current_line == line_idx { raw_line[..end_byte] } else { raw_line }
+		source_line_import_code(fragment, mut scan_state)
+	}
+	code := source_line_import_code(lines[line_idx][end_byte..], mut scan_state)
+	mut has_separator := false
+	for c in code {
+		if c in [` `, `\t`, `\r`] {
+			has_separator = true
+			continue
+		}
+		is_type_start := (is_ident_char(c) && !(c >= `0` && c <= `9`))
+			|| c in [`[`, `?`, `&`, `.`]
+		return has_separator && is_type_start
+	}
+	return false
+}
+
 // source_occurrences_have_potential_local_binding conservatively recognizes
 // local declarations that can shadow a top-level or imported symbol. False
 // positives only defer to compiler-backed lookup; false negatives could return
@@ -2258,12 +2283,7 @@ fn source_occurrences_have_potential_local_binding(lines []string, occurrences [
 		if source_occurrence_is_generic_parameter(lines, occurrence.line, start_byte, end_byte) {
 			return true
 		}
-		mut suffix_byte := end_byte
-		for suffix_byte < line.len && (line[suffix_byte] == ` ` || line[suffix_byte] == `\t`) {
-			suffix_byte++
-		}
-		if suffix_byte > end_byte && suffix_byte < line.len
-			&& (is_ident_char(line[suffix_byte]) || line[suffix_byte] in [`[`, `?`, `&`, `.`]) {
+		if source_occurrence_has_type_suffix(lines, occurrence.line, end_byte) {
 			return true
 		}
 	}

--- a/handlers.v
+++ b/handlers.v
@@ -1820,7 +1820,9 @@ fn source_occurrence_is_sql_expression(lines []string, target_line int, start_by
 	}
 	mut brace_depth := 0
 	mut sql_depths := []int{}
-	mut sql_prefix_tokens := 0
+	// 1 means the contextual `sql` keyword was seen; 2 means its database
+	// expression has started and remains active until the query block opens.
+	mut sql_connection_state := 0
 	mut scan_state := ImportScanState{}
 	for line_idx, raw_line in lines {
 		if line_idx > target_line {
@@ -1837,21 +1839,19 @@ fn source_occurrence_is_sql_expression(lines []string, target_line int, start_by
 					col++
 				}
 				identifier := line[identifier_start..col]
-				if identifier == 'sql' {
-					sql_prefix_tokens = 1
-				} else if sql_prefix_tokens == 1 {
-					sql_prefix_tokens = 2
-				} else if sql_prefix_tokens == 2 {
-					sql_prefix_tokens = 0
+				if sql_connection_state == 0 && sql_depths.len == 0 && identifier == 'sql' {
+					sql_connection_state = 1
+				} else if sql_connection_state == 1 {
+					sql_connection_state = 2
 				}
 				continue
 			}
 			if line[col] == `{` {
 				brace_depth++
-				if sql_prefix_tokens == 2 {
+				if sql_connection_state == 2 {
 					sql_depths << brace_depth
 				}
-				sql_prefix_tokens = 0
+				sql_connection_state = 0
 			} else if line[col] == `}` {
 				if sql_depths.len > 0 && sql_depths.last() == brace_depth {
 					sql_depths.delete_last()
@@ -1859,9 +1859,12 @@ fn source_occurrence_is_sql_expression(lines []string, target_line int, start_by
 				if brace_depth > 0 {
 					brace_depth--
 				}
-				sql_prefix_tokens = 0
-			} else if line[col] != ` ` && line[col] != `\t` && line[col] != `\r` {
-				sql_prefix_tokens = 0
+				sql_connection_state = 0
+			} else if sql_connection_state == 1 && line[col] != ` ` && line[col] != `\t`
+				&& line[col] != `\r` {
+				sql_connection_state = 0
+			} else if sql_connection_state == 2 && line[col] == `;` {
+				sql_connection_state = 0
 			}
 			col++
 		}

--- a/handlers.v
+++ b/handlers.v
@@ -1993,6 +1993,77 @@ fn source_occurrence_is_generic_parameter(lines []string, line_idx int, start_by
 		|| declaration_prefix.starts_with('interface ') || declaration_prefix.starts_with('type ')
 }
 
+fn source_occurrence_is_for_binding(lines []string, line_idx int, start_byte int, end_byte int) bool {
+	if line_idx < 0 || line_idx >= lines.len || start_byte < 0 || end_byte <= start_byte
+		|| end_byte > lines[line_idx].len {
+		return false
+	}
+	mut scan_state := ImportScanState{}
+	mut before_lines := []string{cap: line_idx + 1}
+	for current_line in 0 .. line_idx + 1 {
+		raw_line := lines[current_line]
+		fragment := if current_line == line_idx { raw_line[..start_byte] } else { raw_line }
+		before_lines << source_line_import_code(fragment, mut scan_state)
+	}
+	mut has_for := false
+	mut has_in := false
+	before := before_lines.join('\n')
+	mut col := 0
+	for col < before.len {
+		if before[col] in [`{`, `}`, `;`] {
+			has_for = false
+			has_in = false
+			col++
+			continue
+		}
+		if !is_ident_char(before[col]) {
+			col++
+			continue
+		}
+		start := col
+		col++
+		for col < before.len && is_ident_char(before[col]) {
+			col++
+		}
+		word := before[start..col]
+		if word == 'for' {
+			has_for = true
+			has_in = false
+		} else if has_for && word == 'in' {
+			has_in = true
+		}
+	}
+	if !has_for || has_in {
+		return false
+	}
+	mut after_lines := []string{cap: lines.len - line_idx}
+	for current_line in line_idx .. lines.len {
+		raw_line := lines[current_line]
+		fragment := if current_line == line_idx { raw_line[end_byte..] } else { raw_line }
+		after_lines << source_line_import_code(fragment, mut scan_state)
+	}
+	after := after_lines.join('\n')
+	col = 0
+	for col < after.len {
+		if after[col] in [`{`, `}`, `;`] {
+			return false
+		}
+		if !is_ident_char(after[col]) {
+			col++
+			continue
+		}
+		start := col
+		col++
+		for col < after.len && is_ident_char(after[col]) {
+			col++
+		}
+		if after[start..col] == 'in' {
+			return true
+		}
+	}
+	return false
+}
+
 // source_occurrences_have_potential_local_binding conservatively recognizes
 // local declarations that can shadow a top-level or imported symbol. False
 // positives only defer to compiler-backed lookup; false negatives could return
@@ -2009,7 +2080,8 @@ fn source_occurrences_have_potential_local_binding(lines []string, occurrences [
 		if start_byte < 0 || end_byte <= start_byte || end_byte > line.len {
 			continue
 		}
-		if is_for_binding_highlight(line, start_byte, end_byte) {
+		if is_for_binding_highlight(line, start_byte, end_byte)
+			|| source_occurrence_is_for_binding(lines, occurrence.line, start_byte, end_byte) {
 			return true
 		}
 		if source_occurrence_precedes_local_declaration(line, end_byte) {

--- a/handlers.v
+++ b/handlers.v
@@ -1105,7 +1105,7 @@ fn (mut app App) handle_rename(request Request) Response {
 	for uri, edits in changes {
 		mut version := ?i64(none)
 		if uri in app.open_files_versions {
-			version = i64(app.open_files_versions[uri])
+			version = app.open_files_versions[uri]
 		}
 		doc_changes << TextDocumentEdit{
 			text_document: VersionedTextDocumentIdentifier{

--- a/handlers.v
+++ b/handlers.v
@@ -1446,6 +1446,12 @@ fn (mut app App) resolve_indexed_definition(uri string, position Position) ?Loca
 	if symbol == '' {
 		return none
 	}
+	// Reuse the reference tokenizer to reject identifier-shaped text in comments
+	// and string literals while still accepting executable string interpolations.
+	occurrences := app.occurrences_for(uri)[symbol] or { return none }
+	if !occurrences.any(it.line == position.line && it.start_char == start && it.end_char == end) {
+		return none
+	}
 	start_byte := encoded_col_to_byte(line, start, app.position_encoding)
 	if start_byte > 0 && line[start_byte - 1] == `.` {
 		dot_col := byte_to_encoded_col(line, start_byte - 1, app.position_encoding)

--- a/handlers.v
+++ b/handlers.v
@@ -1525,12 +1525,77 @@ fn source_declaration_is_public(uri string, sym DocumentSymbol, app &App) bool {
 	return lines[sym.range.start.line].trim_space().starts_with('pub ')
 }
 
+fn source_attribute_content_is_conditional(content string) bool {
+	for attribute in content.split(';') {
+		fields := attribute.fields()
+		if fields.len > 0 && fields[0] == 'if' {
+			return true
+		}
+	}
+	return false
+}
+
+fn source_declaration_has_conditional_attribute(content string, declaration_line int) bool {
+	lines := content.split_into_lines()
+	if declaration_line < 0 || declaration_line >= lines.len {
+		return false
+	}
+	mut pending_conditional := false
+	mut attribute_depth := 0
+	mut attribute_content := []u8{}
+	mut scan_state := ImportScanState{}
+	for line_idx in 0 .. declaration_line {
+		line := source_line_import_code(lines[line_idx], mut scan_state)
+		mut col := 0
+		for col < line.len {
+			if attribute_depth == 0 && col + 1 < line.len && line[col] == `@`
+				&& line[col + 1] == `[` {
+				attribute_depth = 1
+				attribute_content = []u8{}
+				col += 2
+				continue
+			}
+			if attribute_depth > 0 {
+				if line[col] == `[` {
+					attribute_depth++
+					attribute_content << line[col]
+				} else if line[col] == `]` {
+					attribute_depth--
+					if attribute_depth == 0 {
+						if source_attribute_content_is_conditional(attribute_content.bytestr()) {
+							pending_conditional = true
+						}
+					} else {
+						attribute_content << line[col]
+					}
+				} else {
+					attribute_content << line[col]
+				}
+				col++
+				continue
+			}
+			if line[col] !in [` `, `\t`, `\r`] {
+				pending_conditional = false
+			}
+			col++
+		}
+		if attribute_depth > 0 {
+			attribute_content << `\n`
+		}
+	}
+	return pending_conditional
+}
+
 // source_declaration_is_compile_time_conditional identifies declarations nested
-// under `$if` or `$else`. The shallow index does not evaluate compile-time
-// conditions, so every such declaration must defer to compiler-backed lookup.
+// under `$if`/`$else` or guarded by `@[if ...]`. The shallow index does not
+// evaluate compile-time conditions, so every such declaration must defer to
+// compiler-backed lookup.
 fn source_declaration_is_compile_time_conditional(content string, declaration_line int) bool {
 	if declaration_line < 0 {
 		return false
+	}
+	if source_declaration_has_conditional_attribute(content, declaration_line) {
+		return true
 	}
 	lines := content.split_into_lines()
 	mut brace_depth := 0

--- a/handlers.v
+++ b/handlers.v
@@ -1489,6 +1489,17 @@ fn source_occurrence_precedes_local_declaration(line string, end_byte int) bool 
 	return true
 }
 
+fn source_occurrence_is_field_label(line string, end_byte int) bool {
+	if end_byte < 0 || end_byte > line.len {
+		return false
+	}
+	mut suffix_byte := end_byte
+	for suffix_byte < line.len && (line[suffix_byte] == ` ` || line[suffix_byte] == `\t`) {
+		suffix_byte++
+	}
+	return suffix_byte < line.len && line[suffix_byte] == `:`
+}
+
 // source_occurrences_have_potential_local_binding conservatively recognizes
 // local declarations that can shadow a top-level or imported symbol. False
 // positives only defer to compiler-backed lookup; false negatives could return
@@ -1658,6 +1669,10 @@ fn (mut app App) resolve_indexed_definition(uri string, position Position) ?Loca
 		return none
 	}
 	start_byte := encoded_col_to_byte(line, start, app.position_encoding)
+	end_byte := encoded_col_to_byte(line, end, app.position_encoding)
+	if source_occurrence_is_field_label(line, end_byte) {
+		return none
+	}
 	if start_byte > 0 && line[start_byte - 1] == `.` {
 		dot_col := byte_to_encoded_col(line, start_byte - 1, app.position_encoding)
 		alias := get_word_before_dot(line, dot_col, app.position_encoding)

--- a/handlers.v
+++ b/handlers.v
@@ -246,6 +246,7 @@ struct ImportScanState {
 mut:
 	in_block_comment bool
 	quote            u8
+	raw_string       bool
 }
 
 fn source_line_import_code(line string, mut state ImportScanState) string {
@@ -263,12 +264,13 @@ fn source_line_import_code(line string, mut state ImportScanState) string {
 			continue
 		}
 		if state.quote != 0 {
-			if line[col] == `\\` && col + 1 < line.len {
+			if !state.raw_string && line[col] == `\\` && col + 1 < line.len {
 				col += 2
 				continue
 			}
 			if line[col] == state.quote {
 				state.quote = 0
+				state.raw_string = false
 				code << ` `
 			}
 			col++
@@ -283,8 +285,17 @@ fn source_line_import_code(line string, mut state ImportScanState) string {
 			col += 2
 			continue
 		}
+		if line[col] == `r` && col + 1 < line.len
+			&& (line[col + 1] == `"` || line[col + 1] == `'`) {
+			state.quote = line[col + 1]
+			state.raw_string = true
+			code << ` `
+			col += 2
+			continue
+		}
 		if line[col] == `"` || line[col] == `'` || line[col] == 96 {
 			state.quote = line[col]
+			state.raw_string = false
 			code << ` `
 			col++
 			continue

--- a/handlers.v
+++ b/handlers.v
@@ -322,24 +322,31 @@ fn resolve_import_module_dir(module_path string, work_dir string) string {
 	return ''
 }
 
-// resolve_indexed_import_module_dir prefers modules in the active project and
-// workspace over the V installation used to launch VLS. This matters when the
-// workspace is a V checkout: `v.builder` belongs to that checkout's `vlib`, not
-// necessarily to the toolchain on PATH.
-fn (app &App) resolve_indexed_import_module_dir(module_path string, work_dir string) string {
-	rel := module_path.replace('.', os.path_separator)
-	mut roots := []string{}
-	project_root := find_project_root(work_dir)
-	if project_root != '' {
-		roots << project_root
-	}
-	for workspace_root in app.workspace_roots {
-		if workspace_root != ''
-			&& !roots.any(normalized_index_path(it) == normalized_index_path(workspace_root)) {
-			roots << workspace_root
+fn (app &App) workspace_root_containing(path string) string {
+	normalized_path := path.replace('\\', '/')
+	mut best_root := ''
+	mut best_len := 0
+	for root in app.workspace_roots {
+		normalized_root := root.replace('\\', '/')
+		if path_is_within(normalized_path, normalized_root) && normalized_root.len > best_len {
+			best_root = root
+			best_len = normalized_root.len
 		}
 	}
-	for root in roots {
+	return best_root
+}
+
+// resolve_indexed_import_module_dir prefers modules in the requesting file's
+// active project or workspace root over the V installation used to launch VLS.
+// Unrelated workspace folders are not compiler import roots and must not affect
+// indexed resolution.
+fn (app &App) resolve_indexed_import_module_dir(module_path string, work_dir string) string {
+	rel := module_path.replace('.', os.path_separator)
+	mut root := find_project_root(work_dir)
+	if root == '' || root == '/' {
+		root = app.workspace_root_containing(work_dir)
+	}
+	if root != '' && root != '/' {
 		for candidate in [os.join_path(root, rel), os.join_path(root, 'vlib', rel)] {
 			if os.is_dir(candidate) {
 				return candidate
@@ -1500,6 +1507,38 @@ fn source_occurrence_is_field_label(line string, end_byte int) bool {
 	return suffix_byte < line.len && line[suffix_byte] == `:`
 }
 
+fn source_line_is_module_or_import_declaration(lines []string, target_line int) bool {
+	mut in_import_block := false
+	for line_idx, raw_line in lines {
+		if line_idx > target_line {
+			break
+		}
+		line := raw_line.trim_space()
+		if in_import_block {
+			if line_idx == target_line {
+				return true
+			}
+			if line.starts_with(')') {
+				in_import_block = false
+			}
+			continue
+		}
+		if line.starts_with('import ') {
+			if line_idx == target_line {
+				return true
+			}
+			if line[7..].all_before('//').trim_space() == '(' {
+				in_import_block = true
+			}
+			continue
+		}
+		if line_idx == target_line {
+			return line.starts_with('module ')
+		}
+	}
+	return false
+}
+
 // source_occurrences_have_potential_local_binding conservatively recognizes
 // local declarations that can shadow a top-level or imported symbol. False
 // positives only defer to compiler-backed lookup; false negatives could return
@@ -1666,6 +1705,9 @@ fn (mut app App) resolve_indexed_definition(uri string, position Position) ?Loca
 	// and string literals while still accepting executable string interpolations.
 	occurrences := app.occurrences_for(uri)[symbol] or { return none }
 	if !occurrences.any(it.line == position.line && it.start_char == start && it.end_char == end) {
+		return none
+	}
+	if source_line_is_module_or_import_declaration(lines, position.line) {
 		return none
 	}
 	start_byte := encoded_col_to_byte(line, start, app.position_encoding)

--- a/handlers.v
+++ b/handlers.v
@@ -1669,6 +1669,72 @@ fn source_line_is_module_or_import_declaration(lines []string, target_line int) 
 	return false
 }
 
+fn source_occurrence_is_attribute(lines []string, target_line int, start_byte int) bool {
+	if target_line < 0 || target_line >= lines.len || start_byte < 0
+		|| start_byte > lines[target_line].len {
+		return false
+	}
+	mut in_block_comment := false
+	mut quote := u8(0)
+	mut attribute_depth := 0
+	for line_idx, line in lines {
+		if line_idx > target_line {
+			break
+		}
+		limit := if line_idx == target_line { start_byte } else { line.len }
+		mut col := 0
+		for col < limit {
+			if in_block_comment {
+				if col + 1 < limit && line[col] == `*` && line[col + 1] == `/` {
+					in_block_comment = false
+					col += 2
+					continue
+				}
+				col++
+				continue
+			}
+			if quote != 0 {
+				if line[col] == `\\` && col + 1 < limit {
+					col += 2
+					continue
+				}
+				if line[col] == quote {
+					quote = 0
+				}
+				col++
+				continue
+			}
+			if col + 1 < limit && line[col] == `/` && line[col + 1] == `/` {
+				break
+			}
+			if col + 1 < limit && line[col] == `/` && line[col + 1] == `*` {
+				in_block_comment = true
+				col += 2
+				continue
+			}
+			if line[col] == `"` || line[col] == `'` || line[col] == 96 {
+				quote = line[col]
+				col++
+				continue
+			}
+			if attribute_depth == 0 && col + 1 < limit && line[col] == `@` && line[col + 1] == `[` {
+				attribute_depth = 1
+				col += 2
+				continue
+			}
+			if attribute_depth > 0 {
+				if line[col] == `[` {
+					attribute_depth++
+				} else if line[col] == `]` {
+					attribute_depth--
+				}
+			}
+			col++
+		}
+	}
+	return attribute_depth > 0
+}
+
 fn source_occurrence_is_enum_member_declaration(content string, symbol string, target_line int) bool {
 	for declaration in parse_document_symbols(content) {
 		if declaration.kind != sym_kind_enum {
@@ -1899,14 +1965,17 @@ fn (mut app App) resolve_indexed_definition(uri string, position Position) ?Loca
 	if !occurrences.any(it.line == position.line && it.start_char == start && it.end_char == end) {
 		return none
 	}
+	start_byte := encoded_col_to_byte(line, start, app.position_encoding)
+	end_byte := encoded_col_to_byte(line, end, app.position_encoding)
 	if source_line_is_module_or_import_declaration(lines, position.line) {
+		return none
+	}
+	if source_occurrence_is_attribute(lines, position.line, start_byte) {
 		return none
 	}
 	if source_occurrence_is_enum_member_declaration(content, symbol, position.line) {
 		return none
 	}
-	start_byte := encoded_col_to_byte(line, start, app.position_encoding)
-	end_byte := encoded_col_to_byte(line, end, app.position_encoding)
 	if_occurrences := file_occurrences['if'] or { []TokenOccurrence{} }
 	if source_occurrence_has_colon_suffix(line, end_byte)
 		|| source_occurrence_is_goto_target(line, start_byte)

--- a/handlers.v
+++ b/handlers.v
@@ -2018,9 +2018,9 @@ fn source_occurrences_have_potential_local_binding(lines []string, occurrences [
 
 // active_indexed_source_file_names applies the compiler's native build-file
 // filtering without removing inactive sources from the broader symbol index.
-// Test files are direct compiler inputs, so normalize their `_test` suffix
-// before checking platform and backend eligibility.
-fn (app &App) active_indexed_source_file_names(dir string, include_tests bool) map[string]bool {
+// The requesting test file is a direct compiler input, but sibling tests are
+// separate targets. Normalize its `_test` suffix before checking eligibility.
+fn (app &App) active_indexed_source_file_names(dir string, active_test_file_name string) map[string]bool {
 	mut file_names := os.ls(dir) or { return map[string]bool{} }
 	file_names = file_names.filter(it.ends_with('.v'))
 	normalized_dir := normalized_index_path(dir)
@@ -2052,12 +2052,10 @@ fn (app &App) active_indexed_source_file_names(dir string, include_tests bool) m
 	for path in build_prefs.should_compile_filtered_files(dir, source_names) {
 		active[os.file_name(path)] = true
 	}
-	if include_tests {
-		for name in test_names {
-			build_name := name[..name.len - '_test.v'.len] + '.v'
-			if build_prefs.should_compile_filtered_files(dir, [build_name]).len == 1 {
-				active[name] = true
-			}
+	if active_test_file_name in test_names {
+		build_name := active_test_file_name[..active_test_file_name.len - '_test.v'.len] + '.v'
+		if build_prefs.should_compile_filtered_files(dir, [build_name]).len == 1 {
+			active[active_test_file_name] = true
 		}
 	}
 	return active
@@ -2066,7 +2064,7 @@ fn (app &App) active_indexed_source_file_names(dir string, include_tests bool) m
 // find_indexed_source_definition finds one unambiguous top-level declaration
 // in `dir`. Methods and fields are intentionally excluded because resolving
 // them safely requires receiver type information.
-fn (mut app App) find_indexed_source_definition(dir string, symbol string, include_tests bool, require_public bool, expected_module string) ?Location {
+fn (mut app App) find_indexed_source_definition(dir string, symbol string, active_test_file_name string, require_public bool, expected_module string) ?Location {
 	if dir == '' || dir == '/' || !os.is_dir(dir) {
 		return none
 	}
@@ -2079,14 +2077,11 @@ fn (mut app App) find_indexed_source_definition(dir string, symbol string, inclu
 			app.reindex_uri(open_uri)
 		}
 	}
-	active_file_names := app.active_indexed_source_file_names(dir, include_tests)
+	active_file_names := app.active_indexed_source_file_names(dir, active_test_file_name)
 	mut matches := []Location{}
 	mut uris := app.symbol_index.keys()
 	uris.sort()
 	for uri in uris {
-		if !include_tests && uri.ends_with('_test.v') {
-			continue
-		}
 		path := uri_to_path(uri)
 		if normalized_index_path(os.dir(path)) != normalized_dir {
 			continue
@@ -2200,14 +2195,20 @@ fn (mut app App) resolve_indexed_definition(uri string, position Position) ?Loca
 		}
 		module_path := parse_import_aliases(content)[alias] or { return none }
 		module_dir := app.resolve_indexed_import_module_dir(module_path, os.dir(uri_to_path(uri)))
-		return app.find_indexed_source_definition(module_dir, symbol, false, true,
+		return app.find_indexed_source_definition(module_dir, symbol, '', true,
 			module_path.all_after_last('.'))
 	}
 	if source_occurrences_have_potential_local_binding(lines, occurrences, app.position_encoding) {
 		return none
 	}
-	return app.find_indexed_source_definition(os.dir(uri_to_path(uri)), symbol,
-		uri.ends_with('_test.v'), false, get_module_name(content))
+	requesting_path := uri_to_path(uri)
+	active_test_file_name := if requesting_path.ends_with('_test.v') {
+		os.file_name(requesting_path)
+	} else {
+		''
+	}
+	return app.find_indexed_source_definition(os.dir(requesting_path), symbol,
+		active_test_file_name, false, get_module_name(content))
 }
 
 // find_declaration_line searches `lines` for a top-level declaration whose name

--- a/handlers.v
+++ b/handlers.v
@@ -1477,6 +1477,7 @@ fn source_declaration_is_compile_time_conditional(content string, declaration_li
 	mut conditional_depths := []int{}
 	mut pending_conditional := false
 	mut in_block_comment := false
+	mut quote := u8(0)
 	for line_idx, line in lines {
 		if line_idx == declaration_line {
 			return conditional_depths.len > 0
@@ -1489,6 +1490,17 @@ fn source_declaration_is_compile_time_conditional(content string, declaration_li
 				in_block_comment = false
 				continue
 			}
+			if quote != 0 {
+				if line[col] == `\\` && col + 1 < line.len {
+					col += 2
+					continue
+				}
+				if line[col] == quote {
+					quote = 0
+				}
+				col++
+				continue
+			}
 			if col + 1 < line.len && line[col] == `/` && line[col + 1] == `/` {
 				break
 			}
@@ -1498,19 +1510,8 @@ fn source_declaration_is_compile_time_conditional(content string, declaration_li
 				continue
 			}
 			if line[col] == `'` || line[col] == `"` || line[col] == 96 {
-				quote := line[col]
+				quote = line[col]
 				col++
-				for col < line.len {
-					if line[col] == `\\` {
-						col += 2
-						continue
-					}
-					if line[col] == quote {
-						col++
-						break
-					}
-					col++
-				}
 				continue
 			}
 			if line[col] == `$` {

--- a/handlers.v
+++ b/handlers.v
@@ -1382,6 +1382,89 @@ fn source_declaration_is_public(uri string, sym DocumentSymbol, app &App) bool {
 	return lines[sym.range.start.line].trim_space().starts_with('pub ')
 }
 
+// source_declaration_is_compile_time_conditional identifies declarations nested
+// under `$if` or `$else`. The shallow index does not evaluate compile-time
+// conditions, so every such declaration must defer to compiler-backed lookup.
+fn source_declaration_is_compile_time_conditional(content string, declaration_line int) bool {
+	if declaration_line < 0 {
+		return false
+	}
+	lines := content.split_into_lines()
+	mut brace_depth := 0
+	mut conditional_depths := []int{}
+	mut pending_conditional := false
+	mut in_block_comment := false
+	for line_idx, line in lines {
+		if line_idx == declaration_line {
+			return conditional_depths.len > 0
+		}
+		mut col := 0
+		for col < line.len {
+			if in_block_comment {
+				comment_end := line[col..].index('*/') or { break }
+				col += comment_end + 2
+				in_block_comment = false
+				continue
+			}
+			if col + 1 < line.len && line[col] == `/` && line[col + 1] == `/` {
+				break
+			}
+			if col + 1 < line.len && line[col] == `/` && line[col + 1] == `*` {
+				in_block_comment = true
+				col += 2
+				continue
+			}
+			if line[col] == `'` || line[col] == `"` || line[col] == 96 {
+				quote := line[col]
+				col++
+				for col < line.len {
+					if line[col] == `\\` {
+						col += 2
+						continue
+					}
+					if line[col] == quote {
+						col++
+						break
+					}
+					col++
+				}
+				continue
+			}
+			if line[col] == `$` {
+				directive_len := if line[col..].starts_with('$if') {
+					3
+				} else if line[col..].starts_with('$else') {
+					5
+				} else {
+					0
+				}
+				if directive_len > 0 && (col + directive_len == line.len
+					|| !is_ident_char(line[col + directive_len])) {
+					pending_conditional = true
+					col += directive_len
+					continue
+				}
+			}
+			if line[col] == `{` {
+				brace_depth++
+				if pending_conditional {
+					conditional_depths << brace_depth
+					pending_conditional = false
+				}
+			} else if line[col] == `}` {
+				if conditional_depths.len > 0 && conditional_depths.last() == brace_depth {
+					conditional_depths.delete_last()
+				}
+				if brace_depth > 0 {
+					brace_depth--
+				}
+			}
+			col++
+		}
+	}
+	return false
+}
+
 // source_occurrence_precedes_local_declaration recognizes every target on the
 // comma-separated left side of `:=`. Invalid or ambiguous matches only defer
 // to compiler-backed lookup, so this deliberately favors avoiding false
@@ -1516,9 +1599,13 @@ fn (mut app App) find_indexed_source_definition(dir string, symbol string, inclu
 		if expected_module != '' && entry.module_name != expected_module {
 			continue
 		}
+		source := app.index_source_for(uri) or { continue }
 		for sym in entry.doc_symbols {
 			if !source_definition_kind_is_supported(sym.kind)
 				|| extract_simple_fn_name(sym.name) != symbol {
+				continue
+			}
+			if source_declaration_is_compile_time_conditional(source, sym.range.start.line) {
 				continue
 			}
 			if require_public && !source_declaration_is_public(uri, sym, app) {

--- a/handlers.v
+++ b/handlers.v
@@ -242,17 +242,34 @@ fn parse_import_aliases(content string) map[string]string {
 	return aliases
 }
 
-fn source_line_without_comments(line string, was_in_block_comment bool) (string, bool) {
+struct ImportScanState {
+mut:
+	in_block_comment bool
+	quote            u8
+}
+
+fn source_line_import_code(line string, mut state ImportScanState) string {
 	mut code := []u8{cap: line.len}
-	mut in_block_comment := was_in_block_comment
 	mut col := 0
 	for col < line.len {
-		if in_block_comment {
+		if state.in_block_comment {
 			if col + 1 < line.len && line[col] == `*` && line[col + 1] == `/` {
-				in_block_comment = false
+				state.in_block_comment = false
 				code << ` `
 				col += 2
 				continue
+			}
+			col++
+			continue
+		}
+		if state.quote != 0 {
+			if line[col] == `\\` && col + 1 < line.len {
+				col += 2
+				continue
+			}
+			if line[col] == state.quote {
+				state.quote = 0
+				code << ` `
 			}
 			col++
 			continue
@@ -261,40 +278,28 @@ fn source_line_without_comments(line string, was_in_block_comment bool) (string,
 			break
 		}
 		if col + 1 < line.len && line[col] == `/` && line[col + 1] == `*` {
-			in_block_comment = true
+			state.in_block_comment = true
 			code << ` `
 			col += 2
 			continue
 		}
 		if line[col] == `"` || line[col] == `'` || line[col] == 96 {
-			quote := line[col]
-			code << line[col]
+			state.quote = line[col]
+			code << ` `
 			col++
-			for col < line.len {
-				code << line[col]
-				if line[col] == `\\` && col + 1 < line.len {
-					col++
-					code << line[col]
-				} else if line[col] == quote {
-					col++
-					break
-				}
-				col++
-			}
 			continue
 		}
 		code << line[col]
 		col++
 	}
-	return code.bytestr(), in_block_comment
+	return code.bytestr()
 }
 
 fn parse_import_bindings(content string) []ImportedModuleBinding {
 	mut bindings := []ImportedModuleBinding{}
-	mut in_block_comment := false
+	mut scan_state := ImportScanState{}
 	for raw_line in content.split_into_lines() {
-		line, next_in_block_comment := source_line_without_comments(raw_line, in_block_comment)
-		in_block_comment = next_in_block_comment
+		line := source_line_import_code(raw_line, mut scan_state)
 		trimmed := line.trim_space()
 		if !trimmed.starts_with('import ') {
 			continue
@@ -1824,6 +1829,11 @@ fn (mut app App) resolve_indexed_definition(uri string, position Position) ?Loca
 	}
 	symbol := substr_by_char_bounds(line, start, end, app.position_encoding)
 	if symbol == '' {
+		return none
+	}
+	// `it` can be introduced implicitly by array operations such as filter/map.
+	// Text-only indexing cannot distinguish that binding from a top-level symbol.
+	if symbol == 'it' {
 		return none
 	}
 	// Reuse the reference tokenizer to reject identifier-shaped text in comments

--- a/handlers.v
+++ b/handlers.v
@@ -1522,6 +1522,66 @@ fn source_occurrence_is_goto_target(line string, start_byte int) bool {
 	return line[keyword_start..keyword_end] == 'goto'
 }
 
+fn source_occurrence_is_compile_time_condition(line string, line_idx int, start_byte int, if_occurrences []TokenOccurrence, enc PositionEncoding) bool {
+	if start_byte < 0 || start_byte > line.len {
+		return false
+	}
+	for occurrence in if_occurrences {
+		if occurrence.line != line_idx {
+			continue
+		}
+		directive_start := encoded_col_to_byte(line, occurrence.start_char, enc)
+		directive_end := encoded_col_to_byte(line, occurrence.end_char, enc)
+		if directive_start <= 0 || directive_end > start_byte || line[directive_start - 1] != `$` {
+			continue
+		}
+		mut col := directive_end
+		mut reaches_target := true
+		mut in_block_comment := false
+		for col < start_byte {
+			if in_block_comment {
+				if col + 1 < start_byte && line[col] == `*` && line[col + 1] == `/` {
+					in_block_comment = false
+					col += 2
+					continue
+				}
+				col++
+				continue
+			}
+			if col + 1 < start_byte && line[col] == `/` && line[col + 1] == `*` {
+				in_block_comment = true
+				col += 2
+				continue
+			}
+			if line[col] == `"` || line[col] == `'` {
+				quote := line[col]
+				col++
+				for col < start_byte {
+					if line[col] == `\\` {
+						col += 2
+						continue
+					}
+					if line[col] == quote {
+						col++
+						break
+					}
+					col++
+				}
+				continue
+			}
+			if line[col] == `{` {
+				reaches_target = false
+				break
+			}
+			col++
+		}
+		if reaches_target {
+			return true
+		}
+	}
+	return false
+}
+
 fn source_line_is_module_or_import_declaration(lines []string, target_line int) bool {
 	mut in_import_block := false
 	for line_idx, raw_line in lines {
@@ -1718,7 +1778,8 @@ fn (mut app App) resolve_indexed_definition(uri string, position Position) ?Loca
 	}
 	// Reuse the reference tokenizer to reject identifier-shaped text in comments
 	// and string literals while still accepting executable string interpolations.
-	occurrences := app.occurrences_for(uri)[symbol] or { return none }
+	file_occurrences := app.occurrences_for(uri)
+	occurrences := file_occurrences[symbol] or { return none }
 	if !occurrences.any(it.line == position.line && it.start_char == start && it.end_char == end) {
 		return none
 	}
@@ -1727,14 +1788,16 @@ fn (mut app App) resolve_indexed_definition(uri string, position Position) ?Loca
 	}
 	start_byte := encoded_col_to_byte(line, start, app.position_encoding)
 	end_byte := encoded_col_to_byte(line, end, app.position_encoding)
+	if_occurrences := file_occurrences['if'] or { []TokenOccurrence{} }
 	if source_occurrence_has_colon_suffix(line, end_byte)
-		|| source_occurrence_is_goto_target(line, start_byte) {
+		|| source_occurrence_is_goto_target(line, start_byte)
+		|| source_occurrence_is_compile_time_condition(line, position.line, start_byte, if_occurrences, app.position_encoding) {
 		return none
 	}
 	if start_byte > 0 && line[start_byte - 1] == `.` {
 		dot_col := byte_to_encoded_col(line, start_byte - 1, app.position_encoding)
 		alias := get_word_before_dot(line, dot_col, app.position_encoding)
-		alias_occurrences := app.occurrences_for(uri)[alias] or { return none }
+		alias_occurrences := file_occurrences[alias] or { return none }
 		if source_occurrences_have_potential_local_binding(lines, alias_occurrences,
 			app.position_encoding)
 		{

--- a/handlers.v
+++ b/handlers.v
@@ -250,19 +250,24 @@ mut:
 
 struct ImportScanState {
 mut:
-	in_block_comment bool
-	quote            u8
-	raw_string       bool
-	interpolations   []ImportInterpolationState
+	block_comment_depth int
+	quote               u8
+	raw_string          bool
+	interpolations      []ImportInterpolationState
 }
 
 fn source_line_import_code(line string, mut state ImportScanState) string {
 	mut code := []u8{cap: line.len}
 	mut col := 0
 	for col < line.len {
-		if state.in_block_comment {
+		if state.block_comment_depth > 0 {
+			if col + 1 < line.len && line[col] == `/` && line[col + 1] == `*` {
+				state.block_comment_depth++
+				col += 2
+				continue
+			}
 			if col + 1 < line.len && line[col] == `*` && line[col + 1] == `/` {
-				state.in_block_comment = false
+				state.block_comment_depth--
 				code << ` `
 				col += 2
 				continue
@@ -297,7 +302,7 @@ fn source_line_import_code(line string, mut state ImportScanState) string {
 			break
 		}
 		if col + 1 < line.len && line[col] == `/` && line[col + 1] == `*` {
-			state.in_block_comment = true
+			state.block_comment_depth = 1
 			code << ` `
 			col += 2
 			continue

--- a/handlers.v
+++ b/handlers.v
@@ -242,11 +242,18 @@ fn parse_import_aliases(content string) map[string]string {
 	return aliases
 }
 
+struct ImportInterpolationState {
+	quote u8
+mut:
+	brace_depth int
+}
+
 struct ImportScanState {
 mut:
 	in_block_comment bool
 	quote            u8
 	raw_string       bool
+	interpolations   []ImportInterpolationState
 }
 
 fn source_line_import_code(line string, mut state ImportScanState) string {
@@ -268,6 +275,16 @@ fn source_line_import_code(line string, mut state ImportScanState) string {
 				col += 2
 				continue
 			}
+			if !state.raw_string && line[col] == `$` && col + 1 < line.len
+				&& line[col + 1] == `{` {
+				state.interpolations << ImportInterpolationState{
+					quote: state.quote
+				}
+				state.quote = 0
+				code << ` `
+				col += 2
+				continue
+			}
 			if line[col] == state.quote {
 				state.quote = 0
 				state.raw_string = false
@@ -283,6 +300,27 @@ fn source_line_import_code(line string, mut state ImportScanState) string {
 			state.in_block_comment = true
 			code << ` `
 			col += 2
+			continue
+		}
+		if line[col] == `{` && state.interpolations.len > 0 {
+			last := state.interpolations.len - 1
+			state.interpolations[last].brace_depth++
+			code << line[col]
+			col++
+			continue
+		}
+		if line[col] == `}` && state.interpolations.len > 0 {
+			last := state.interpolations.len - 1
+			if state.interpolations[last].brace_depth == 0 {
+				interpolation := state.interpolations.pop()
+				state.quote = interpolation.quote
+				state.raw_string = false
+				code << ` `
+			} else {
+				state.interpolations[last].brace_depth--
+				code << line[col]
+			}
+			col++
 			continue
 		}
 		if line[col] == `r` && col + 1 < line.len

--- a/handlers.v
+++ b/handlers.v
@@ -242,9 +242,59 @@ fn parse_import_aliases(content string) map[string]string {
 	return aliases
 }
 
+fn source_line_without_comments(line string, was_in_block_comment bool) (string, bool) {
+	mut code := []u8{cap: line.len}
+	mut in_block_comment := was_in_block_comment
+	mut col := 0
+	for col < line.len {
+		if in_block_comment {
+			if col + 1 < line.len && line[col] == `*` && line[col + 1] == `/` {
+				in_block_comment = false
+				code << ` `
+				col += 2
+				continue
+			}
+			col++
+			continue
+		}
+		if col + 1 < line.len && line[col] == `/` && line[col + 1] == `/` {
+			break
+		}
+		if col + 1 < line.len && line[col] == `/` && line[col + 1] == `*` {
+			in_block_comment = true
+			code << ` `
+			col += 2
+			continue
+		}
+		if line[col] == `"` || line[col] == `'` || line[col] == 96 {
+			quote := line[col]
+			code << line[col]
+			col++
+			for col < line.len {
+				code << line[col]
+				if line[col] == `\\` && col + 1 < line.len {
+					col++
+					code << line[col]
+				} else if line[col] == quote {
+					col++
+					break
+				}
+				col++
+			}
+			continue
+		}
+		code << line[col]
+		col++
+	}
+	return code.bytestr(), in_block_comment
+}
+
 fn parse_import_bindings(content string) []ImportedModuleBinding {
 	mut bindings := []ImportedModuleBinding{}
-	for line in content.split_into_lines() {
+	mut in_block_comment := false
+	for raw_line in content.split_into_lines() {
+		line, next_in_block_comment := source_line_without_comments(raw_line, in_block_comment)
+		in_block_comment = next_in_block_comment
 		trimmed := line.trim_space()
 		if !trimmed.starts_with('import ') {
 			continue

--- a/handlers.v
+++ b/handlers.v
@@ -1801,50 +1801,18 @@ fn source_occurrence_is_attribute(lines []string, target_line int, start_byte in
 		|| start_byte > lines[target_line].len {
 		return false
 	}
-	mut in_block_comment := false
-	mut quote := u8(0)
 	mut attribute_depth := 0
-	for line_idx, line in lines {
+	mut scan_state := ImportScanState{}
+	for line_idx, raw_line in lines {
 		if line_idx > target_line {
 			break
 		}
-		limit := if line_idx == target_line { start_byte } else { line.len }
+		fragment := if line_idx == target_line { raw_line[..start_byte] } else { raw_line }
+		line := source_line_import_code(fragment, mut scan_state)
 		mut col := 0
-		for col < limit {
-			if in_block_comment {
-				if col + 1 < limit && line[col] == `*` && line[col + 1] == `/` {
-					in_block_comment = false
-					col += 2
-					continue
-				}
-				col++
-				continue
-			}
-			if quote != 0 {
-				if line[col] == `\\` && col + 1 < limit {
-					col += 2
-					continue
-				}
-				if line[col] == quote {
-					quote = 0
-				}
-				col++
-				continue
-			}
-			if col + 1 < limit && line[col] == `/` && line[col + 1] == `/` {
-				break
-			}
-			if col + 1 < limit && line[col] == `/` && line[col + 1] == `*` {
-				in_block_comment = true
-				col += 2
-				continue
-			}
-			if line[col] == `"` || line[col] == `'` || line[col] == 96 {
-				quote = line[col]
-				col++
-				continue
-			}
-			if attribute_depth == 0 && col + 1 < limit && line[col] == `@` && line[col + 1] == `[` {
+		for col < line.len {
+			if attribute_depth == 0 && col + 1 < line.len && line[col] == `@`
+				&& line[col + 1] == `[` {
 				attribute_depth = 1
 				col += 2
 				continue

--- a/handlers.v
+++ b/handlers.v
@@ -1669,6 +1669,44 @@ fn source_line_is_module_or_import_declaration(lines []string, target_line int) 
 	return false
 }
 
+fn source_occurrence_is_generic_parameter(line string, start_byte int, end_byte int) bool {
+	if start_byte < 0 || end_byte <= start_byte || end_byte > line.len {
+		return false
+	}
+	mut open_byte := start_byte
+	for open_byte > 0 && line[open_byte - 1] != `[` && line[open_byte - 1] != `]` {
+		open_byte--
+	}
+	if open_byte == 0 || line[open_byte - 1] != `[` {
+		return false
+	}
+	open_byte--
+	mut close_byte := end_byte
+	for close_byte < line.len && line[close_byte] != `[` && line[close_byte] != `]` {
+		close_byte++
+	}
+	if close_byte >= line.len || line[close_byte] != `]` {
+		return false
+	}
+	for parameter in line[open_byte + 1..close_byte].split(',') {
+		name := parameter.trim_space()
+		if name == '' || name[0] >= `0` && name[0] <= `9` {
+			return false
+		}
+		for c in name {
+			if !is_ident_char(c) {
+				return false
+			}
+		}
+	}
+	mut declaration_prefix := line[..open_byte].trim_space()
+	if declaration_prefix.starts_with('pub ') {
+		declaration_prefix = declaration_prefix[4..].trim_space()
+	}
+	return declaration_prefix.starts_with('fn ') || declaration_prefix.starts_with('struct ')
+		|| declaration_prefix.starts_with('interface ') || declaration_prefix.starts_with('type ')
+}
+
 // source_occurrences_have_potential_local_binding conservatively recognizes
 // local declarations that can shadow a top-level or imported symbol. False
 // positives only defer to compiler-backed lookup; false negatives could return
@@ -1689,6 +1727,9 @@ fn source_occurrences_have_potential_local_binding(lines []string, occurrences [
 			return true
 		}
 		if source_occurrence_precedes_local_declaration(line, end_byte) {
+			return true
+		}
+		if source_occurrence_is_generic_parameter(line, start_byte, end_byte) {
 			return true
 		}
 		mut suffix_byte := end_byte

--- a/handlers.v
+++ b/handlers.v
@@ -1662,19 +1662,46 @@ fn source_line_is_module_or_import_declaration(lines []string, target_line int) 
 	return false
 }
 
-fn source_occurrence_is_method_declaration(line string, start_byte int) bool {
-	if start_byte < 0 || start_byte > line.len {
+fn source_occurrence_is_method_declaration(lines []string, target_line int, start_byte int) bool {
+	if target_line < 0 || target_line >= lines.len || start_byte < 0
+		|| start_byte > lines[target_line].len {
 		return false
 	}
-	mut prefix := line[..start_byte].trim_space()
-	if prefix.starts_with('pub ') {
-		prefix = prefix[4..].trim_space()
+	mut code_lines := []string{cap: target_line + 1}
+	mut scan_state := ImportScanState{}
+	for line_idx in 0 .. target_line + 1 {
+		raw_line := lines[line_idx]
+		fragment := if line_idx == target_line { raw_line[..start_byte] } else { raw_line }
+		code_lines << source_line_import_code(fragment, mut scan_state)
 	}
-	if !prefix.starts_with('fn ') {
+	prefix := code_lines.join(' ').trim_space()
+	if prefix.len < 3 || prefix[prefix.len - 1] != `)` {
 		return false
 	}
-	receiver := prefix[3..].trim_space()
-	return receiver.starts_with('(') && receiver.ends_with(')')
+	mut depth := 0
+	mut receiver_start := -1
+	mut col := prefix.len - 1
+	for col >= 0 {
+		if prefix[col] == `)` {
+			depth++
+		} else if prefix[col] == `(` {
+			depth--
+			if depth == 0 {
+				receiver_start = col
+				break
+			}
+		}
+		col--
+	}
+	if receiver_start < 0 || prefix[receiver_start + 1..prefix.len - 1].trim_space() == '' {
+		return false
+	}
+	declaration_prefix := prefix[..receiver_start].trim_space()
+	if !declaration_prefix.ends_with('fn') {
+		return false
+	}
+	fn_start := declaration_prefix.len - 2
+	return fn_start == 0 || !is_ident_char(declaration_prefix[fn_start - 1])
 }
 
 fn source_occurrence_has_compile_time_prefix(line string, start_byte int) bool {
@@ -2112,7 +2139,7 @@ fn (mut app App) resolve_indexed_definition(uri string, position Position) ?Loca
 	if source_occurrence_is_enum_member_declaration(content, symbol, position.line) {
 		return none
 	}
-	if source_occurrence_is_method_declaration(line, start_byte) {
+	if source_occurrence_is_method_declaration(lines, position.line, start_byte) {
 		return none
 	}
 	if source_occurrence_is_interface_method_signature(lines, position.line, start_byte, end_byte) {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -956,6 +956,41 @@ fn test_resolve_indexed_definition_defers_implicit_it_binding() {
 	assert location == none
 }
 
+fn test_resolve_indexed_definition_defers_generic_type_parameter() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	test_dir := os.join_path(app.temp_dir, 'indexed_definition_generic_parameter')
+	must_mkdir_all(test_dir)
+	test_file := os.join_path(test_dir, 'main.v')
+	content := 'module main\n\nstruct T {}\n\nfn identity[T](value T) T {\n\treturn value\n}\n'
+	must_write_file(test_file, content)
+	uri := path_to_uri(test_file)
+	app.open_files[uri] = content
+	line := content.split_into_lines()[4]
+	generic_col := line.index('[T]') or {
+		assert false, 'expected generic parameter declaration'
+		return
+	}
+	value_col := line.index('value T') or {
+		assert false, 'expected generic parameter type'
+		return
+	}
+	return_col := line.last_index('T {') or {
+		assert false, 'expected generic return type'
+		return
+	}
+
+	for col in [generic_col + 1, value_col + 6, return_col] {
+		location := app.resolve_indexed_definition(uri, Position{
+			line: 4
+			char: col
+		})
+		assert location == none
+	}
+}
+
 fn test_resolve_indexed_definition_defers_destructured_local_shadow() {
 	mut app := create_test_app()
 	defer {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -1052,6 +1052,30 @@ fn test_resolve_indexed_definition_defers_imported_module_qualifier() {
 	assert location == none
 }
 
+fn test_resolve_indexed_definition_defers_grouped_import_module_qualifier() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	test_dir := os.join_path(app.temp_dir, 'indexed_definition_grouped_module_qualifier')
+	must_mkdir_all(test_dir)
+	test_file := os.join_path(test_dir, 'main.v')
+	content := 'module main\n\nimport (\n\tmath as util\n)\n\nfn util() {}\n\nfn main() {\n\t_ := util.sin(0.0)\n}\n'
+	must_write_file(test_file, content)
+	uri := path_to_uri(test_file)
+	app.open_files[uri] = content
+	qualifier_col := content.split_into_lines()[9].index('util') or {
+		assert false, 'expected grouped import module qualifier'
+		return
+	}
+
+	location := app.resolve_indexed_definition(uri, Position{
+		line: 9
+		char: qualifier_col + 2
+	})
+	assert location == none
+}
+
 fn test_resolve_indexed_definition_defers_generic_type_parameter() {
 	mut app := create_test_app()
 	defer {
@@ -3003,6 +3027,15 @@ fn test_parse_imports_grouped() {
 	content := 'module main\n\nimport (\n\tos\n\tv.util as util // alias\n\n\t// comment\n\tstrings\n)\n'
 	imports := parse_imports(content)
 	assert imports == ['os', 'v.util', 'strings']
+}
+
+fn test_parse_import_aliases_grouped() {
+	content := 'module main\n\nimport (\n\tmath as util\n\tv.ast\n)\n'
+	aliases := parse_import_aliases(content)
+	assert aliases == {
+		'util': 'math'
+		'ast':  'v.ast'
+	}
 }
 
 fn test_parse_imports_none() {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -956,6 +956,54 @@ fn test_resolve_indexed_definition_defers_implicit_it_binding() {
 	assert location == none
 }
 
+fn test_resolve_indexed_definition_defers_implicit_err_binding() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	test_dir := os.join_path(app.temp_dir, 'indexed_definition_implicit_err')
+	must_mkdir_all(test_dir)
+	test_file := os.join_path(test_dir, 'main.v')
+	content := "module main\n\nfn err() {}\n\nfn main() {\n\t_ := os.read_file('missing') or {\n\t\teprintln(err)\n\t\t''\n\t}\n}\n"
+	must_write_file(test_file, content)
+	uri := path_to_uri(test_file)
+	app.open_files[uri] = content
+	err_col := content.split_into_lines()[6].index('err') or {
+		assert false, 'expected implicit err reference'
+		return
+	}
+
+	location := app.resolve_indexed_definition(uri, Position{
+		line: 6
+		char: err_col + 1
+	})
+	assert location == none
+}
+
+fn test_resolve_indexed_definition_defers_enum_member_declaration() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	test_dir := os.join_path(app.temp_dir, 'indexed_definition_enum_member')
+	must_mkdir_all(test_dir)
+	test_file := os.join_path(test_dir, 'main.v')
+	content := 'module main\n\nfn red() {}\n\nenum Color {\n\tred\n}\n'
+	must_write_file(test_file, content)
+	uri := path_to_uri(test_file)
+	app.open_files[uri] = content
+	red_col := content.split_into_lines()[5].index('red') or {
+		assert false, 'expected enum member declaration'
+		return
+	}
+
+	location := app.resolve_indexed_definition(uri, Position{
+		line: 5
+		char: red_col + 1
+	})
+	assert location == none
+}
+
 fn test_resolve_indexed_definition_defers_generic_type_parameter() {
 	mut app := create_test_app()
 	defer {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -1175,6 +1175,30 @@ fn test_resolve_indexed_definition_defers_compile_time_at_identifier() {
 	assert location == none
 }
 
+fn test_resolve_indexed_definition_defers_orm_field_reference() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	test_dir := os.join_path(app.temp_dir, 'indexed_definition_orm_field')
+	must_mkdir_all(test_dir)
+	test_file := os.join_path(test_dir, 'main.v')
+	content := 'module main\n\nfn age() {}\n\nfn query() {\n\t_ := sql db {\n\t\tselect from User where age > 21\n\t}\n}\n'
+	must_write_file(test_file, content)
+	uri := path_to_uri(test_file)
+	app.open_files[uri] = content
+	age_col := content.split_into_lines()[6].index('age') or {
+		assert false, 'expected ORM field reference'
+		return
+	}
+
+	location := app.resolve_indexed_definition(uri, Position{
+		line: 6
+		char: age_col + 1
+	})
+	assert location == none
+}
+
 fn test_resolve_indexed_definition_defers_generic_type_parameter() {
 	mut app := create_test_app()
 	defer {
@@ -1469,6 +1493,30 @@ fn test_resolve_indexed_definition_excludes_different_module_sibling() {
 
 	location := app.resolve_indexed_definition(main_uri, Position{
 		line: 3
+		char: 3
+	})
+	assert location == none
+}
+
+fn test_resolve_indexed_definition_ignores_commented_requesting_module() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	test_dir := os.join_path(app.temp_dir, 'indexed_definition_commented_module')
+	must_mkdir_all(test_dir)
+	main_file := os.join_path(test_dir, 'main.v')
+	sibling_file := os.join_path(test_dir, 'sibling.v')
+	main_content := '/*\nmodule legacy\n*/\nmodule main\n\nfn main() {\n\thelper()\n}\n'
+	must_write_file(main_file, main_content)
+	must_write_file(sibling_file, 'module main\n')
+	main_uri := path_to_uri(main_file)
+	sibling_uri := path_to_uri(sibling_file)
+	app.open_files[main_uri] = main_content
+	app.open_files[sibling_uri] = 'module legacy\n\nfn helper() {}\n'
+
+	location := app.resolve_indexed_definition(main_uri, Position{
+		line: 6
 		char: 3
 	})
 	assert location == none
@@ -4153,8 +4201,9 @@ fn test_get_module_name_no_declaration() {
 
 fn test_get_module_name_ignores_comments() {
 	// module keyword inside a comment is not a declaration
-	content := '// module notthis\nmodule real\n'
-	assert get_module_name(content) == 'real'
+	assert get_module_name('// module notthis\nmodule real\n') == 'real'
+	assert get_module_name('/*\nmodule legacy\n*/\nmodule real\n') == 'real'
+	assert get_module_name("const text = 'start\nmodule legacy\nend'\nmodule real\n") == 'real'
 }
 
 fn test_collect_module_fn_completions_excludes_different_module() {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -1792,6 +1792,41 @@ fn test_resolve_indexed_definition_defers_multiline_parameter_shadow() {
 	assert location == none
 }
 
+fn test_resolve_indexed_definition_defers_commented_parameter_shadow() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	test_dir := os.join_path(app.temp_dir, 'indexed_definition_commented_parameter_shadow')
+	must_mkdir_all(test_dir)
+	test_file := os.join_path(test_dir, 'main.v')
+	content := 'module main\n\nfn helper() {}\n\nfn use(helper /* explanation */ int) {\n\tprintln(helper)\n}\n'
+	must_write_file(test_file, content)
+	uri := path_to_uri(test_file)
+	app.open_files[uri] = content
+	lines := content.split_into_lines()
+	parameter_col := lines[4].index('helper') or {
+		assert false, 'expected commented parameter'
+		return
+	}
+	use_col := lines[5].index('helper') or {
+		assert false, 'expected parameter use'
+		return
+	}
+
+	assert source_occurrence_has_type_suffix(lines, 4, parameter_col + 6)
+	for position in [Position{
+		line: 4
+		char: parameter_col + 2
+	}, Position{
+		line: 5
+		char: use_col + 2
+	}] {
+		location := app.resolve_indexed_definition(uri, position)
+		assert location == none
+	}
+}
+
 fn test_resolve_indexed_definition_excludes_inactive_platform_file() {
 	mut app := create_test_app()
 	defer {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -990,6 +990,26 @@ fn test_resolve_indexed_definition_defers_compile_time_declaration() {
 	assert location == none
 }
 
+fn test_resolve_indexed_definition_excludes_block_comment_declaration() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	test_dir := os.join_path(app.temp_dir, 'indexed_definition_block_comment')
+	must_mkdir_all(test_dir)
+	main_file := os.join_path(test_dir, 'main.v')
+	main_content := 'module main\n\n/*\nfn helper() {}\n*/\n\nfn main() {\n\thelper()\n}\n'
+	must_write_file(main_file, main_content)
+	main_uri := path_to_uri(main_file)
+	app.open_files[main_uri] = main_content
+
+	location := app.resolve_indexed_definition(main_uri, Position{
+		line: 7
+		char: 3
+	})
+	assert location == none
+}
+
 fn test_resolve_indexed_definition_excludes_different_module_sibling() {
 	mut app := create_test_app()
 	defer {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -1714,6 +1714,28 @@ fn test_resolve_indexed_definition_excludes_different_module_sibling() {
 	assert location == none
 }
 
+fn test_resolve_indexed_definition_defers_moduleless_script_sibling() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	test_dir := os.join_path(app.temp_dir, 'indexed_definition_moduleless_script')
+	must_mkdir_all(test_dir)
+	main_file := os.join_path(test_dir, 'script.v')
+	sibling_file := os.join_path(test_dir, 'sibling.v')
+	main_content := 'helper()\n'
+	must_write_file(main_file, main_content)
+	must_write_file(sibling_file, 'module unrelated\n\nfn helper() {}\n')
+	main_uri := path_to_uri(main_file)
+	app.open_files[main_uri] = main_content
+
+	location := app.resolve_indexed_definition(main_uri, Position{
+		line: 0
+		char: 2
+	})
+	assert location == none
+}
+
 fn test_resolve_indexed_definition_ignores_commented_requesting_module() {
 	mut app := create_test_app()
 	defer {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -846,6 +846,41 @@ fn test_resolve_indexed_definition_finds_current_file_function() {
 	assert location.range.start.line == 2
 }
 
+fn test_resolve_indexed_definition_limits_test_target() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	test_dir := os.join_path(app.temp_dir, 'indexed_definition_test_target')
+	must_mkdir_all(test_dir)
+	foo_file := os.join_path(test_dir, 'foo_test.v')
+	bar_file := os.join_path(test_dir, 'bar_test.v')
+	foo_content := 'module main\n\nfn local_helper() {}\n\nfn test_target() {\n\thelper()\n\tlocal_helper()\n}\n'
+	bar_content := 'module main\n\nfn helper() {}\n'
+	must_write_file(foo_file, foo_content)
+	must_write_file(bar_file, bar_content)
+	foo_uri := path_to_uri(foo_file)
+	bar_uri := path_to_uri(bar_file)
+	app.open_files[foo_uri] = foo_content
+	app.open_files[bar_uri] = bar_content
+
+	sibling_location := app.resolve_indexed_definition(foo_uri, Position{
+		line: 5
+		char: 3
+	})
+	assert sibling_location == none
+
+	local_location := app.resolve_indexed_definition(foo_uri, Position{
+		line: 6
+		char: 4
+	}) or {
+		assert false, 'expected definition from requesting test target'
+		return
+	}
+	assert local_location.uri == foo_uri
+	assert local_location.range.start.line == 2
+}
+
 fn test_resolve_indexed_definition_rejects_comments_and_string_literals() {
 	mut app := create_test_app()
 	defer {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -1164,6 +1164,45 @@ fn test_resolve_indexed_definition_uses_unsaved_imported_module() {
 	assert location.range.start.line == 3
 }
 
+fn test_resolve_indexed_definition_ignores_import_in_block_comment() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	test_dir := os.join_path(app.temp_dir, 'indexed_definition_commented_import')
+	right_dir := os.join_path(test_dir, 'right')
+	wrong_dir := os.join_path(test_dir, 'wrong')
+	must_mkdir_all(right_dir)
+	must_mkdir_all(wrong_dir)
+	main_file := os.join_path(test_dir, 'main.v')
+	right_file := os.join_path(right_dir, 'right.v')
+	wrong_file := os.join_path(wrong_dir, 'wrong.v')
+	main_content := 'module main\n\nimport right as util\n/*\nimport wrong as util\n*/\n\nfn main() {\n\tutil.answer()\n}\n'
+	right_content := 'module right\n\npub fn answer() {}\n'
+	wrong_content := 'module wrong\n\npub fn answer() {}\n'
+	must_write_file(main_file, main_content)
+	must_write_file(right_file, right_content)
+	must_write_file(wrong_file, wrong_content)
+	main_uri := path_to_uri(main_file)
+	right_uri := path_to_uri(right_file)
+	app.open_files[main_uri] = main_content
+	app.open_files[right_uri] = right_content
+	app.open_files[path_to_uri(wrong_file)] = wrong_content
+	answer_col := main_content.split_into_lines()[8].index('answer') or {
+		assert false, 'expected imported member reference'
+		return
+	}
+
+	location := app.resolve_indexed_definition(main_uri, Position{
+		line: 8
+		char: answer_col + 2
+	}) or {
+		assert false, 'expected real imported module definition'
+		return
+	}
+	assert location.uri == right_uri
+}
+
 fn test_resolve_indexed_definition_ignores_unrelated_workspace_module() {
 	mut app := create_test_app()
 	defer {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -1596,6 +1596,41 @@ fn test_resolve_indexed_definition_defers_destructured_local_shadow() {
 	assert location == none
 }
 
+fn test_resolve_indexed_definition_defers_multiline_destructured_local_shadow() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	test_dir := os.join_path(app.temp_dir, 'indexed_definition_multiline_destructured_shadow')
+	must_mkdir_all(test_dir)
+	test_file := os.join_path(test_dir, 'main.v')
+	content := 'module main\n\nfn key() {}\n\nfn pair() (int, int) {\n\treturn 1, 2\n}\n\nfn main() {\n\tkey,\n\t\tvalue := pair()\n\tprintln(key)\n\tprintln(value)\n}\n'
+	must_write_file(test_file, content)
+	uri := path_to_uri(test_file)
+	app.open_files[uri] = content
+	lines := content.split_into_lines()
+	declaration_col := lines[9].index('key') or {
+		assert false, 'expected first destructured target'
+		return
+	}
+	use_col := lines[11].index('key') or {
+		assert false, 'expected destructured local use'
+		return
+	}
+
+	assert source_occurrence_precedes_local_declaration(lines, 9, declaration_col + 3)
+	for position in [Position{
+		line: 9
+		char: declaration_col + 1
+	}, Position{
+		line: 11
+		char: use_col + 1
+	}] {
+		location := app.resolve_indexed_definition(uri, position)
+		assert location == none
+	}
+}
+
 fn test_resolve_indexed_definition_defers_multiline_for_bindings() {
 	mut app := create_test_app()
 	defer {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -1465,6 +1465,48 @@ fn test_resolve_indexed_definition_defers_destructured_local_shadow() {
 	assert location == none
 }
 
+fn test_resolve_indexed_definition_defers_multiline_for_bindings() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	test_dir := os.join_path(app.temp_dir, 'indexed_definition_multiline_for_binding')
+	must_mkdir_all(test_dir)
+	test_file := os.join_path(test_dir, 'main.v')
+	content := "module main\n\nfn key() {}\nfn value() {}\n\nfn main() {\n\tentries := {'a': 1}\n\tfor key,\n\t\tvalue in entries {\n\t\tprintln(key)\n\t\tprintln(value)\n\t}\n}\n"
+	must_write_file(test_file, content)
+	uri := path_to_uri(test_file)
+	app.open_files[uri] = content
+	lines := content.split_into_lines()
+	key_col := lines[7].index('key') or {
+		assert false, 'expected multiline for key binding'
+		return
+	}
+	value_col := lines[8].index('value') or {
+		assert false, 'expected multiline for value binding'
+		return
+	}
+
+	assert source_occurrence_is_for_binding(lines, 7, key_col, key_col + 3)
+	assert source_occurrence_is_for_binding(lines, 8, value_col, value_col + 5)
+	for position in [Position{
+		line: 7
+		char: key_col + 1
+	}, Position{
+		line: 8
+		char: value_col + 2
+	}, Position{
+		line: 9
+		char: 11
+	}, Position{
+		line: 10
+		char: 11
+	}] {
+		location := app.resolve_indexed_definition(uri, position)
+		assert location == none
+	}
+}
+
 fn test_resolve_indexed_definition_defers_struct_initializer_field() {
 	mut app := create_test_app()
 	defer {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -1175,6 +1175,36 @@ fn test_resolve_indexed_definition_defers_compile_time_at_identifier() {
 	assert location == none
 }
 
+fn test_resolve_indexed_definition_defers_dollar_prefixed_identifiers() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	test_dir := os.join_path(app.temp_dir, 'indexed_definition_compile_time_dollar')
+	must_mkdir_all(test_dir)
+	test_file := os.join_path(test_dir, 'main.v')
+	content := "module main\n\nfn embed_file() {}\nfn tmpl() {}\n\nfn main() {\n\t_ := \$embed_file('asset.txt')\n\t_ := \$tmpl('page.html')\n}\n"
+	must_write_file(test_file, content)
+	uri := path_to_uri(test_file)
+	app.open_files[uri] = content
+	lines := content.split_into_lines()
+
+	for line_idx, symbol in {
+		6: 'embed_file'
+		7: 'tmpl'
+	} {
+		directive_col := lines[line_idx].index(symbol) or {
+			assert false, 'expected dollar-prefixed identifier'
+			return
+		}
+		location := app.resolve_indexed_definition(uri, Position{
+			line: line_idx
+			char: directive_col + 2
+		})
+		assert location == none
+	}
+}
+
 fn test_resolve_indexed_definition_defers_orm_field_reference() {
 	mut app := create_test_app()
 	defer {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -1238,6 +1238,32 @@ fn test_resolve_indexed_definition_defers_method_declaration_name() {
 	assert location == none
 }
 
+fn test_resolve_indexed_definition_defers_multiline_method_declaration_name() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	test_dir := os.join_path(app.temp_dir, 'indexed_definition_multiline_method_declaration')
+	must_mkdir_all(test_dir)
+	test_file := os.join_path(test_dir, 'main.v')
+	content := 'module main\n\nstruct X {}\n\nfn helper() {}\n\nfn (\n\tx X\n) helper() {}\n'
+	must_write_file(test_file, content)
+	uri := path_to_uri(test_file)
+	app.open_files[uri] = content
+	lines := content.split_into_lines()
+	method_col := lines[8].index('helper') or {
+		assert false, 'expected multiline method declaration name'
+		return
+	}
+
+	assert source_occurrence_is_method_declaration(lines, 8, method_col)
+	location := app.resolve_indexed_definition(uri, Position{
+		line: 8
+		char: method_col + 2
+	})
+	assert location == none
+}
+
 fn test_resolve_indexed_definition_defers_interface_method_signature() {
 	mut app := create_test_app()
 	defer {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -1325,17 +1325,17 @@ fn test_resolve_indexed_definition_defers_orm_field_reference() {
 	test_dir := os.join_path(app.temp_dir, 'indexed_definition_orm_field')
 	must_mkdir_all(test_dir)
 	test_file := os.join_path(test_dir, 'main.v')
-	content := 'module main\n\nfn age() {}\n\nfn query() {\n\t_ := sql db {\n\t\tselect from User where age > 21\n\t}\n}\n'
+	content := "module main\n\nfn age() {}\n\nfn query() {\n\ttext := r'foo\\'\n\t_ := sql db {\n\t\tselect from User where age > 21\n\t}\n\tprintln(text)\n}\n"
 	must_write_file(test_file, content)
 	uri := path_to_uri(test_file)
 	app.open_files[uri] = content
-	age_col := content.split_into_lines()[6].index('age') or {
+	age_col := content.split_into_lines()[7].index('age') or {
 		assert false, 'expected ORM field reference'
 		return
 	}
 
 	location := app.resolve_indexed_definition(uri, Position{
-		line: 6
+		line: 7
 		char: age_col + 1
 	})
 	assert location == none
@@ -3409,6 +3409,16 @@ fn test_get_word_at_col_beyond_end() {
 	line := 'fn foo()'
 	word := get_word_at_col(line, 100, .utf16)
 	assert word == ''
+}
+
+fn test_source_line_import_code_closes_raw_string_after_backslash() {
+	mut state := ImportScanState{}
+	code := source_line_import_code("text := r'foo\\'", mut state)
+
+	assert code.trim_space() == 'text :='
+	assert state.quote == 0
+	assert !state.raw_string
+	assert source_line_import_code('sql db {', mut state) == 'sql db {'
 }
 
 fn test_parse_imports_single() {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -932,6 +932,30 @@ fn test_resolve_indexed_definition_defers_local_variable_shadow() {
 	assert location == none
 }
 
+fn test_resolve_indexed_definition_defers_implicit_it_binding() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	test_dir := os.join_path(app.temp_dir, 'indexed_definition_implicit_it')
+	must_mkdir_all(test_dir)
+	test_file := os.join_path(test_dir, 'main.v')
+	content := 'module main\n\nfn it() {}\n\nfn main() {\n\titems := [1, 2]\n\t_ := items.filter(it > 0)\n}\n'
+	must_write_file(test_file, content)
+	uri := path_to_uri(test_file)
+	app.open_files[uri] = content
+	it_col := content.split_into_lines()[6].index('it >') or {
+		assert false, 'expected implicit it reference'
+		return
+	}
+
+	location := app.resolve_indexed_definition(uri, Position{
+		line: 6
+		char: it_col + 1
+	})
+	assert location == none
+}
+
 fn test_resolve_indexed_definition_defers_destructured_local_shadow() {
 	mut app := create_test_app()
 	defer {
@@ -1195,6 +1219,45 @@ fn test_resolve_indexed_definition_ignores_import_in_block_comment() {
 
 	location := app.resolve_indexed_definition(main_uri, Position{
 		line: 8
+		char: answer_col + 2
+	}) or {
+		assert false, 'expected real imported module definition'
+		return
+	}
+	assert location.uri == right_uri
+}
+
+fn test_resolve_indexed_definition_ignores_import_in_multiline_string() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	test_dir := os.join_path(app.temp_dir, 'indexed_definition_string_import')
+	right_dir := os.join_path(test_dir, 'right')
+	wrong_dir := os.join_path(test_dir, 'wrong')
+	must_mkdir_all(right_dir)
+	must_mkdir_all(wrong_dir)
+	main_file := os.join_path(test_dir, 'main.v')
+	right_file := os.join_path(right_dir, 'right.v')
+	wrong_file := os.join_path(wrong_dir, 'wrong.v')
+	main_content := "module main\n\nimport right as util\n\nconst ignored = 'text\nimport wrong as util\n'\n\nfn main() {\n\tutil.answer()\n}\n"
+	right_content := 'module right\n\npub fn answer() {}\n'
+	wrong_content := 'module wrong\n\npub fn answer() {}\n'
+	must_write_file(main_file, main_content)
+	must_write_file(right_file, right_content)
+	must_write_file(wrong_file, wrong_content)
+	main_uri := path_to_uri(main_file)
+	right_uri := path_to_uri(right_file)
+	app.open_files[main_uri] = main_content
+	app.open_files[right_uri] = right_content
+	app.open_files[path_to_uri(wrong_file)] = wrong_content
+	answer_col := main_content.split_into_lines()[9].index('answer') or {
+		assert false, 'expected imported member reference'
+		return
+	}
+
+	location := app.resolve_indexed_definition(main_uri, Position{
+		line: 9
 		char: answer_col + 2
 	}) or {
 		assert false, 'expected real imported module definition'

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -846,6 +846,47 @@ fn test_resolve_indexed_definition_finds_current_file_function() {
 	assert location.range.start.line == 2
 }
 
+fn test_resolve_indexed_definition_rejects_comments_and_string_literals() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	test_dir := os.join_path(app.temp_dir, 'indexed_definition_source_context')
+	must_mkdir_all(test_dir)
+	test_file := os.join_path(test_dir, 'main.v')
+	content := "module main\n\nfn helper() string { return 'ok' }\n\nfn main() {\n\t// helper is mentioned here\n\tliteral := 'helper'\n\tinterpolated := '\${helper()}'\n}\n"
+	must_write_file(test_file, content)
+	uri := path_to_uri(test_file)
+	app.open_files[uri] = content
+	lines := content.split_into_lines()
+
+	for line_idx in [5, 6] {
+		helper_col := lines[line_idx].index('helper') or {
+			assert false, 'expected helper text'
+			return
+		}
+		location := app.resolve_indexed_definition(uri, Position{
+			line: line_idx
+			char: helper_col + 2
+		})
+		assert location == none
+	}
+
+	helper_col := lines[7].index('helper') or {
+		assert false, 'expected interpolated helper reference'
+		return
+	}
+	location := app.resolve_indexed_definition(uri, Position{
+		line: 7
+		char: helper_col + 2
+	}) or {
+		assert false, 'expected indexed definition from string interpolation'
+		return
+	}
+	assert location.uri == uri
+	assert location.range.start.line == 2
+}
+
 fn test_resolve_indexed_definition_uses_unsaved_imported_module() {
 	mut app := create_test_app()
 	defer {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -1166,6 +1166,31 @@ fn test_resolve_indexed_definition_defers_imported_module_qualifier() {
 	assert location == none
 }
 
+fn test_resolve_indexed_definition_defers_builtin_interop_qualifiers() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	test_dir := os.join_path(app.temp_dir, 'indexed_definition_builtin_interop_qualifiers')
+	must_mkdir_all(test_dir)
+	test_file := os.join_path(test_dir, 'main.v')
+	content := 'module main\n\nstruct C {}\nstruct JS {}\n\nfn main() {\n\tC.some_function()\n\tJS.some_function()\n}\n'
+	must_write_file(test_file, content)
+	uri := path_to_uri(test_file)
+	app.open_files[uri] = content
+
+	for position in [Position{
+		line: 6
+		char: 0
+	}, Position{
+		line: 7
+		char: 1
+	}] {
+		location := app.resolve_indexed_definition(uri, position)
+		assert location == none
+	}
+}
+
 fn test_resolve_indexed_definition_defers_grouped_import_module_qualifier() {
 	mut app := create_test_app()
 	defer {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -1004,6 +1004,30 @@ fn test_resolve_indexed_definition_defers_enum_member_declaration() {
 	assert location == none
 }
 
+fn test_resolve_indexed_definition_defers_attribute_identifier() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	test_dir := os.join_path(app.temp_dir, 'indexed_definition_attribute')
+	must_mkdir_all(test_dir)
+	test_file := os.join_path(test_dir, 'main.v')
+	content := "module main\n\nfn deprecated() {}\n\n@[deprecated: 'use replacement']\nfn old() {}\n"
+	must_write_file(test_file, content)
+	uri := path_to_uri(test_file)
+	app.open_files[uri] = content
+	attribute_col := content.split_into_lines()[4].index('deprecated') or {
+		assert false, 'expected attribute identifier'
+		return
+	}
+
+	location := app.resolve_indexed_definition(uri, Position{
+		line: 4
+		char: attribute_col + 2
+	})
+	assert location == none
+}
+
 fn test_resolve_indexed_definition_defers_generic_type_parameter() {
 	mut app := create_test_app()
 	defer {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -1076,6 +1076,54 @@ fn test_resolve_indexed_definition_defers_grouped_import_module_qualifier() {
 	assert location == none
 }
 
+fn test_resolve_indexed_definition_preserves_grouped_import_through_block_comment() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	test_dir := os.join_path(app.temp_dir, 'indexed_definition_grouped_import_comment')
+	must_mkdir_all(test_dir)
+	test_file := os.join_path(test_dir, 'main.v')
+	content := 'module main\n\nimport (\n\t/*\n) still commented\n\t*/\n\tmath as util\n)\n\nfn util() {}\n'
+	must_write_file(test_file, content)
+	uri := path_to_uri(test_file)
+	app.open_files[uri] = content
+	alias_col := content.split_into_lines()[6].index('util') or {
+		assert false, 'expected grouped import alias after block comment'
+		return
+	}
+
+	location := app.resolve_indexed_definition(uri, Position{
+		line: 6
+		char: alias_col + 2
+	})
+	assert location == none
+}
+
+fn test_resolve_indexed_definition_defers_method_declaration_name() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	test_dir := os.join_path(app.temp_dir, 'indexed_definition_method_declaration')
+	must_mkdir_all(test_dir)
+	test_file := os.join_path(test_dir, 'main.v')
+	content := 'module main\n\nstruct X {}\n\nfn helper() {}\n\nfn (x X) helper() {}\n'
+	must_write_file(test_file, content)
+	uri := path_to_uri(test_file)
+	app.open_files[uri] = content
+	method_col := content.split_into_lines()[6].index('helper') or {
+		assert false, 'expected method declaration name'
+		return
+	}
+
+	location := app.resolve_indexed_definition(uri, Position{
+		line: 6
+		char: method_col + 2
+	})
+	assert location == none
+}
+
 fn test_resolve_indexed_definition_defers_generic_type_parameter() {
 	mut app := create_test_app()
 	defer {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -1484,7 +1484,7 @@ fn test_resolve_indexed_definition_defers_orm_field_reference() {
 	test_dir := os.join_path(app.temp_dir, 'indexed_definition_orm_field')
 	must_mkdir_all(test_dir)
 	test_file := os.join_path(test_dir, 'main.v')
-	content := "module main\n\nfn age() {}\n\nfn query() {\n\ttext := r'foo\\'\n\t_ := sql db {\n\t\tselect from User where age > 21\n\t}\n\tprintln(text)\n}\n"
+	content := "module main\n\nfn age() {}\n\nfn query() {\n\ttext := r'foo\\'\n\t_ := sql app.db {\n\t\tselect from User where age > 21\n\t}\n\tprintln(text)\n}\n"
 	must_write_file(test_file, content)
 	uri := path_to_uri(test_file)
 	app.open_files[uri] = content

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -927,6 +927,30 @@ fn test_resolve_indexed_definition_defers_destructured_local_shadow() {
 	assert location == none
 }
 
+fn test_resolve_indexed_definition_defers_struct_initializer_field() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	test_dir := os.join_path(app.temp_dir, 'indexed_definition_struct_field')
+	must_mkdir_all(test_dir)
+	test_file := os.join_path(test_dir, 'main.v')
+	content := 'module main\n\nfn name() {}\n\nfn main() {\n\tvalue := 1\n\t_ := User{name: value}\n}\n'
+	must_write_file(test_file, content)
+	uri := path_to_uri(test_file)
+	app.open_files[uri] = content
+	field_col := content.split_into_lines()[6].index('name') or {
+		assert false, 'expected struct initializer field'
+		return
+	}
+
+	location := app.resolve_indexed_definition(uri, Position{
+		line: 6
+		char: field_col + 2
+	})
+	assert location == none
+}
+
 fn test_resolve_indexed_definition_defers_multiline_parameter_shadow() {
 	mut app := create_test_app()
 	defer {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -887,6 +887,46 @@ fn test_resolve_indexed_definition_rejects_comments_and_string_literals() {
 	assert location.range.start.line == 2
 }
 
+fn test_resolve_indexed_definition_defers_local_variable_shadow() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	test_dir := os.join_path(app.temp_dir, 'indexed_definition_local_shadow')
+	must_mkdir_all(test_dir)
+	test_file := os.join_path(test_dir, 'main.v')
+	content := 'module main\n\nfn helper() {}\n\nfn main() {\n\thelper := 1\n\tprintln(helper)\n}\n'
+	must_write_file(test_file, content)
+	uri := path_to_uri(test_file)
+	app.open_files[uri] = content
+
+	location := app.resolve_indexed_definition(uri, Position{
+		line: 6
+		char: 11
+	})
+	assert location == none
+}
+
+fn test_resolve_indexed_definition_defers_multiline_parameter_shadow() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	test_dir := os.join_path(app.temp_dir, 'indexed_definition_parameter_shadow')
+	must_mkdir_all(test_dir)
+	test_file := os.join_path(test_dir, 'main.v')
+	content := 'module main\n\nfn helper() {}\n\nfn use(\n\thelper int,\n) {\n\tprintln(helper)\n}\n'
+	must_write_file(test_file, content)
+	uri := path_to_uri(test_file)
+	app.open_files[uri] = content
+
+	location := app.resolve_indexed_definition(uri, Position{
+		line: 7
+		char: 11
+	})
+	assert location == none
+}
+
 fn test_resolve_indexed_definition_uses_unsaved_imported_module() {
 	mut app := create_test_app()
 	defer {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -947,6 +947,30 @@ fn test_resolve_indexed_definition_rejects_multiline_string_continuations() {
 	assert location == none
 }
 
+fn test_resolve_indexed_definition_rejects_rune_literals() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	test_dir := os.join_path(app.temp_dir, 'indexed_definition_rune_literal')
+	must_mkdir_all(test_dir)
+	test_file := os.join_path(test_dir, 'main.v')
+	content := 'module main\n\nfn f() {}\n\nfn main() {\n\tch := `f`\n\tprintln(ch)\n}\n'
+	must_write_file(test_file, content)
+	uri := path_to_uri(test_file)
+	app.open_files[uri] = content
+	f_col := content.split_into_lines()[5].index('f') or {
+		assert false, 'expected rune literal'
+		return
+	}
+
+	location := app.resolve_indexed_definition(uri, Position{
+		line: 5
+		char: f_col
+	})
+	assert location == none
+}
+
 fn test_resolve_indexed_definition_defers_module_and_import_declarations() {
 	mut app := create_test_app()
 	defer {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -1269,6 +1269,27 @@ fn test_resolve_indexed_definition_defers_compile_time_declaration() {
 	assert location == none
 }
 
+fn test_resolve_indexed_definition_defers_compile_time_declaration_after_multiline_string() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	test_dir := os.join_path(app.temp_dir, 'indexed_definition_compile_time_multiline_string')
+	must_mkdir_all(test_dir)
+	main_file := os.join_path(test_dir, 'main.v')
+	inactive_branch := $if windows { r'$if linux {' } $else { r'$if windows {' }
+	main_content := "module main\n\n${inactive_branch}\n\tconst message = 'first\n}\nlast'\n\tfn helper() {}\n}\n\nfn main() {\n\thelper()\n}\n"
+	must_write_file(main_file, main_content)
+	main_uri := path_to_uri(main_file)
+	app.open_files[main_uri] = main_content
+
+	location := app.resolve_indexed_definition(main_uri, Position{
+		line: 10
+		char: 3
+	})
+	assert location == none
+}
+
 fn test_resolve_indexed_definition_excludes_block_comment_declaration() {
 	mut app := create_test_app()
 	defer {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -1124,17 +1124,19 @@ fn test_resolve_indexed_definition_defers_attribute_identifier() {
 	test_dir := os.join_path(app.temp_dir, 'indexed_definition_attribute')
 	must_mkdir_all(test_dir)
 	test_file := os.join_path(test_dir, 'main.v')
-	content := "module main\n\nfn deprecated() {}\n\n@[deprecated: 'use replacement']\nfn old() {}\n"
+	content := "module main\n\nfn deprecated() {}\n\nconst text = r'ends\\'\n\n@[deprecated: 'use replacement']\nfn old() {}\n"
 	must_write_file(test_file, content)
 	uri := path_to_uri(test_file)
 	app.open_files[uri] = content
-	attribute_col := content.split_into_lines()[4].index('deprecated') or {
+	lines := content.split_into_lines()
+	attribute_col := lines[6].index('deprecated') or {
 		assert false, 'expected attribute identifier'
 		return
 	}
 
+	assert source_occurrence_is_attribute(lines, 6, attribute_col)
 	location := app.resolve_indexed_definition(uri, Position{
-		line: 4
+		line: 6
 		char: attribute_col + 2
 	})
 	assert location == none

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -1151,6 +1151,30 @@ fn test_resolve_indexed_definition_defers_interface_method_signature() {
 	}
 }
 
+fn test_resolve_indexed_definition_defers_compile_time_at_identifier() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	test_dir := os.join_path(app.temp_dir, 'indexed_definition_compile_time_at')
+	must_mkdir_all(test_dir)
+	test_file := os.join_path(test_dir, 'main.v')
+	content := 'module main\n\nstruct FN {}\n\nfn main() {\n\tprintln(@FN)\n}\n'
+	must_write_file(test_file, content)
+	uri := path_to_uri(test_file)
+	app.open_files[uri] = content
+	macro_col := content.split_into_lines()[5].index('FN') or {
+		assert false, 'expected compile-time @ identifier'
+		return
+	}
+
+	location := app.resolve_indexed_definition(uri, Position{
+		line: 5
+		char: macro_col + 1
+	})
+	assert location == none
+}
+
 fn test_resolve_indexed_definition_defers_generic_type_parameter() {
 	mut app := create_test_app()
 	defer {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -947,6 +947,28 @@ fn test_resolve_indexed_definition_defers_multiline_parameter_shadow() {
 	assert location == none
 }
 
+fn test_resolve_indexed_definition_excludes_inactive_platform_file() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	test_dir := os.join_path(app.temp_dir, 'indexed_definition_inactive_platform')
+	must_mkdir_all(test_dir)
+	main_file := os.join_path(test_dir, 'main.v')
+	inactive_file_name := $if windows { 'helper_linux.v' } $else { 'helper_windows.v' }
+	main_content := 'module main\n\nfn main() {\n\thelper()\n}\n'
+	must_write_file(main_file, main_content)
+	must_write_file(os.join_path(test_dir, inactive_file_name), 'module main\n\nfn helper() {}\n')
+	main_uri := path_to_uri(main_file)
+	app.open_files[main_uri] = main_content
+
+	location := app.resolve_indexed_definition(main_uri, Position{
+		line: 3
+		char: 3
+	})
+	assert location == none
+}
+
 fn test_resolve_indexed_definition_uses_unsaved_imported_module() {
 	mut app := create_test_app()
 	defer {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -969,6 +969,27 @@ fn test_resolve_indexed_definition_excludes_inactive_platform_file() {
 	assert location == none
 }
 
+fn test_resolve_indexed_definition_defers_compile_time_declaration() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	test_dir := os.join_path(app.temp_dir, 'indexed_definition_compile_time_branch')
+	must_mkdir_all(test_dir)
+	main_file := os.join_path(test_dir, 'main.v')
+	inactive_branch := $if windows { r'$if linux {' } $else { r'$if windows {' }
+	main_content := 'module main\n\n${inactive_branch}\n\tfn helper() {}\n}\n\nfn main() {\n\thelper()\n}\n'
+	must_write_file(main_file, main_content)
+	main_uri := path_to_uri(main_file)
+	app.open_files[main_uri] = main_content
+
+	location := app.resolve_indexed_definition(main_uri, Position{
+		line: 7
+		char: 3
+	})
+	assert location == none
+}
+
 fn test_resolve_indexed_definition_excludes_different_module_sibling() {
 	mut app := create_test_app()
 	defer {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -971,6 +971,34 @@ fn test_resolve_indexed_definition_rejects_rune_literals() {
 	assert location == none
 }
 
+fn test_resolve_indexed_definition_accepts_multiline_string_interpolations() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	test_dir := os.join_path(app.temp_dir, 'indexed_definition_multiline_interpolation')
+	must_mkdir_all(test_dir)
+	test_file := os.join_path(test_dir, 'main.v')
+	content := "module main\n\nfn helper() string { return 'ok' }\n\nfn main() {\n\ttext := 'result \${\n\t\thelper()\n\t}'\n\tprintln(text)\n}\n"
+	must_write_file(test_file, content)
+	uri := path_to_uri(test_file)
+	app.open_files[uri] = content
+	helper_col := content.split_into_lines()[6].index('helper') or {
+		assert false, 'expected multiline interpolation reference'
+		return
+	}
+
+	location := app.resolve_indexed_definition(uri, Position{
+		line: 6
+		char: helper_col + 2
+	}) or {
+		assert false, 'expected indexed multiline interpolation definition'
+		return
+	}
+	assert location.uri == uri
+	assert location.range.start.line == 2
+}
+
 fn test_resolve_indexed_definition_defers_module_and_import_declarations() {
 	mut app := create_test_app()
 	defer {
@@ -5618,6 +5646,16 @@ fn test_document_highlight_candidates_include_braced_string_interpolations() {
 	assert candidates[0].line_idx == 0
 	assert candidates[1].line_idx == 1
 	assert collect_document_highlight_candidates(content, lines, 'literal_name', .utf16).len == 0
+}
+
+fn test_document_highlight_candidates_include_multiline_string_interpolations() {
+	content := "fn greet(name string) {\n\tprintln('hello \${\n\t\tname\n\t}')\n}\n"
+	lines := content.split_into_lines()
+
+	candidates := collect_document_highlight_candidates(content, lines, 'name', .utf16)
+	assert candidates.len == 2
+	assert candidates[0].line_idx == 0
+	assert candidates[1].line_idx == 2
 }
 
 fn test_document_highlight_returns_empty_over_semantic_cap() {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -1124,6 +1124,33 @@ fn test_resolve_indexed_definition_defers_method_declaration_name() {
 	assert location == none
 }
 
+fn test_resolve_indexed_definition_defers_interface_method_signature() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	test_dir := os.join_path(app.temp_dir, 'indexed_definition_interface_method')
+	must_mkdir_all(test_dir)
+	test_file := os.join_path(test_dir, 'main.v')
+	content := 'module main\n\nfn read() {}\n\ninterface Reader {\n\tread()\n}\n\ninterface Writer { read() }\n'
+	must_write_file(test_file, content)
+	uri := path_to_uri(test_file)
+	app.open_files[uri] = content
+	lines := content.split_into_lines()
+
+	for line_idx in [5, 8] {
+		method_col := lines[line_idx].index('read') or {
+			assert false, 'expected interface method signature'
+			return
+		}
+		location := app.resolve_indexed_definition(uri, Position{
+			line: line_idx
+			char: method_col + 2
+		})
+		assert location == none
+	}
+}
+
 fn test_resolve_indexed_definition_defers_generic_type_parameter() {
 	mut app := create_test_app()
 	defer {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -1620,6 +1620,28 @@ fn test_resolve_indexed_definition_defers_compile_time_declaration_after_multili
 	assert location == none
 }
 
+fn test_resolve_indexed_definition_defers_compile_time_declaration_after_raw_string() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	test_dir := os.join_path(app.temp_dir, 'indexed_definition_compile_time_raw_string')
+	must_mkdir_all(test_dir)
+	main_file := os.join_path(test_dir, 'main.v')
+	inactive_branch := $if windows { r'$if linux {' } $else { r'$if windows {' }
+	main_content := "module main\n\nconst text = r'ends\\'\n\n${inactive_branch}\n\tfn helper() {}\n}\n\nfn main() {\n\thelper()\n}\n"
+	must_write_file(main_file, main_content)
+	main_uri := path_to_uri(main_file)
+	app.open_files[main_uri] = main_content
+
+	assert source_declaration_is_compile_time_conditional(main_content, 5)
+	location := app.resolve_indexed_definition(main_uri, Position{
+		line: 9
+		char: 3
+	})
+	assert location == none
+}
+
 fn test_resolve_indexed_definition_excludes_block_comment_declaration() {
 	mut app := create_test_app()
 	defer {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -1800,6 +1800,28 @@ fn test_resolve_indexed_definition_defers_compile_time_declaration() {
 	assert location == none
 }
 
+fn test_resolve_indexed_definition_defers_conditional_attribute_declaration() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	test_dir := os.join_path(app.temp_dir, 'indexed_definition_conditional_attribute')
+	must_mkdir_all(test_dir)
+	main_file := os.join_path(test_dir, 'main.v')
+	inactive_condition := $if windows { 'linux' } $else { 'windows' }
+	main_content := 'module main\n\n@[if ${inactive_condition}]\nfn helper() {}\n\nfn main() {\n\thelper()\n}\n'
+	must_write_file(main_file, main_content)
+	main_uri := path_to_uri(main_file)
+	app.open_files[main_uri] = main_content
+
+	assert source_declaration_is_compile_time_conditional(main_content, 3)
+	location := app.resolve_indexed_definition(main_uri, Position{
+		line: 6
+		char: 3
+	})
+	assert location == none
+}
+
 fn test_resolve_indexed_definition_defers_compile_time_declaration_after_multiline_string() {
 	mut app := create_test_app()
 	defer {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -1820,7 +1820,7 @@ fn test_resolve_indexed_definition_ignores_import_in_multiline_string() {
 	main_file := os.join_path(test_dir, 'main.v')
 	right_file := os.join_path(right_dir, 'right.v')
 	wrong_file := os.join_path(wrong_dir, 'wrong.v')
-	main_content := "module main\n\nimport right as util\n\nconst ignored = 'text\nimport wrong as util\n'\n\nfn main() {\n\tutil.answer()\n}\n"
+	main_content := "module main\n\nimport right as util\n\nconst ignored = 'text \${\n\t'import wrong as util'\n}'\n\nfn main() {\n\tutil.answer()\n}\n"
 	right_content := 'module right\n\npub fn answer() {}\n'
 	wrong_content := 'module wrong\n\npub fn answer() {}\n'
 	must_write_file(main_file, main_content)
@@ -3469,6 +3469,19 @@ fn test_source_line_import_code_closes_raw_string_after_backslash() {
 	assert state.quote == 0
 	assert !state.raw_string
 	assert source_line_import_code('sql db {', mut state) == 'sql db {'
+}
+
+fn test_source_line_import_code_preserves_multiline_interpolation_mode() {
+	mut state := ImportScanState{}
+	start := source_line_import_code("text := 'value \${", mut state)
+	nested := source_line_import_code("\t'import wrong as util'", mut state)
+	end := source_line_import_code("}'", mut state)
+
+	assert start.trim_space() == 'text :='
+	assert nested.trim_space() == ''
+	assert end.trim_space() == ''
+	assert state.quote == 0
+	assert state.interpolations.len == 0
 }
 
 fn test_parse_imports_single() {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -1905,7 +1905,7 @@ fn test_resolve_indexed_definition_uses_unsaved_imported_module() {
 	assert location.range.start.line == 3
 }
 
-fn test_resolve_indexed_definition_ignores_import_in_block_comment() {
+fn test_resolve_indexed_definition_ignores_import_in_nested_block_comment() {
 	mut app := create_test_app()
 	defer {
 		cleanup_test_app(app)
@@ -1918,7 +1918,7 @@ fn test_resolve_indexed_definition_ignores_import_in_block_comment() {
 	main_file := os.join_path(test_dir, 'main.v')
 	right_file := os.join_path(right_dir, 'right.v')
 	wrong_file := os.join_path(wrong_dir, 'wrong.v')
-	main_content := 'module main\n\nimport right as util\n/*\nimport wrong as util\n*/\n\nfn main() {\n\tutil.answer()\n}\n'
+	main_content := 'module main\n\nimport right as util\n/* outer\n\t/* inner */\nimport wrong as util\n*/\n\nfn main() {\n\tutil.answer()\n}\n'
 	right_content := 'module right\n\npub fn answer() {}\n'
 	wrong_content := 'module wrong\n\npub fn answer() {}\n'
 	must_write_file(main_file, main_content)
@@ -1929,13 +1929,13 @@ fn test_resolve_indexed_definition_ignores_import_in_block_comment() {
 	app.open_files[main_uri] = main_content
 	app.open_files[right_uri] = right_content
 	app.open_files[path_to_uri(wrong_file)] = wrong_content
-	answer_col := main_content.split_into_lines()[8].index('answer') or {
+	answer_col := main_content.split_into_lines()[9].index('answer') or {
 		assert false, 'expected imported member reference'
 		return
 	}
 
 	location := app.resolve_indexed_definition(main_uri, Position{
-		line: 8
+		line: 9
 		char: answer_col + 2
 	}) or {
 		assert false, 'expected real imported module definition'
@@ -3606,6 +3606,20 @@ fn test_source_line_import_code_closes_raw_string_after_backslash() {
 	assert state.quote == 0
 	assert !state.raw_string
 	assert source_line_import_code('sql db {', mut state) == 'sql db {'
+}
+
+fn test_source_line_import_code_tracks_nested_block_comments() {
+	mut state := ImportScanState{}
+	outer := source_line_import_code('before /* outer', mut state)
+	inner := source_line_import_code('/* inner */', mut state)
+	commented := source_line_import_code('import wrong as util', mut state)
+	after := source_line_import_code('*/ import right as util', mut state)
+
+	assert outer.trim_space() == 'before'
+	assert inner.trim_space() == ''
+	assert commented.trim_space() == ''
+	assert after.trim_space() == 'import right as util'
+	assert state.block_comment_depth == 0
 }
 
 fn test_source_line_import_code_preserves_multiline_interpolation_mode() {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -969,6 +969,30 @@ fn test_resolve_indexed_definition_excludes_inactive_platform_file() {
 	assert location == none
 }
 
+fn test_resolve_indexed_definition_excludes_different_module_sibling() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	test_dir := os.join_path(app.temp_dir, 'indexed_definition_different_module')
+	must_mkdir_all(test_dir)
+	main_file := os.join_path(test_dir, 'main.v')
+	sibling_file := os.join_path(test_dir, 'sibling.v')
+	main_content := 'module bar\n\nfn main() {\n\thelper()\n}\n'
+	must_write_file(main_file, main_content)
+	must_write_file(sibling_file, 'module bar\n')
+	main_uri := path_to_uri(main_file)
+	sibling_uri := path_to_uri(sibling_file)
+	app.open_files[main_uri] = main_content
+	app.open_files[sibling_uri] = 'module main\n\nfn helper() {}\n'
+
+	location := app.resolve_indexed_definition(main_uri, Position{
+		line: 3
+		char: 3
+	})
+	assert location == none
+}
+
 fn test_resolve_indexed_definition_uses_unsaved_imported_module() {
 	mut app := create_test_app()
 	defer {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -970,6 +970,64 @@ fn test_resolve_indexed_definition_rejects_declaration_in_nested_block_comment()
 	assert location == none
 }
 
+fn test_resolve_indexed_definition_defers_inline_assembly_identifiers() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	test_dir := os.join_path(app.temp_dir, 'indexed_definition_inline_assembly')
+	must_mkdir_all(test_dir)
+	test_file := os.join_path(test_dir, 'main.v')
+	content := 'module main\n\nfn mov() {}\n\nfn main() {\n\tasm amd64 { mov rax, 1 }\n}\n'
+	must_write_file(test_file, content)
+	uri := path_to_uri(test_file)
+	app.open_files[uri] = content
+	mov_col := content.split_into_lines()[5].index('mov') or {
+		assert false, 'expected assembly mnemonic'
+		return
+	}
+
+	location := app.resolve_indexed_definition(uri, Position{
+		line: 5
+		char: mov_col + 1
+	})
+	assert location == none
+}
+
+fn test_resolve_indexed_definition_defers_hash_directive_contents() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	test_dir := os.join_path(app.temp_dir, 'indexed_definition_hash_directive')
+	must_mkdir_all(test_dir)
+	test_file := os.join_path(test_dir, 'main.v')
+	content := 'module main\n\n#include <helper.h>\n#flag -l library\n\nfn helper() {}\nfn library() {}\n'
+	must_write_file(test_file, content)
+	uri := path_to_uri(test_file)
+	app.open_files[uri] = content
+	lines := content.split_into_lines()
+	helper_col := lines[2].index('helper') or {
+		assert false, 'expected include header'
+		return
+	}
+	library_col := lines[3].index('library') or {
+		assert false, 'expected flag argument'
+		return
+	}
+
+	header_location := app.resolve_indexed_definition(uri, Position{
+		line: 2
+		char: helper_col + 2
+	})
+	assert header_location == none
+	flag_location := app.resolve_indexed_definition(uri, Position{
+		line: 3
+		char: library_col + 2
+	})
+	assert flag_location == none
+}
+
 fn test_resolve_indexed_definition_rejects_multiline_string_continuations() {
 	mut app := create_test_app()
 	defer {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -822,6 +822,114 @@ fn test_operation_at_pos_definition_line_info() {
 	assert loc.range.start.line == 2
 }
 
+fn test_resolve_indexed_definition_finds_current_file_function() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	test_dir := os.join_path(app.temp_dir, 'indexed_definition_current')
+	must_mkdir_all(test_dir)
+	test_file := os.join_path(test_dir, 'main.v')
+	content := 'module main\n\nfn helper() {}\n\nfn main() {\n\thelper()\n}\n'
+	must_write_file(test_file, content)
+	uri := path_to_uri(test_file)
+	app.open_files[uri] = content
+
+	location := app.resolve_indexed_definition(uri, Position{
+		line: 5
+		char: 2
+	}) or {
+		assert false, 'expected indexed definition'
+		return
+	}
+	assert location.uri == uri
+	assert location.range.start.line == 2
+}
+
+fn test_resolve_indexed_definition_uses_unsaved_imported_module() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	test_dir := os.join_path(app.temp_dir, 'indexed_definition_import')
+	module_dir := os.join_path(test_dir, 'mathutil')
+	must_mkdir_all(module_dir)
+	main_file := os.join_path(test_dir, 'main.v')
+	module_file := os.join_path(module_dir, 'mathutil.v')
+	main_content := 'module main\n\nimport mathutil\n\nfn main() {\n\tmathutil.answer()\n}\n'
+	module_content := 'module mathutil\n\n// answer is not saved yet.\npub fn answer() int {\n\treturn 42\n}\n'
+	must_write_file(main_file, main_content)
+	must_write_file(module_file, 'module mathutil\n')
+	main_uri := path_to_uri(main_file)
+	module_uri := path_to_uri(module_file)
+	app.open_files[main_uri] = main_content
+	app.open_files[module_uri] = module_content
+
+	location := app.resolve_indexed_definition(main_uri, Position{
+		line: 5
+		char: 12
+	}) or {
+		assert false, 'expected imported indexed definition'
+		return
+	}
+	assert location.uri == module_uri
+	assert location.range.start.line == 3
+}
+
+fn test_resolve_indexed_definition_prefers_workspace_vlib() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	root := os.join_path(app.temp_dir, 'indexed_definition_workspace_vlib')
+	main_dir := os.join_path(root, 'cmd', 'tool')
+	module_dir := os.join_path(root, 'vlib', 'v', 'builder')
+	must_mkdir_all(main_dir)
+	must_mkdir_all(module_dir)
+	must_write_file(os.join_path(root, 'v.mod'), 'Module {}\n')
+	main_file := os.join_path(main_dir, 'main.v')
+	module_file := os.join_path(module_dir, 'compile.v')
+	main_content := 'module main\n\nimport v.builder\n\nfn main() {\n\tbuilder.compile()\n}\n'
+	module_content := 'module builder\n\npub fn compile() {}\n'
+	must_write_file(main_file, main_content)
+	must_write_file(module_file, module_content)
+	main_uri := path_to_uri(main_file)
+	module_uri := path_to_uri(module_file)
+	app.open_files[main_uri] = main_content
+	app.open_files[module_uri] = module_content
+	app.workspace_roots = [root]
+
+	location := app.resolve_indexed_definition(main_uri, Position{
+		line: 5
+		char: 12
+	}) or {
+		assert false, 'expected workspace vlib definition'
+		return
+	}
+	assert location.uri == module_uri
+	assert location.range.start.line == 2
+}
+
+fn test_resolve_indexed_definition_defers_receiver_method() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	test_dir := os.join_path(app.temp_dir, 'indexed_definition_receiver')
+	must_mkdir_all(test_dir)
+	test_file := os.join_path(test_dir, 'main.v')
+	content := 'module main\n\nstruct Item {}\n\nfn (item Item) answer() {}\n\nfn main() {\n\titem := Item{}\n\titem.answer()\n}\n'
+	must_write_file(test_file, content)
+	uri := path_to_uri(test_file)
+	app.open_files[uri] = content
+
+	location := app.resolve_indexed_definition(uri, Position{
+		line: 8
+		char: 8
+	})
+	assert location == none
+}
+
 fn test_operation_at_pos_signature_help_line_info() {
 	mut app := create_test_app()
 	defer {
@@ -1268,7 +1376,7 @@ fn test_app_cur_mod_default() {
 
 fn test_app_exit_flag_default() {
 	app := App{}
-	app.exit
+	assert app.exit == os.args.contains('exit')
 }
 
 fn test_v_error_to_lsp_diagnostic_basic() {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -907,6 +907,26 @@ fn test_resolve_indexed_definition_defers_local_variable_shadow() {
 	assert location == none
 }
 
+fn test_resolve_indexed_definition_defers_destructured_local_shadow() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	test_dir := os.join_path(app.temp_dir, 'indexed_definition_destructured_shadow')
+	must_mkdir_all(test_dir)
+	test_file := os.join_path(test_dir, 'main.v')
+	content := 'module main\n\nfn helper() {}\n\nfn make_value() (int, int) {\n\treturn 1, 2\n}\n\nfn main() {\n\thelper, err := make_value()\n\tprintln(helper)\n\tprintln(err)\n}\n'
+	must_write_file(test_file, content)
+	uri := path_to_uri(test_file)
+	app.open_files[uri] = content
+
+	location := app.resolve_indexed_definition(uri, Position{
+		line: 10
+		char: 11
+	})
+	assert location == none
+}
+
 fn test_resolve_indexed_definition_defers_multiline_parameter_shadow() {
 	mut app := create_test_app()
 	defer {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -887,6 +887,31 @@ fn test_resolve_indexed_definition_rejects_comments_and_string_literals() {
 	assert location.range.start.line == 2
 }
 
+fn test_resolve_indexed_definition_defers_module_and_import_declarations() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	test_dir := os.join_path(app.temp_dir, 'indexed_definition_declarations')
+	must_mkdir_all(test_dir)
+	test_file := os.join_path(test_dir, 'main.v')
+	content := 'module main\n\nimport helper\n\nfn main() {}\nfn helper() {}\n'
+	must_write_file(test_file, content)
+	uri := path_to_uri(test_file)
+	app.open_files[uri] = content
+
+	module_location := app.resolve_indexed_definition(uri, Position{
+		line: 0
+		char: 8
+	})
+	assert module_location == none
+	import_location := app.resolve_indexed_definition(uri, Position{
+		line: 2
+		char: 9
+	})
+	assert import_location == none
+}
+
 fn test_resolve_indexed_definition_defers_local_variable_shadow() {
 	mut app := create_test_app()
 	defer {
@@ -1086,6 +1111,37 @@ fn test_resolve_indexed_definition_uses_unsaved_imported_module() {
 	}
 	assert location.uri == module_uri
 	assert location.range.start.line == 3
+}
+
+fn test_resolve_indexed_definition_ignores_unrelated_workspace_module() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	root_a := os.join_path(app.temp_dir, 'indexed_definition_workspace_a')
+	root_b := os.join_path(app.temp_dir, 'indexed_definition_workspace_b')
+	module_name := 'vls_unrelated_module'
+	module_dir := os.join_path(root_b, module_name)
+	must_mkdir_all(root_a)
+	must_mkdir_all(module_dir)
+	must_write_file(os.join_path(root_a, 'v.mod'), 'Module {}\n')
+	main_file := os.join_path(root_a, 'main.v')
+	module_file := os.join_path(module_dir, '${module_name}.v')
+	main_content := 'module main\n\nimport ${module_name}\n\nfn main() {\n\t${module_name}.answer()\n}\n'
+	module_content := 'module ${module_name}\n\npub fn answer() {}\n'
+	must_write_file(main_file, main_content)
+	must_write_file(module_file, module_content)
+	main_uri := path_to_uri(main_file)
+	module_uri := path_to_uri(module_file)
+	app.open_files[main_uri] = main_content
+	app.open_files[module_uri] = module_content
+	app.workspace_roots = [root_a, root_b]
+
+	location := app.resolve_indexed_definition(main_uri, Position{
+		line: 5
+		char: module_name.len + 2
+	})
+	assert location == none
 }
 
 fn test_resolve_indexed_definition_prefers_workspace_vlib() {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -976,6 +976,33 @@ fn test_resolve_indexed_definition_defers_struct_initializer_field() {
 	assert location == none
 }
 
+fn test_resolve_indexed_definition_defers_goto_label() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	test_dir := os.join_path(app.temp_dir, 'indexed_definition_goto_label')
+	must_mkdir_all(test_dir)
+	test_file := os.join_path(test_dir, 'main.v')
+	content := 'module main\n\nfn retry() {}\n\nfn main() {\n\tgoto retry\n\tretry:\n\treturn\n}\n'
+	must_write_file(test_file, content)
+	uri := path_to_uri(test_file)
+	app.open_files[uri] = content
+	lines := content.split_into_lines()
+
+	for line_idx in [5, 6] {
+		retry_col := lines[line_idx].index('retry') or {
+			assert false, 'expected goto label'
+			return
+		}
+		location := app.resolve_indexed_definition(uri, Position{
+			line: line_idx
+			char: retry_col + 2
+		})
+		assert location == none
+	}
+}
+
 fn test_resolve_indexed_definition_defers_multiline_parameter_shadow() {
 	mut app := create_test_app()
 	defer {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -922,6 +922,31 @@ fn test_resolve_indexed_definition_rejects_comments_and_string_literals() {
 	assert location.range.start.line == 2
 }
 
+fn test_resolve_indexed_definition_rejects_multiline_string_continuations() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	test_dir := os.join_path(app.temp_dir, 'indexed_definition_multiline_string')
+	must_mkdir_all(test_dir)
+	test_file := os.join_path(test_dir, 'main.v')
+	content := "module main\n\nfn helper() string { return 'ok' }\n\nfn main() {\n\ttext := 'first\nhelper\nlast'\n\tprintln(text)\n}\n"
+	must_write_file(test_file, content)
+	uri := path_to_uri(test_file)
+	app.open_files[uri] = content
+	lines := content.split_into_lines()
+	helper_col := lines[6].index('helper') or {
+		assert false, 'expected helper text in multiline string'
+		return
+	}
+
+	location := app.resolve_indexed_definition(uri, Position{
+		line: 6
+		char: helper_col + 2
+	})
+	assert location == none
+}
+
 fn test_resolve_indexed_definition_defers_module_and_import_declarations() {
 	mut app := create_test_app()
 	defer {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -1003,6 +1003,30 @@ fn test_resolve_indexed_definition_defers_goto_label() {
 	}
 }
 
+fn test_resolve_indexed_definition_defers_compile_time_condition() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	test_dir := os.join_path(app.temp_dir, 'indexed_definition_compile_time_condition')
+	must_mkdir_all(test_dir)
+	test_file := os.join_path(test_dir, 'main.v')
+	content := 'module main\n\nfn windows() {}\n\n$if windows {\n\tfn active() {}\n}\n'
+	must_write_file(test_file, content)
+	uri := path_to_uri(test_file)
+	app.open_files[uri] = content
+	condition_col := content.split_into_lines()[4].index('windows') or {
+		assert false, 'expected compile-time condition'
+		return
+	}
+
+	location := app.resolve_indexed_definition(uri, Position{
+		line: 4
+		char: condition_col + 2
+	})
+	assert location == none
+}
+
 fn test_resolve_indexed_definition_defers_multiline_parameter_shadow() {
 	mut app := create_test_app()
 	defer {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -1028,6 +1028,30 @@ fn test_resolve_indexed_definition_defers_attribute_identifier() {
 	assert location == none
 }
 
+fn test_resolve_indexed_definition_defers_imported_module_qualifier() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	test_dir := os.join_path(app.temp_dir, 'indexed_definition_module_qualifier')
+	must_mkdir_all(test_dir)
+	test_file := os.join_path(test_dir, 'main.v')
+	content := 'module main\n\nimport math as util\n\nfn util() {}\n\nfn main() {\n\t_ := util.sin(0.0)\n}\n'
+	must_write_file(test_file, content)
+	uri := path_to_uri(test_file)
+	app.open_files[uri] = content
+	qualifier_col := content.split_into_lines()[7].index('util') or {
+		assert false, 'expected imported module qualifier'
+		return
+	}
+
+	location := app.resolve_indexed_definition(uri, Position{
+		line: 7
+		char: qualifier_col + 2
+	})
+	assert location == none
+}
+
 fn test_resolve_indexed_definition_defers_generic_type_parameter() {
 	mut app := create_test_app()
 	defer {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -1111,6 +1111,47 @@ fn test_resolve_indexed_definition_defers_generic_type_parameter() {
 	}
 }
 
+fn test_resolve_indexed_definition_defers_multiline_generic_type_parameter() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	test_dir := os.join_path(app.temp_dir, 'indexed_definition_multiline_generic_parameter')
+	must_mkdir_all(test_dir)
+	test_file := os.join_path(test_dir, 'main.v')
+	content := 'module main\n\nstruct T {}\n\nfn identity[\n\tT\n](value T) T {\n\treturn value\n}\n'
+	must_write_file(test_file, content)
+	uri := path_to_uri(test_file)
+	app.open_files[uri] = content
+	lines := content.split_into_lines()
+	declaration_col := lines[5].index('T') or {
+		assert false, 'expected multiline generic parameter declaration'
+		return
+	}
+	value_col := lines[6].index('value T') or {
+		assert false, 'expected multiline generic parameter type'
+		return
+	}
+	return_col := lines[6].last_index('T {') or {
+		assert false, 'expected multiline generic return type'
+		return
+	}
+
+	for position in [Position{
+		line: 5
+		char: declaration_col
+	}, Position{
+		line: 6
+		char: value_col + 6
+	}, Position{
+		line: 6
+		char: return_col
+	}] {
+		location := app.resolve_indexed_definition(uri, position)
+		assert location == none
+	}
+}
+
 fn test_resolve_indexed_definition_defers_destructured_local_shadow() {
 	mut app := create_test_app()
 	defer {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -889,13 +889,13 @@ fn test_resolve_indexed_definition_rejects_comments_and_string_literals() {
 	test_dir := os.join_path(app.temp_dir, 'indexed_definition_source_context')
 	must_mkdir_all(test_dir)
 	test_file := os.join_path(test_dir, 'main.v')
-	content := "module main\n\nfn helper() string { return 'ok' }\n\nfn main() {\n\t// helper is mentioned here\n\tliteral := 'helper'\n\tinterpolated := '\${helper()}'\n}\n"
+	content := "module main\n\nfn helper() string { return 'ok' }\n\nfn main() {\n\t// helper is mentioned here\n\tliteral := 'helper'\n\tplain_dollar := '\$helper'\n\traw := r'\$helper'\n\tinterpolated := '\${helper()}'\n}\n"
 	must_write_file(test_file, content)
 	uri := path_to_uri(test_file)
 	app.open_files[uri] = content
 	lines := content.split_into_lines()
 
-	for line_idx in [5, 6] {
+	for line_idx in [5, 6, 7, 8] {
 		helper_col := lines[line_idx].index('helper') or {
 			assert false, 'expected helper text'
 			return
@@ -907,12 +907,12 @@ fn test_resolve_indexed_definition_rejects_comments_and_string_literals() {
 		assert location == none
 	}
 
-	helper_col := lines[7].index('helper') or {
+	helper_col := lines[9].index('helper') or {
 		assert false, 'expected interpolated helper reference'
 		return
 	}
 	location := app.resolve_indexed_definition(uri, Position{
-		line: 7
+		line: 9
 		char: helper_col + 2
 	}) or {
 		assert false, 'expected indexed definition from string interpolation'
@@ -5609,15 +5609,14 @@ fn test_classify_highlight_kind_read_write() {
 	assert classify_highlight_kind('for item in items {}', 12, 17) == doc_highlight_read
 }
 
-fn test_document_highlight_candidates_include_string_interpolations() {
+fn test_document_highlight_candidates_include_braced_string_interpolations() {
 	content := "fn greet(name string) {\n\tprintln('hello \${name} \$name literal_name')\n}\n"
 	lines := content.split_into_lines()
 
 	candidates := collect_document_highlight_candidates(content, lines, 'name', .utf16)
-	assert candidates.len == 3
+	assert candidates.len == 2
 	assert candidates[0].line_idx == 0
 	assert candidates[1].line_idx == 1
-	assert candidates[2].line_idx == 1
 	assert collect_document_highlight_candidates(content, lines, 'literal_name', .utf16).len == 0
 }
 

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -1370,6 +1370,30 @@ fn test_resolve_indexed_definition_defers_compile_time_condition() {
 	assert location == none
 }
 
+fn test_resolve_indexed_definition_defers_multiline_compile_time_condition() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	test_dir := os.join_path(app.temp_dir, 'indexed_definition_multiline_compile_time_condition')
+	must_mkdir_all(test_dir)
+	test_file := os.join_path(test_dir, 'main.v')
+	content := 'module main\n\nfn windows() {}\n\n$if (\n\twindows\n) {\n\tfn active() {}\n}\n'
+	must_write_file(test_file, content)
+	uri := path_to_uri(test_file)
+	app.open_files[uri] = content
+	condition_col := content.split_into_lines()[5].index('windows') or {
+		assert false, 'expected multiline compile-time condition'
+		return
+	}
+
+	location := app.resolve_indexed_definition(uri, Position{
+		line: 5
+		char: condition_col + 2
+	})
+	assert location == none
+}
+
 fn test_resolve_indexed_definition_defers_multiline_parameter_shadow() {
 	mut app := create_test_app()
 	defer {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -1749,6 +1749,43 @@ fn test_resolve_indexed_definition_prefers_workspace_vlib() {
 	assert location.range.start.line == 2
 }
 
+fn test_resolve_indexed_definition_prefers_source_relative_module() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	root := os.join_path(app.temp_dir, 'indexed_definition_source_relative')
+	source_dir := os.join_path(root, 'src')
+	module_dir := os.join_path(source_dir, 'os')
+	must_mkdir_all(module_dir)
+	must_write_file(os.join_path(root, 'v.mod'), 'Module {}\n')
+	main_file := os.join_path(source_dir, 'main.v')
+	module_file := os.join_path(module_dir, 'os.v')
+	main_content := 'module main\n\nimport os\n\nfn main() {\n\tos.local_answer()\n}\n'
+	module_content := 'module os\n\npub fn local_answer() {}\n'
+	must_write_file(main_file, main_content)
+	must_write_file(module_file, module_content)
+	main_uri := path_to_uri(main_file)
+	module_uri := path_to_uri(module_file)
+	app.open_files[main_uri] = main_content
+	app.open_files[module_uri] = module_content
+	app.workspace_roots = [root]
+	answer_col := main_content.split_into_lines()[5].index('local_answer') or {
+		assert false, 'expected source-relative module member'
+		return
+	}
+
+	location := app.resolve_indexed_definition(main_uri, Position{
+		line: 5
+		char: answer_col + 2
+	}) or {
+		assert false, 'expected source-relative indexed definition'
+		return
+	}
+	assert location.uri == module_uri
+	assert location.range.start.line == 2
+}
+
 fn test_resolve_indexed_definition_defers_receiver_method() {
 	mut app := create_test_app()
 	defer {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -922,6 +922,30 @@ fn test_resolve_indexed_definition_rejects_comments_and_string_literals() {
 	assert location.range.start.line == 2
 }
 
+fn test_resolve_indexed_definition_rejects_c_string_prefix() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	test_dir := os.join_path(app.temp_dir, 'indexed_definition_c_string_prefix')
+	must_mkdir_all(test_dir)
+	test_file := os.join_path(test_dir, 'main.v')
+	content := "module main\n\nfn c() {}\n\nfn main() {\n\ttext := c'hello'\n\tprintln(text)\n}\n"
+	must_write_file(test_file, content)
+	uri := path_to_uri(test_file)
+	app.open_files[uri] = content
+	c_string_col := content.split_into_lines()[5].index("c'hello'") or {
+		assert false, 'expected C-string prefix'
+		return
+	}
+
+	location := app.resolve_indexed_definition(uri, Position{
+		line: 5
+		char: c_string_col
+	})
+	assert location == none
+}
+
 fn test_resolve_indexed_definition_rejects_multiline_string_continuations() {
 	mut app := create_test_app()
 	defer {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -946,6 +946,30 @@ fn test_resolve_indexed_definition_rejects_c_string_prefix() {
 	assert location == none
 }
 
+fn test_resolve_indexed_definition_rejects_declaration_in_nested_block_comment() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	test_dir := os.join_path(app.temp_dir, 'indexed_definition_nested_block_comment')
+	must_mkdir_all(test_dir)
+	test_file := os.join_path(test_dir, 'main.v')
+	content := 'module main\n/* outer\n\t/* inner */\n\tfn helper() {}\n*/\nfn main() { helper() }\n'
+	must_write_file(test_file, content)
+	uri := path_to_uri(test_file)
+	app.open_files[uri] = content
+	helper_col := content.split_into_lines()[5].index('helper') or {
+		assert false, 'expected unresolved helper call'
+		return
+	}
+
+	location := app.resolve_indexed_definition(uri, Position{
+		line: 5
+		char: helper_col + 2
+	})
+	assert location == none
+}
+
 fn test_resolve_indexed_definition_rejects_multiline_string_continuations() {
 	mut app := create_test_app()
 	defer {

--- a/index.v
+++ b/index.v
@@ -212,9 +212,9 @@ fn scan_code_identifier_occurrences(line_text string, line_idx int, start int, e
 			col += 2
 			continue
 		}
-		if c == `r` && col + 1 < line_text.len
+		if c in [`r`, `c`] && col + 1 < line_text.len
 			&& (line_text[col + 1] == `"` || line_text[col + 1] == `'`) {
-			state.raw_string = true
+			state.raw_string = c == `r`
 			col = scan_literal_identifier_occurrences(line_text, line_idx, col + 1, enc, mut state, mut
 				occ)
 			continue

--- a/index.v
+++ b/index.v
@@ -140,10 +140,11 @@ fn add_identifier_occurrence(line_text string, line_idx int, start int, end int,
 	}
 }
 
-// scan_string_identifier_occurrences skips literal text while indexing V string
-// interpolation expressions. It preserves an unterminated quote across source
-// lines and returns the byte after the closing quote or the end of the line.
-fn scan_string_identifier_occurrences(line_text string, line_idx int, start int, enc PositionEncoding, mut state OccurrenceScanState, mut occ map[string][]TokenOccurrence) int {
+// scan_literal_identifier_occurrences skips string and rune literal text while
+// indexing V string interpolation expressions. It preserves an unterminated
+// quote across source lines and returns the byte after the closing quote or the
+// end of the line.
+fn scan_literal_identifier_occurrences(line_text string, line_idx int, start int, enc PositionEncoding, mut state OccurrenceScanState, mut occ map[string][]TokenOccurrence) int {
 	mut col := start
 	if state.quote == 0 {
 		state.quote = line_text[start]
@@ -190,7 +191,7 @@ fn scan_code_identifier_occurrences(line_text string, line_idx int, start int, e
 	mut brace_depth := 0
 	for col < line_text.len {
 		if state.quote != 0 {
-			col = scan_string_identifier_occurrences(line_text, line_idx, col, enc, mut state, mut
+			col = scan_literal_identifier_occurrences(line_text, line_idx, col, enc, mut state, mut
 				occ)
 			continue
 		}
@@ -212,9 +213,9 @@ fn scan_code_identifier_occurrences(line_text string, line_idx int, start int, e
 			col += 2
 			continue
 		}
-		if c == `"` || c == `'` {
+		if c == `"` || c == `'` || c == 96 {
 			col =
-				scan_string_identifier_occurrences(line_text, line_idx, col, enc, mut state, mut occ)
+				scan_literal_identifier_occurrences(line_text, line_idx, col, enc, mut state, mut occ)
 			continue
 		}
 		if c == `{` {

--- a/index.v
+++ b/index.v
@@ -130,10 +130,10 @@ mut:
 
 struct OccurrenceScanState {
 mut:
-	in_block_comment bool
-	quote            u8
-	raw_string       bool
-	interpolations   []OccurrenceInterpolationState
+	block_comment_depth int
+	quote               u8
+	raw_string          bool
+	interpolations      []OccurrenceInterpolationState
 }
 
 fn add_identifier_occurrence(line_text string, line_idx int, start int, end int, enc PositionEncoding, mut occ map[string][]TokenOccurrence) {
@@ -195,9 +195,14 @@ fn scan_code_identifier_occurrences(line_text string, line_idx int, start int, e
 			continue
 		}
 		c := line_text[col]
-		if state.in_block_comment {
+		if state.block_comment_depth > 0 {
+			if col + 1 < line_text.len && c == `/` && line_text[col + 1] == `*` {
+				state.block_comment_depth++
+				col += 2
+				continue
+			}
 			if col + 1 < line_text.len && c == `*` && line_text[col + 1] == `/` {
-				state.in_block_comment = false
+				state.block_comment_depth--
 				col += 2
 				continue
 			}
@@ -208,7 +213,7 @@ fn scan_code_identifier_occurrences(line_text string, line_idx int, start int, e
 			return line_text.len
 		}
 		if col + 1 < line_text.len && c == `/` && line_text[col + 1] == `*` {
-			state.in_block_comment = true
+			state.block_comment_depth = 1
 			col += 2
 			continue
 		}

--- a/index.v
+++ b/index.v
@@ -126,6 +126,7 @@ struct OccurrenceScanState {
 mut:
 	in_block_comment bool
 	quote            u8
+	raw_string       bool
 }
 
 fn add_identifier_occurrence(line_text string, line_idx int, start int, end int, enc PositionEncoding, mut occ map[string][]TokenOccurrence) {
@@ -152,32 +153,22 @@ fn scan_literal_identifier_occurrences(line_text string, line_idx int, start int
 	}
 	quote := state.quote
 	for col < line_text.len {
-		if line_text[col] == `\\` {
+		if line_text[col] == `\\` && !state.raw_string {
 			col += 2
 			continue
 		}
 		if line_text[col] == quote {
 			state.quote = 0
+			state.raw_string = false
 			return col + 1
 		}
-		if line_text[col] == `$` && col + 1 < line_text.len {
-			if line_text[col + 1] == `{` {
-				state.quote = 0
-				col = scan_code_identifier_occurrences(line_text, line_idx, col + 2, enc, true, mut
-					state, mut occ)
-				state.quote = quote
-				continue
-			}
-			if is_ident_char(line_text[col + 1]) && !(line_text[col + 1] >= `0`
-				&& line_text[col + 1] <= `9`) {
-				ident_start := col + 1
-				col = ident_start + 1
-				for col < line_text.len && is_ident_char(line_text[col]) {
-					col++
-				}
-				add_identifier_occurrence(line_text, line_idx, ident_start, col, enc, mut occ)
-				continue
-			}
+		if !state.raw_string && line_text[col] == `$` && col + 1 < line_text.len
+			&& line_text[col + 1] == `{` {
+			state.quote = 0
+			col = scan_code_identifier_occurrences(line_text, line_idx, col + 2, enc, true, mut
+				state, mut occ)
+			state.quote = quote
+			continue
 		}
 		col++
 	}
@@ -211,6 +202,13 @@ fn scan_code_identifier_occurrences(line_text string, line_idx int, start int, e
 		if col + 1 < line_text.len && c == `/` && line_text[col + 1] == `*` {
 			state.in_block_comment = true
 			col += 2
+			continue
+		}
+		if c == `r` && col + 1 < line_text.len
+			&& (line_text[col + 1] == `"` || line_text[col + 1] == `'`) {
+			state.raw_string = true
+			col = scan_literal_identifier_occurrences(line_text, line_idx, col + 1, enc, mut state, mut
+				occ)
 			continue
 		}
 		if c == `"` || c == `'` || c == 96 {

--- a/index.v
+++ b/index.v
@@ -122,11 +122,18 @@ struct OccEntry {
 	occ         map[string][]TokenOccurrence
 }
 
+struct OccurrenceInterpolationState {
+	quote u8
+mut:
+	brace_depth int
+}
+
 struct OccurrenceScanState {
 mut:
 	in_block_comment bool
 	quote            u8
 	raw_string       bool
+	interpolations   []OccurrenceInterpolationState
 }
 
 fn add_identifier_occurrence(line_text string, line_idx int, start int, end int, enc PositionEncoding, mut occ map[string][]TokenOccurrence) {
@@ -165,10 +172,11 @@ fn scan_literal_identifier_occurrences(line_text string, line_idx int, start int
 		if !state.raw_string && line_text[col] == `$` && col + 1 < line_text.len
 			&& line_text[col + 1] == `{` {
 			state.quote = 0
-			col = scan_code_identifier_occurrences(line_text, line_idx, col + 2, enc, true, mut
-				state, mut occ)
-			state.quote = quote
-			continue
+			state.interpolations << OccurrenceInterpolationState{
+				quote: quote
+			}
+			return scan_code_identifier_occurrences(line_text, line_idx, col + 2, enc, mut state, mut
+				occ)
 		}
 		col++
 	}
@@ -176,10 +184,10 @@ fn scan_literal_identifier_occurrences(line_text string, line_idx int, start int
 }
 
 // scan_code_identifier_occurrences indexes code between `start` and the end of
-// the line, or through the matching `}` for a braced interpolation expression.
-fn scan_code_identifier_occurrences(line_text string, line_idx int, start int, enc PositionEncoding, stop_at_closing_brace bool, mut state OccurrenceScanState, mut occ map[string][]TokenOccurrence) int {
+// the line. Braced interpolation state is retained across lines, including its
+// nested brace depth, and the suspended literal resumes after the matching `}`.
+fn scan_code_identifier_occurrences(line_text string, line_idx int, start int, enc PositionEncoding, mut state OccurrenceScanState, mut occ map[string][]TokenOccurrence) int {
 	mut col := start
-	mut brace_depth := 0
 	for col < line_text.len {
 		if state.quote != 0 {
 			col = scan_literal_identifier_occurrences(line_text, line_idx, col, enc, mut state, mut
@@ -217,15 +225,21 @@ fn scan_code_identifier_occurrences(line_text string, line_idx int, start int, e
 			continue
 		}
 		if c == `{` {
-			brace_depth++
+			if state.interpolations.len > 0 {
+				last := state.interpolations.len - 1
+				state.interpolations[last].brace_depth++
+			}
 			col++
 			continue
 		}
-		if c == `}` && stop_at_closing_brace {
-			if brace_depth == 0 {
-				return col + 1
+		if c == `}` && state.interpolations.len > 0 {
+			last := state.interpolations.len - 1
+			if state.interpolations[last].brace_depth == 0 {
+				interpolation := state.interpolations.pop()
+				state.quote = interpolation.quote
+			} else {
+				state.interpolations[last].brace_depth--
 			}
-			brace_depth--
 			col++
 			continue
 		}
@@ -253,7 +267,7 @@ fn extract_identifier_occurrences(content string, enc PositionEncoding) map[stri
 	mut occ := map[string][]TokenOccurrence{}
 	mut state := OccurrenceScanState{}
 	for line_idx, line_text in content.split_into_lines() {
-		scan_code_identifier_occurrences(line_text, line_idx, 0, enc, false, mut state, mut occ)
+		scan_code_identifier_occurrences(line_text, line_idx, 0, enc, mut state, mut occ)
 	}
 	return occ
 }

--- a/index.v
+++ b/index.v
@@ -125,6 +125,7 @@ struct OccEntry {
 struct OccurrenceScanState {
 mut:
 	in_block_comment bool
+	quote            u8
 }
 
 fn add_identifier_occurrence(line_text string, line_idx int, start int, end int, enc PositionEncoding, mut occ map[string][]TokenOccurrence) {
@@ -140,22 +141,30 @@ fn add_identifier_occurrence(line_text string, line_idx int, start int, end int,
 }
 
 // scan_string_identifier_occurrences skips literal text while indexing V string
-// interpolation expressions. It returns the byte after the closing quote.
+// interpolation expressions. It preserves an unterminated quote across source
+// lines and returns the byte after the closing quote or the end of the line.
 fn scan_string_identifier_occurrences(line_text string, line_idx int, start int, enc PositionEncoding, mut state OccurrenceScanState, mut occ map[string][]TokenOccurrence) int {
-	quote := line_text[start]
-	mut col := start + 1
+	mut col := start
+	if state.quote == 0 {
+		state.quote = line_text[start]
+		col++
+	}
+	quote := state.quote
 	for col < line_text.len {
 		if line_text[col] == `\\` {
 			col += 2
 			continue
 		}
 		if line_text[col] == quote {
+			state.quote = 0
 			return col + 1
 		}
 		if line_text[col] == `$` && col + 1 < line_text.len {
 			if line_text[col + 1] == `{` {
+				state.quote = 0
 				col = scan_code_identifier_occurrences(line_text, line_idx, col + 2, enc, true, mut
 					state, mut occ)
+				state.quote = quote
 				continue
 			}
 			if is_ident_char(line_text[col + 1]) && !(line_text[col + 1] >= `0`
@@ -180,6 +189,11 @@ fn scan_code_identifier_occurrences(line_text string, line_idx int, start int, e
 	mut col := start
 	mut brace_depth := 0
 	for col < line_text.len {
+		if state.quote != 0 {
+			col = scan_string_identifier_occurrences(line_text, line_idx, col, enc, mut state, mut
+				occ)
+			continue
+		}
 		c := line_text[col]
 		if state.in_block_comment {
 			if col + 1 < line_text.len && c == `*` && line_text[col + 1] == `/` {
@@ -231,11 +245,11 @@ fn scan_code_identifier_occurrences(line_text string, line_idx int, start int, e
 }
 
 // extract_identifier_occurrences returns every identifier occurrence in `content`
-// grouped by name, positioned in `enc` units. Line comments and string literal
-// text are skipped, interpolation expressions are scanned, and number literals
-// are ignored. This is the reference-index tokenizer: references/rename read
-// candidates from here instead of re-walking and re-tokenizing files per request
-// (P1-05).
+// grouped by name, positioned in `enc` units. Comments and string literal text
+// are skipped across source lines, interpolation expressions are scanned, and
+// number literals are ignored. This is the reference-index tokenizer:
+// references/rename read candidates from here instead of re-walking and
+// re-tokenizing files per request (P1-05).
 fn extract_identifier_occurrences(content string, enc PositionEncoding) map[string][]TokenOccurrence {
 	mut occ := map[string][]TokenOccurrence{}
 	mut state := OccurrenceScanState{}

--- a/index_test.v
+++ b/index_test.v
@@ -610,6 +610,18 @@ fn test_extract_identifier_occurrences_skips_multiline_block_comments() {
 	assert occ['target'].len == 2
 }
 
+fn test_extract_identifier_occurrences_skips_multiline_strings() {
+	content := "module main\n\nfn helper() {}\n\nfn main() {\n\ttext := 'first\nhelper\nlast'\n\tprintln(text)\n}\n"
+	occ := extract_identifier_occurrences(content, .utf16)
+
+	// The declaration is indexed, but the continuation line inside the literal
+	// is not treated as code. Scanning resumes after the closing quote.
+	assert occ['helper'].len == 1
+	assert occ['helper'][0].line == 2
+	assert occ['println'].len == 1
+	assert occ['text'].len == 2
+}
+
 fn test_occurrences_for_caches_by_fingerprint() {
 	mut app := index_test_app()
 	uri := 'file:///tmp/occ.v'

--- a/index_test.v
+++ b/index_test.v
@@ -586,8 +586,9 @@ fn test_extract_identifier_occurrences_indexes_string_interpolations() {
 	content := "fn greet(name string) string {\n\tother := 'ignored'\n\treturn 'hello \${name} \${other.to_upper()} \$name literal_name'\n}\n"
 	occ := extract_identifier_occurrences(content, .utf16)
 
-	// The parameter plus braced and shorthand interpolation references.
-	assert occ['name'].len == 3
+	// The parameter plus its braced interpolation reference. Unbraced `$name`
+	// is ordinary string text in current V syntax.
+	assert occ['name'].len == 2
 	// The declaration and its use inside a compound interpolation expression.
 	assert occ['other'].len == 2
 	assert occ['to_upper'].len == 1
@@ -595,6 +596,17 @@ fn test_extract_identifier_occurrences_indexes_string_interpolations() {
 	assert 'ignored' !in occ
 	assert 'hello' !in occ
 	assert 'literal_name' !in occ
+}
+
+fn test_extract_identifier_occurrences_skips_raw_string_interpolation_text() {
+	content := "fn helper() {}\nfn plain() {}\nfn main() {\n\traw := r'\${helper()} \$helper'\n\ttext := '\$plain \${helper()}'\n}\n"
+	occ := extract_identifier_occurrences(content, .utf16)
+
+	// Raw strings suppress all interpolation, while ordinary strings index only
+	// braced expressions.
+	assert occ['helper'].len == 2
+	assert occ['plain'].len == 1
+	assert 'r' !in occ
 }
 
 fn test_extract_identifier_occurrences_skips_multiline_block_comments() {

--- a/index_test.v
+++ b/index_test.v
@@ -609,6 +609,17 @@ fn test_extract_identifier_occurrences_skips_raw_string_interpolation_text() {
 	assert 'r' !in occ
 }
 
+fn test_extract_identifier_occurrences_skips_c_string_prefixes() {
+	content := "fn c() {}\nfn main() {\n\ttext := c'hello'\n\tprintln(text)\n}\n"
+	occ := extract_identifier_occurrences(content, .utf16)
+
+	// The declaration is indexed, but the C-string prefix and contents are not
+	// references to top-level declarations with matching names.
+	assert occ['c'].len == 1
+	assert occ['c'][0].line == 0
+	assert 'hello' !in occ
+}
+
 fn test_extract_identifier_occurrences_tracks_multiline_interpolations() {
 	content := "fn helper() int { return 1 }\nfn main() {\n\tvalue := 1\n\ttext := 'result \${match value {\n\t\t1 {\n\t\t\thelper()\n\t\t}\n\t\telse { 0 }\n\t}} literal_helper'\n\thelper()\n}\n"
 	occ := extract_identifier_occurrences(content, .utf16)

--- a/index_test.v
+++ b/index_test.v
@@ -646,6 +646,16 @@ fn test_extract_identifier_occurrences_skips_multiline_block_comments() {
 	assert occ['target'].len == 2
 }
 
+fn test_extract_identifier_occurrences_tracks_nested_block_comments() {
+	content := 'module main\n/* outer\n\t/* inner */\n\tfn helper() {}\n*/\nfn main() { helper() }\n'
+	occ := extract_identifier_occurrences(content, .utf16)
+
+	// Closing the nested comment must not expose the remainder of the outer
+	// comment to identifier indexing.
+	assert occ['helper'].len == 1
+	assert occ['helper'][0].line == 5
+}
+
 fn test_extract_identifier_occurrences_skips_multiline_strings() {
 	content := "module main\n\nfn helper() {}\n\nfn main() {\n\ttext := 'first\nhelper\nlast'\n\tprintln(text)\n}\n"
 	occ := extract_identifier_occurrences(content, .utf16)

--- a/index_test.v
+++ b/index_test.v
@@ -609,6 +609,19 @@ fn test_extract_identifier_occurrences_skips_raw_string_interpolation_text() {
 	assert 'r' !in occ
 }
 
+fn test_extract_identifier_occurrences_tracks_multiline_interpolations() {
+	content := "fn helper() int { return 1 }\nfn main() {\n\tvalue := 1\n\ttext := 'result \${match value {\n\t\t1 {\n\t\t\thelper()\n\t\t}\n\t\telse { 0 }\n\t}} literal_helper'\n\thelper()\n}\n"
+	occ := extract_identifier_occurrences(content, .utf16)
+
+	// Nested braces remain part of the interpolation across line boundaries.
+	// Scanning resumes as literal text after its matching closing brace.
+	assert occ['helper'].len == 3
+	assert occ['helper'][1].line == 5
+	assert occ['helper'][2].line == 9
+	assert occ['value'].len == 2
+	assert 'literal_helper' !in occ
+}
+
 fn test_extract_identifier_occurrences_skips_multiline_block_comments() {
 	mut content := 'fn target() {}\n/*\n'
 	for _ in 0 .. reference_semantic_max_candidates + 1 {

--- a/index_test.v
+++ b/index_test.v
@@ -622,6 +622,17 @@ fn test_extract_identifier_occurrences_skips_multiline_strings() {
 	assert occ['text'].len == 2
 }
 
+fn test_extract_identifier_occurrences_skips_rune_literals() {
+	content := 'fn f() {}\nfn main() {\n\tch := `f`\n\tprintln(ch)\n}\n'
+	occ := extract_identifier_occurrences(content, .utf16)
+
+	// The function declaration is indexed, but the matching rune contents are
+	// literal text rather than a reference to that function.
+	assert occ['f'].len == 1
+	assert occ['f'][0].line == 0
+	assert occ['ch'].len == 2
+}
+
 fn test_occurrences_for_caches_by_fingerprint() {
 	mut app := index_test_app()
 	uri := 'file:///tmp/occ.v'

--- a/interop.v
+++ b/interop.v
@@ -244,12 +244,15 @@ fn v3_compiler_selection_args() []string {
 
 fn build_v_check_args_single(file_to_check string) []string {
 	mut args := v3_compiler_selection_args()
+	// V3 emits warnings by default. At the pinned compiler revision `-w` means
+	// "hide warnings" and also selects established-compiler compatibility.
 	args << ['-check', '-nocolor', file_to_check]
 	return args
 }
 
 fn build_v_check_args_multifile() []string {
 	mut args := v3_compiler_selection_args()
+	// Do not add `-w`: omitting it preserves V3's default warning diagnostics.
 	args << ['-check', '-nocolor', '.']
 	return args
 }

--- a/interop.v
+++ b/interop.v
@@ -300,23 +300,34 @@ fn parse_v_check_diagnostics(output string) []JsonError {
 fn parse_v_check_diagnostic_header(line string) ?JsonError {
 	for level in ['error', 'warning', 'notice'] {
 		marker := ': ${level}: '
-		marker_idx := line.last_index(marker) or { continue }
-		location := line[..marker_idx]
-		col_separator := location.last_index(':') or { continue }
-		line_location := location[..col_separator]
-		line_separator := line_location.last_index(':') or { continue }
-		path := line_location[..line_separator]
-		line_nr_text := line_location[line_separator + 1..]
-		col_text := location[col_separator + 1..]
-		if path == '' || !decimal_text_is_valid(line_nr_text) || !decimal_text_is_valid(col_text) {
-			continue
-		}
-		return JsonError{
-			path:    path
-			message: line[marker_idx + marker.len..]
-			line_nr: line_nr_text.int()
-			col:     col_text.int()
-			level:   level
+		mut search_end := line.len
+		for search_end > 0 {
+			marker_idx := line[..search_end].last_index(marker) or { break }
+			location := line[..marker_idx]
+			col_separator := location.last_index(':') or {
+				search_end = marker_idx
+				continue
+			}
+			line_location := location[..col_separator]
+			line_separator := line_location.last_index(':') or {
+				search_end = marker_idx
+				continue
+			}
+			path := line_location[..line_separator]
+			line_nr_text := line_location[line_separator + 1..]
+			col_text := location[col_separator + 1..]
+			if path == '' || !decimal_text_is_valid(line_nr_text)
+				|| !decimal_text_is_valid(col_text) {
+				search_end = marker_idx
+				continue
+			}
+			return JsonError{
+				path:    path
+				message: line[marker_idx + marker.len..]
+				line_nr: line_nr_text.int()
+				col:     col_text.int()
+				level:   level
+			}
 		}
 	}
 	return none

--- a/interop.v
+++ b/interop.v
@@ -275,11 +275,11 @@ fn build_v_fmt_args(temp_file string) []string {
 // compiler-neutral diagnostic representation used by the LSP layer. V3 emits
 // headers as `path:line:column: severity: message`; paths may themselves
 // contain colons, so location fields are peeled from the right.
-fn parse_v_check_diagnostics(output string) []JsonError {
+fn parse_v_check_diagnostics(output string, source_dir string) []JsonError {
 	mut diagnostics := []JsonError{}
 	mut active := -1
 	for line in output.split_into_lines() {
-		if diagnostic := parse_v_check_diagnostic_header(line) {
+		if diagnostic := parse_v_check_diagnostic_header(line, source_dir) {
 			diagnostics << diagnostic
 			active = diagnostics.len - 1
 			continue
@@ -297,7 +297,18 @@ fn parse_v_check_diagnostics(output string) []JsonError {
 	return diagnostics
 }
 
-fn parse_v_check_diagnostic_header(line string) ?JsonError {
+fn diagnostic_source_path_is_valid(path string, source_dir string) bool {
+	if !path.ends_with('.v') && !path.ends_with('.vsh') {
+		return false
+	}
+	if source_dir == '' {
+		return true
+	}
+	resolved_path := if os.is_abs_path(path) { path } else { os.join_path(source_dir, path) }
+	return os.is_file(resolved_path)
+}
+
+fn parse_v_check_diagnostic_header(line string, source_dir string) ?JsonError {
 	mut best_marker_idx := -1
 	mut best := JsonError{}
 	for level in ['error', 'warning', 'notice'] {
@@ -318,8 +329,8 @@ fn parse_v_check_diagnostic_header(line string) ?JsonError {
 			path := line_location[..line_separator]
 			line_nr_text := line_location[line_separator + 1..]
 			col_text := location[col_separator + 1..]
-			if path == '' || !decimal_text_is_valid(line_nr_text)
-				|| !decimal_text_is_valid(col_text) {
+			if !diagnostic_source_path_is_valid(path, source_dir)
+				|| !decimal_text_is_valid(line_nr_text) || !decimal_text_is_valid(col_text) {
 				search_end = marker_idx
 				continue
 			}
@@ -678,12 +689,12 @@ fn (mut app App) run_v_check(path string, text string) []JsonError {
 
 	log('Check - RUN RES ${x}')
 
-	cleanup_compilation_temp(temp_project_dir, singlefile_tmppath)
-
 	// `-json-errors`, `-w`, and `-vls-mode` select the established compiler.
 	// Parse V3's native flat-AST checker diagnostics instead so ordinary
 	// diagnostics stay on the default backend.
-	v_errors := parse_v_check_diagnostics(x.output)
+	diagnostic_source_dir := if use_multifile { exec_dir } else { os.dir(file_to_check) }
+	v_errors := parse_v_check_diagnostics(x.output, diagnostic_source_dir)
+	cleanup_compilation_temp(temp_project_dir, singlefile_tmppath)
 
 	// error filtlering
 	if use_multifile {

--- a/interop.v
+++ b/interop.v
@@ -298,6 +298,8 @@ fn parse_v_check_diagnostics(output string) []JsonError {
 }
 
 fn parse_v_check_diagnostic_header(line string) ?JsonError {
+	mut best_marker_idx := -1
+	mut best := JsonError{}
 	for level in ['error', 'warning', 'notice'] {
 		marker := ': ${level}: '
 		mut search_end := line.len
@@ -321,14 +323,21 @@ fn parse_v_check_diagnostic_header(line string) ?JsonError {
 				search_end = marker_idx
 				continue
 			}
-			return JsonError{
-				path:    path
-				message: line[marker_idx + marker.len..]
-				line_nr: line_nr_text.int()
-				col:     col_text.int()
-				level:   level
+			if marker_idx > best_marker_idx {
+				best_marker_idx = marker_idx
+				best = JsonError{
+					path:    path
+					message: line[marker_idx + marker.len..]
+					line_nr: line_nr_text.int()
+					col:     col_text.int()
+					level:   level
+				}
 			}
+			break
 		}
+	}
+	if best_marker_idx >= 0 {
+		return best
 	}
 	return none
 }

--- a/interop.v
+++ b/interop.v
@@ -359,11 +359,11 @@ fn v_diagnostic_underline_len(line string) int {
 	return marker.len
 }
 
-// cache_v_check_result retains clean results only when the compiler completed
-// successfully. A failed invocation is cacheable only when it produced parsed
-// diagnostics; otherwise a transient timeout or crash must be retried.
+// cache_v_check_result never retains timed-out output because it may be partial.
+// Other failed invocations are cacheable only when they produced parsed
+// diagnostics; otherwise a transient compiler crash must be retried.
 fn (mut app App) cache_v_check_result(path string, content_hash int, generation int, errors []JsonError, exit_code int, parsed_diagnostic_count int) {
-	if exit_code != 0 && parsed_diagnostic_count == 0 {
+	if exit_code == compiler_exit_timeout || (exit_code != 0 && parsed_diagnostic_count == 0) {
 		app.diag_cache.delete(path)
 		return
 	}

--- a/interop.v
+++ b/interop.v
@@ -297,7 +297,7 @@ fn parse_v_check_diagnostics(output string) []JsonError {
 fn parse_v_check_diagnostic_header(line string) ?JsonError {
 	for level in ['error', 'warning', 'notice'] {
 		marker := ': ${level}: '
-		marker_idx := line.index(marker) or { continue }
+		marker_idx := line.last_index(marker) or { continue }
 		location := line[..marker_idx]
 		col_separator := location.last_index(':') or { continue }
 		line_location := location[..col_separator]

--- a/interop.v
+++ b/interop.v
@@ -345,6 +345,21 @@ fn v_diagnostic_underline_len(line string) int {
 	return marker.len
 }
 
+// cache_v_check_result retains clean results only when the compiler completed
+// successfully. A failed invocation is cacheable only when it produced parsed
+// diagnostics; otherwise a transient timeout or crash must be retried.
+fn (mut app App) cache_v_check_result(path string, content_hash int, generation int, errors []JsonError, exit_code int, parsed_diagnostic_count int) {
+	if exit_code != 0 && parsed_diagnostic_count == 0 {
+		app.diag_cache.delete(path)
+		return
+	}
+	app.diag_cache[path] = DiagCacheEntry{
+		content_hash: content_hash
+		generation:   generation
+		errors:       errors
+	}
+}
+
 // Sentinel exit code returned when a compiler invocation is killed for
 // exceeding compiler_timeout_ms. 124 matches the coreutils `timeout` convention.
 const compiler_exit_timeout = 124
@@ -670,20 +685,13 @@ fn (mut app App) run_v_check(path string, text string) []JsonError {
 		}
 
 		log('FILTERED ERRORS: ${filtered_errors.len} of ${v_errors.len}')
-		app.diag_cache[path] = DiagCacheEntry{
-			content_hash: content_hash
-			generation:   gen
-			errors:       filtered_errors
-		}
+		app.cache_v_check_result(path, content_hash, gen, filtered_errors, x.exit_code,
+			v_errors.len)
 		return filtered_errors
 	}
 
 	log('V3 CHECK ERRORS: ${v_errors.len}')
-	app.diag_cache[path] = DiagCacheEntry{
-		content_hash: content_hash
-		generation:   gen
-		errors:       v_errors
-	}
+	app.cache_v_check_result(path, content_hash, gen, v_errors, x.exit_code, v_errors.len)
 	return v_errors
 }
 

--- a/interop.v
+++ b/interop.v
@@ -233,12 +233,25 @@ fn make_singlefile_temp_path(temp_root string, real_path string, purpose string)
 // separate argv element to os.Process, so no shell metacharacter (spaces,
 // `$()`, backticks, quotes, `;`, `&`, `|`, `%`, ...) in a filename or path can
 // alter the executed command. There is no shell involved at any point.
+fn v3_compiler_selection_args() []string {
+	$if macos || linux {
+		// Default V3 dispatch only applies to executables named `v` or `vnew`.
+		// VLS may be configured with a renamed compiler, so select V3 explicitly.
+		return ['-new-compiler']
+	}
+	return []
+}
+
 fn build_v_check_args_single(file_to_check string) []string {
-	return ['-w', '-vls-mode', '-check', '-json-errors', '-nocolor', file_to_check]
+	mut args := v3_compiler_selection_args()
+	args << ['-check', '-nocolor', file_to_check]
+	return args
 }
 
 fn build_v_check_args_multifile() []string {
-	return ['-w', '-check', '-json-errors', '-nocolor', '.']
+	mut args := v3_compiler_selection_args()
+	args << ['-check', '-nocolor', '.']
+	return args
 }
 
 fn build_v_line_info_args_multifile(rel_file string, line_info string) []string {
@@ -253,6 +266,83 @@ fn build_v_line_info_args_single(file_to_check string, line_info string, compile
 
 fn build_v_fmt_args(temp_file string) []string {
 	return ['fmt', '-inprocess', '-w', temp_file]
+}
+
+// parse_v_check_diagnostics converts V3's flat-AST checker output into the
+// compiler-neutral diagnostic representation used by the LSP layer. V3 emits
+// headers as `path:line:column: severity: message`; paths may themselves
+// contain colons, so location fields are peeled from the right.
+fn parse_v_check_diagnostics(output string) []JsonError {
+	mut diagnostics := []JsonError{}
+	mut active := -1
+	for line in output.split_into_lines() {
+		if diagnostic := parse_v_check_diagnostic_header(line) {
+			diagnostics << diagnostic
+			active = diagnostics.len - 1
+			continue
+		}
+		if active >= 0 && diagnostics[active].len == 0 {
+			underline_len := v_diagnostic_underline_len(line)
+			if underline_len > 0 {
+				diagnostics[active] = JsonError{
+					...diagnostics[active]
+					len: underline_len
+				}
+			}
+		}
+	}
+	return diagnostics
+}
+
+fn parse_v_check_diagnostic_header(line string) ?JsonError {
+	for level in ['error', 'warning', 'notice'] {
+		marker := ': ${level}: '
+		marker_idx := line.index(marker) or { continue }
+		location := line[..marker_idx]
+		col_separator := location.last_index(':') or { continue }
+		line_location := location[..col_separator]
+		line_separator := line_location.last_index(':') or { continue }
+		path := line_location[..line_separator]
+		line_nr_text := line_location[line_separator + 1..]
+		col_text := location[col_separator + 1..]
+		if path == '' || !decimal_text_is_valid(line_nr_text) || !decimal_text_is_valid(col_text) {
+			continue
+		}
+		return JsonError{
+			path:    path
+			message: line[marker_idx + marker.len..]
+			line_nr: line_nr_text.int()
+			col:     col_text.int()
+			level:   level
+		}
+	}
+	return none
+}
+
+fn decimal_text_is_valid(text string) bool {
+	if text == '' {
+		return false
+	}
+	for c in text {
+		if c < `0` || c > `9` {
+			return false
+		}
+	}
+	return true
+}
+
+fn v_diagnostic_underline_len(line string) int {
+	separator := line.index('|') or { return 0 }
+	marker := line[separator + 1..].trim_space()
+	if marker == '' {
+		return 0
+	}
+	for c in marker {
+		if c != `~` && c != `^` {
+			return 0
+		}
+	}
+	return marker.len
 }
 
 // Sentinel exit code returned when a compiler invocation is killed for
@@ -552,16 +642,16 @@ fn (mut app App) run_v_check(path string, text string) []JsonError {
 
 	cleanup_compilation_temp(temp_project_dir, singlefile_tmppath)
 
-	json_errors := json2.decode[[]JsonError](x.output) or {
-		log('failed to parse json ${err}')
-		return []
-	}
+	// `-json-errors`, `-w`, and `-vls-mode` select the established compiler.
+	// Parse V3's native flat-AST checker diagnostics instead so ordinary
+	// diagnostics stay on the default backend.
+	v_errors := parse_v_check_diagnostics(x.output)
 
 	// error filtlering
 	if use_multifile {
 		mut filtered_errors := []JsonError{}
 
-		for err in json_errors {
+		for err in v_errors {
 			err_file := source_path_from_overlay(err.path, overlay)
 			if normalized_index_path(err_file) == normalized_index_path(real_path) {
 				updated_err := JsonError{
@@ -579,7 +669,7 @@ fn (mut app App) run_v_check(path string, text string) []JsonError {
 			}
 		}
 
-		log('FILTERED ERRORS: ${filtered_errors.len} of ${json_errors.len}')
+		log('FILTERED ERRORS: ${filtered_errors.len} of ${v_errors.len}')
 		app.diag_cache[path] = DiagCacheEntry{
 			content_hash: content_hash
 			generation:   gen
@@ -588,13 +678,13 @@ fn (mut app App) run_v_check(path string, text string) []JsonError {
 		return filtered_errors
 	}
 
-	log('JSON ERRORS: ${json_errors.len}')
+	log('V3 CHECK ERRORS: ${v_errors.len}')
 	app.diag_cache[path] = DiagCacheEntry{
 		content_hash: content_hash
 		generation:   gen
-		errors:       json_errors
+		errors:       v_errors
 	}
-	return json_errors
+	return v_errors
 }
 
 fn (mut app App) write_tracked_files_to_temp(working_dir string) !string {

--- a/interop_test.v
+++ b/interop_test.v
@@ -419,6 +419,17 @@ fn test_parse_v_check_diagnostics_preserves_windows_drive_path() {
 	assert diagnostics[0].level == 'notice'
 }
 
+fn test_parse_v_check_diagnostics_preserves_severity_marker_in_posix_path() {
+	header := '/tmp/project: error: fixtures/main.v:12:9: error: unknown identifier'
+	diagnostics := parse_v_check_diagnostics(header)
+	assert diagnostics.len == 1
+	assert diagnostics[0].path == '/tmp/project: error: fixtures/main.v'
+	assert diagnostics[0].message == 'unknown identifier'
+	assert diagnostics[0].line_nr == 12
+	assert diagnostics[0].col == 9
+	assert diagnostics[0].level == 'error'
+}
+
 fn test_parse_v_check_diagnostics_ignores_non_diagnostic_output() {
 	output := 'V3 compatibility fallback disabled; requested reason: compiler_error
 Use `v help build` for more information.

--- a/interop_test.v
+++ b/interop_test.v
@@ -432,6 +432,17 @@ fn test_parse_v_check_diagnostics_preserves_severity_marker_in_posix_path() {
 	assert diagnostics[0].level == 'error'
 }
 
+fn test_parse_v_check_diagnostics_preserves_severity_marker_in_message() {
+	header := '/tmp/main.v:1:1: error: failed: error: detail'
+	diagnostics := parse_v_check_diagnostics(header)
+	assert diagnostics.len == 1
+	assert diagnostics[0].path == '/tmp/main.v'
+	assert diagnostics[0].message == 'failed: error: detail'
+	assert diagnostics[0].line_nr == 1
+	assert diagnostics[0].col == 1
+	assert diagnostics[0].level == 'error'
+}
+
 fn test_parse_v_check_diagnostics_ignores_non_diagnostic_output() {
 	output := 'V3 compatibility fallback disabled; requested reason: compiler_error
 Use `v help build` for more information.

--- a/interop_test.v
+++ b/interop_test.v
@@ -437,6 +437,31 @@ Use `v help build` for more information.
 	assert parse_v_check_diagnostics(output).len == 0
 }
 
+fn test_cache_v_check_result_retries_failure_without_diagnostics() {
+	mut app := App{}
+	path := 'file:///tmp/main.v'
+	app.diag_cache[path] = DiagCacheEntry{
+		content_hash: 1
+		generation:   1
+		errors:       []
+	}
+	app.cache_v_check_result(path, 2, 2, [], compiler_exit_timeout, 0)
+	assert path !in app.diag_cache
+}
+
+fn test_cache_v_check_result_keeps_valid_clean_and_diagnostic_results() {
+	mut app := App{}
+	path := 'file:///tmp/main.v'
+	app.cache_v_check_result(path, 1, 1, [], 0, 0)
+	assert path in app.diag_cache
+	assert app.diag_cache[path].errors.len == 0
+
+	app.cache_v_check_result(path, 2, 2, [], 1, 1)
+	assert path in app.diag_cache
+	assert app.diag_cache[path].content_hash == 2
+	assert app.diag_cache[path].generation == 2
+}
+
 fn test_run_v_argv_reports_missing_working_dir() {
 	missing_dir := os.join_path(os.temp_dir(),
 		'vls_missing_dir_${os.getpid()}_${time.now().unix_nano()}')

--- a/interop_test.v
+++ b/interop_test.v
@@ -432,6 +432,17 @@ fn test_parse_v_check_diagnostics_preserves_severity_marker_in_posix_path() {
 	assert diagnostics[0].level == 'error'
 }
 
+fn test_parse_v_check_diagnostics_chooses_rightmost_marker_across_severities() {
+	header := '/tmp/foo:1:2: error: dir/main.v:12:9: warning: unused variable'
+	diagnostics := parse_v_check_diagnostics(header)
+	assert diagnostics.len == 1
+	assert diagnostics[0].path == '/tmp/foo:1:2: error: dir/main.v'
+	assert diagnostics[0].message == 'unused variable'
+	assert diagnostics[0].line_nr == 12
+	assert diagnostics[0].col == 9
+	assert diagnostics[0].level == 'warning'
+}
+
 fn test_parse_v_check_diagnostics_preserves_severity_marker_in_message() {
 	header := '/tmp/main.v:1:1: error: failed: error: detail'
 	diagnostics := parse_v_check_diagnostics(header)

--- a/interop_test.v
+++ b/interop_test.v
@@ -328,9 +328,32 @@ fn test_cleanup_compilation_temp_removes_project_dir() {
 
 fn test_build_v_check_args_single_passes_path_literally() {
 	args := build_v_check_args_single('/tmp/a b/test.v')
-	assert '/tmp/a b/test.v' in args
-	assert '-vls-mode' in args
-	assert '-check' in args
+	mut expected := v3_compiler_selection_args()
+	expected << ['-check', '-nocolor', '/tmp/a b/test.v']
+	assert args == expected
+	assert '-vls-mode' !in args
+	assert '-json-errors' !in args
+	assert '-w' !in args
+	$if macos || linux {
+		assert '-new-compiler' in args
+	} $else {
+		assert '-new-compiler' !in args
+	}
+}
+
+fn test_build_v_check_args_multifile_uses_v3_compatible_flags() {
+	args := build_v_check_args_multifile()
+	mut expected := v3_compiler_selection_args()
+	expected << ['-check', '-nocolor', '.']
+	assert args == expected
+	assert '-vls-mode' !in args
+	assert '-json-errors' !in args
+	assert '-w' !in args
+	$if macos || linux {
+		assert '-new-compiler' in args
+	} $else {
+		assert '-new-compiler' !in args
+	}
 }
 
 fn test_build_v_check_args_single_no_shell_injection() {
@@ -357,6 +380,50 @@ fn test_build_v_line_info_args_single_embeds_line_info() {
 	args := build_v_line_info_args_single('/tmp/a.v', '10:gd^5', '/tmp/a.v')
 	assert '/tmp/a.v:10:gd^5' in args
 	assert '-line-info' in args
+}
+
+fn test_parse_v_check_diagnostics_reads_v3_output() {
+	output := '/tmp/main.v:4:7: error: undefined variable: `missing_name`
+    2 |
+    3 | fn main() {
+    4 |     x := missing_name
+      |          ~~~~~~~~~~~~
+    5 | }
+/tmp/main.v:8:3: warning: unused variable `value`
+    8 |   value := 1
+      |   ~~~~~
+'
+	diagnostics := parse_v_check_diagnostics(output)
+	assert diagnostics.len == 2
+	assert diagnostics[0] == JsonError{
+		path:    '/tmp/main.v'
+		message: 'undefined variable: `missing_name`'
+		line_nr: 4
+		col:     7
+		len:     12
+		level:   'error'
+	}
+	assert diagnostics[1].level == 'warning'
+	assert diagnostics[1].line_nr == 8
+	assert diagnostics[1].col == 3
+	assert diagnostics[1].len == 5
+}
+
+fn test_parse_v_check_diagnostics_preserves_windows_drive_path() {
+	header := r'C:\work\project\main.v:12:9: notice: deprecated declaration'
+	diagnostics := parse_v_check_diagnostics(header)
+	assert diagnostics.len == 1
+	assert diagnostics[0].path == r'C:\work\project\main.v'
+	assert diagnostics[0].line_nr == 12
+	assert diagnostics[0].col == 9
+	assert diagnostics[0].level == 'notice'
+}
+
+fn test_parse_v_check_diagnostics_ignores_non_diagnostic_output() {
+	output := 'V3 compatibility fallback disabled; requested reason: compiler_error
+Use `v help build` for more information.
+'
+	assert parse_v_check_diagnostics(output).len == 0
 }
 
 fn test_run_v_argv_reports_missing_working_dir() {

--- a/interop_test.v
+++ b/interop_test.v
@@ -333,6 +333,7 @@ fn test_build_v_check_args_single_passes_path_literally() {
 	assert args == expected
 	assert '-vls-mode' !in args
 	assert '-json-errors' !in args
+	// At the pinned V3 revision `-w` hides warnings; omission preserves them.
 	assert '-w' !in args
 	$if macos || linux {
 		assert '-new-compiler' in args
@@ -348,6 +349,7 @@ fn test_build_v_check_args_multifile_uses_v3_compatible_flags() {
 	assert args == expected
 	assert '-vls-mode' !in args
 	assert '-json-errors' !in args
+	// V3 reports warnings by default, while `-w` requests compatibility suppression.
 	assert '-w' !in args
 	$if macos || linux {
 		assert '-new-compiler' in args

--- a/interop_test.v
+++ b/interop_test.v
@@ -462,6 +462,27 @@ fn test_cache_v_check_result_retries_failure_without_diagnostics() {
 	assert path !in app.diag_cache
 }
 
+fn test_cache_v_check_result_retries_timeout_with_partial_diagnostics() {
+	mut app := App{}
+	path := 'file:///tmp/main.v'
+	app.diag_cache[path] = DiagCacheEntry{
+		content_hash: 1
+		generation:   1
+		errors:       []
+	}
+	partial_errors := [
+		JsonError{
+			path:    '/tmp/main.v'
+			message: 'partial compiler output'
+			line_nr: 1
+			col:     1
+			level:   'error'
+		},
+	]
+	app.cache_v_check_result(path, 2, 2, partial_errors, compiler_exit_timeout, partial_errors.len)
+	assert path !in app.diag_cache
+}
+
 fn test_cache_v_check_result_keeps_valid_clean_and_diagnostic_results() {
 	mut app := App{}
 	path := 'file:///tmp/main.v'

--- a/interop_test.v
+++ b/interop_test.v
@@ -395,7 +395,7 @@ fn test_parse_v_check_diagnostics_reads_v3_output() {
     8 |   value := 1
       |   ~~~~~
 '
-	diagnostics := parse_v_check_diagnostics(output)
+	diagnostics := parse_v_check_diagnostics(output, '')
 	assert diagnostics.len == 2
 	assert diagnostics[0] == JsonError{
 		path:    '/tmp/main.v'
@@ -413,7 +413,7 @@ fn test_parse_v_check_diagnostics_reads_v3_output() {
 
 fn test_parse_v_check_diagnostics_preserves_windows_drive_path() {
 	header := r'C:\work\project\main.v:12:9: notice: deprecated declaration'
-	diagnostics := parse_v_check_diagnostics(header)
+	diagnostics := parse_v_check_diagnostics(header, '')
 	assert diagnostics.len == 1
 	assert diagnostics[0].path == r'C:\work\project\main.v'
 	assert diagnostics[0].line_nr == 12
@@ -423,7 +423,7 @@ fn test_parse_v_check_diagnostics_preserves_windows_drive_path() {
 
 fn test_parse_v_check_diagnostics_preserves_severity_marker_in_posix_path() {
 	header := '/tmp/project: error: fixtures/main.v:12:9: error: unknown identifier'
-	diagnostics := parse_v_check_diagnostics(header)
+	diagnostics := parse_v_check_diagnostics(header, '')
 	assert diagnostics.len == 1
 	assert diagnostics[0].path == '/tmp/project: error: fixtures/main.v'
 	assert diagnostics[0].message == 'unknown identifier'
@@ -434,7 +434,7 @@ fn test_parse_v_check_diagnostics_preserves_severity_marker_in_posix_path() {
 
 fn test_parse_v_check_diagnostics_chooses_rightmost_marker_across_severities() {
 	header := '/tmp/foo:1:2: error: dir/main.v:12:9: warning: unused variable'
-	diagnostics := parse_v_check_diagnostics(header)
+	diagnostics := parse_v_check_diagnostics(header, '')
 	assert diagnostics.len == 1
 	assert diagnostics[0].path == '/tmp/foo:1:2: error: dir/main.v'
 	assert diagnostics[0].message == 'unused variable'
@@ -445,10 +445,29 @@ fn test_parse_v_check_diagnostics_chooses_rightmost_marker_across_severities() {
 
 fn test_parse_v_check_diagnostics_preserves_severity_marker_in_message() {
 	header := '/tmp/main.v:1:1: error: failed: error: detail'
-	diagnostics := parse_v_check_diagnostics(header)
+	diagnostics := parse_v_check_diagnostics(header, '')
 	assert diagnostics.len == 1
 	assert diagnostics[0].path == '/tmp/main.v'
 	assert diagnostics[0].message == 'failed: error: detail'
+	assert diagnostics[0].line_nr == 1
+	assert diagnostics[0].col == 1
+	assert diagnostics[0].level == 'error'
+}
+
+fn test_parse_v_check_diagnostics_rejects_header_marker_in_message() {
+	temp_dir := os.join_path(os.temp_dir(),
+		'vls_diagnostic_source_${os.getpid()}_${time.now().unix_nano()}')
+	interop_test_must_mkdir_all(temp_dir)
+	defer {
+		os.rmdir_all(temp_dir) or {}
+	}
+	source_path := os.join_path(temp_dir, 'main.v')
+	interop_test_must_write_file(source_path, 'module main\n')
+	header := '${source_path}:1:1: error: failed at foo.v:2:3: warning: detail'
+	diagnostics := parse_v_check_diagnostics(header, temp_dir)
+	assert diagnostics.len == 1
+	assert diagnostics[0].path == source_path
+	assert diagnostics[0].message == 'failed at foo.v:2:3: warning: detail'
 	assert diagnostics[0].line_nr == 1
 	assert diagnostics[0].col == 1
 	assert diagnostics[0].level == 'error'
@@ -458,7 +477,7 @@ fn test_parse_v_check_diagnostics_ignores_non_diagnostic_output() {
 	output := 'V3 compatibility fallback disabled; requested reason: compiler_error
 Use `v help build` for more information.
 '
-	assert parse_v_check_diagnostics(output).len == 0
+	assert parse_v_check_diagnostics(output, '').len == 0
 }
 
 fn test_cache_v_check_result_retries_failure_without_diagnostics() {

--- a/lsp.v
+++ b/lsp.v
@@ -40,11 +40,13 @@ struct Params {
 	new_name        string                 @[json: 'newName']
 }
 
+// Optional JSON integers use i64 because V3 emits a generic option ABI for struct fields, while
+// json2 specializes ?int during reflection. JSON and LSP integers have no wire-level width.
 // ContentChange represents a change to a document's content.
 struct ContentChange {
 	text         string
 	range        ?LSPRange
-	range_length ?int @[json: 'rangeLength']
+	range_length ?i64 @[json: 'rangeLength']
 }
 
 // Response represents an LSP response sent to the client.
@@ -162,7 +164,7 @@ struct Notification {
 // PublishDiagnosticsParams contains diagnostics for a document.
 struct PublishDiagnosticsParams {
 	uri         string
-	version     ?int
+	version     ?i64
 	diagnostics []LSPDiagnostic
 }
 
@@ -192,7 +194,7 @@ struct Detail {
 	sort_text          ?string @[json: 'sortText']   // sort key, defaults to label
 	filter_text        ?string @[json: 'filterText'] // filter key, defaults to label
 	insert_text        ?string @[json: 'insertText']
-	insert_text_format ?int    @[json: 'insertTextFormat'] // 1 for PlainText, 2 for Snippet
+	insert_text_format ?i64    @[json: 'insertTextFormat'] // 1 for PlainText, 2 for Snippet
 	tags               ?[]int  @[json: 'tags']             // 1 = deprecated
 	deprecated         ?bool   @[json: 'deprecated']       // legacy deprecated flag
 }
@@ -528,14 +530,14 @@ struct WorkDoneProgressBegin {
 	title       string
 	cancellable bool
 	message     ?string
-	percentage  ?int
+	percentage  ?i64
 }
 
 // WorkDoneProgressReport sends an incremental update for a work-done progress.
 struct WorkDoneProgressReport {
 	kind       string = 'report'
 	message    ?string
-	percentage ?int
+	percentage ?i64
 }
 
 // WorkDoneProgressEnd sends the final update for a work-done progress.
@@ -708,7 +710,7 @@ struct WorkspaceEdit {
 // VersionedTextDocumentIdentifier identifies a versioned text document.
 struct VersionedTextDocumentIdentifier {
 	uri     string
-	version ?int
+	version ?i64
 }
 
 // TextDocumentEdit represents a list of edits applied to a versioned document.
@@ -757,7 +759,7 @@ struct CodeActionParams {
 struct CodeActionContext {
 	diagnostics  []LSPDiagnostic
 	only         ?[]string
-	trigger_kind ?int      @[json: 'triggerKind']
+	trigger_kind ?i64 @[json: 'triggerKind']
 }
 
 // DocumentHighlight represents a highlighted occurrence of a symbol in a document.
@@ -897,7 +899,7 @@ struct TextDocumentPositionParams {
 struct DidOpenTextDocumentItem {
 	uri         string
 	language_id ?string @[json: 'languageId']
-	version     ?int
+	version     ?i64
 	text        ?string
 }
 

--- a/lsp_test.v
+++ b/lsp_test.v
@@ -196,7 +196,7 @@ fn test_method_roundtrip_all_values() {
 	// Ensure all Method enum values round-trip correctly
 	$for m in Method.values {
 		if m.value != Method.unknown {
-			assert Method.from_string(m.value.str()) == m.value
+			assert Method.from_string(m.attrs[0]) == m.value
 		}
 	}
 }

--- a/main.v
+++ b/main.v
@@ -6,7 +6,6 @@ import json2
 import net
 import os
 import time
-import v.pref
 import io
 
 // App represents the context of the server during its lifetime.
@@ -70,10 +69,6 @@ struct DiagCacheEntry {
 	errors       []JsonError
 }
 
-const v_prefs = pref.Preferences{
-	is_vls: true
-}
-
 // v_dir is the path to the V home directory, derived from the V compiler executable.
 // It is resolved once at process start and never changes.
 const v_dir = find_v_dir()
@@ -129,7 +124,6 @@ fn new_stdin_buffered_reader() &io.BufferedReader {
 
 fn main() {
 	log('VLS started. Reading from stdin...')
-	log('VLS preferences: is_vls=${v_prefs.is_vls}')
 
 	// Check for --port PORT argument to start as a TCP multi-client server.
 	// TCP binds to loopback (127.0.0.1) by default; binding to any other
@@ -1455,7 +1449,7 @@ fn make_internal_error_response(id int, message string) ErrorResponse {
 }
 
 fn validate_request_params(method Method, params_json string) ?string {
-	return match method {
+	match method {
 		.initialize {
 			params := json2.decode[InitializeParams](params_json) or {
 				return 'Invalid initialize params: ${err.msg()}'
@@ -1467,7 +1461,6 @@ fn validate_request_params(method Method, params_json string) ?string {
 					}
 				}
 			}
-			none
 		}
 		.completion, .signature_help, .definition, .hover, .declaration, .type_definition,
 		.implementation, .prepare_rename, .document_highlight {
@@ -1477,7 +1470,6 @@ fn validate_request_params(method Method, params_json string) ?string {
 			if params.text_document.uri == '' {
 				return 'Missing textDocument.uri'
 			}
-			none
 		}
 		.references {
 			params := json2.decode[ReferenceParams](params_json) or {
@@ -1486,7 +1478,6 @@ fn validate_request_params(method Method, params_json string) ?string {
 			if params.text_document.uri == '' {
 				return 'Missing textDocument.uri'
 			}
-			none
 		}
 		.rename {
 			params := json2.decode[RenameParams](params_json) or {
@@ -1502,13 +1493,11 @@ fn validate_request_params(method Method, params_json string) ?string {
 			if params.new_name in v_keywords || params.new_name in v_builtins {
 				return 'newName `${params.new_name}` is a reserved V keyword or builtin'
 			}
-			none
 		}
 		.workspace_symbol {
 			json2.decode[WorkspaceSymbolParams](params_json) or {
 				return 'Invalid workspace/symbol params: ${err.msg()}'
 			}
-			none
 		}
 		.formatting {
 			params := json2.decode[DocumentFormattingParams](params_json) or {
@@ -1517,7 +1506,6 @@ fn validate_request_params(method Method, params_json string) ?string {
 			if params.text_document.uri == '' {
 				return 'Missing textDocument.uri'
 			}
-			none
 		}
 		.document_symbols {
 			params := json2.decode[DocumentSymbolParams](params_json) or {
@@ -1526,7 +1514,6 @@ fn validate_request_params(method Method, params_json string) ?string {
 			if params.text_document.uri == '' {
 				return 'Missing textDocument.uri'
 			}
-			none
 		}
 		.inlay_hint {
 			params := json2.decode[InlayHintParams](params_json) or {
@@ -1535,7 +1522,6 @@ fn validate_request_params(method Method, params_json string) ?string {
 			if params.text_document.uri == '' {
 				return 'Missing textDocument.uri'
 			}
-			none
 		}
 		.code_action {
 			params := json2.decode[CodeActionParams](params_json) or {
@@ -1544,7 +1530,6 @@ fn validate_request_params(method Method, params_json string) ?string {
 			if params.text_document.uri == '' {
 				return 'Missing textDocument.uri'
 			}
-			none
 		}
 		.semantic_tokens {
 			params := json2.decode[SemanticTokensParams](params_json) or {
@@ -1553,7 +1538,6 @@ fn validate_request_params(method Method, params_json string) ?string {
 			if params.text_document.uri == '' {
 				return 'Missing textDocument.uri'
 			}
-			none
 		}
 		.folding_range {
 			params := json2.decode[FoldingRangeParams](params_json) or {
@@ -1562,7 +1546,6 @@ fn validate_request_params(method Method, params_json string) ?string {
 			if params.text_document.uri == '' {
 				return 'Missing textDocument.uri'
 			}
-			none
 		}
 		.callhierarchy_prepare {
 			params := json2.decode[PrepareCallHierarchyParams](params_json) or {
@@ -1571,7 +1554,6 @@ fn validate_request_params(method Method, params_json string) ?string {
 			if params.text_document.uri == '' {
 				return 'Missing textDocument.uri'
 			}
-			none
 		}
 		.callhierarchy_incoming {
 			params := json2.decode[CallHierarchyIncomingCallsParams](params_json) or {
@@ -1580,7 +1562,6 @@ fn validate_request_params(method Method, params_json string) ?string {
 			if params.item.uri == '' {
 				return 'Missing item.uri'
 			}
-			none
 		}
 		.callhierarchy_outgoing {
 			params := json2.decode[CallHierarchyOutgoingCallsParams](params_json) or {
@@ -1589,7 +1570,6 @@ fn validate_request_params(method Method, params_json string) ?string {
 			if params.item.uri == '' {
 				return 'Missing item.uri'
 			}
-			none
 		}
 		.selection_range {
 			params := json2.decode[SelectionRangeParams](params_json) or {
@@ -1598,7 +1578,6 @@ fn validate_request_params(method Method, params_json string) ?string {
 			if params.text_document.uri == '' {
 				return 'Missing textDocument.uri'
 			}
-			none
 		}
 		.semantic_tokens_range {
 			params := json2.decode[SemanticTokensRangeParams](params_json) or {
@@ -1607,7 +1586,6 @@ fn validate_request_params(method Method, params_json string) ?string {
 			if params.text_document.uri == '' {
 				return 'Missing textDocument.uri'
 			}
-			none
 		}
 		.range_formatting {
 			params := json2.decode[DocumentRangeFormattingParams](params_json) or {
@@ -1616,7 +1594,6 @@ fn validate_request_params(method Method, params_json string) ?string {
 			if params.text_document.uri == '' {
 				return 'Missing textDocument.uri'
 			}
-			none
 		}
 		.linked_editing_range {
 			params := json2.decode[TextDocumentPositionParams](params_json) or {
@@ -1625,7 +1602,6 @@ fn validate_request_params(method Method, params_json string) ?string {
 			if params.text_document.uri == '' {
 				return 'Missing textDocument.uri'
 			}
-			none
 		}
 		.inline_value {
 			params := json2.decode[InlineValueParams](params_json) or {
@@ -1634,7 +1610,6 @@ fn validate_request_params(method Method, params_json string) ?string {
 			if params.text_document.uri == '' {
 				return 'Missing textDocument.uri'
 			}
-			none
 		}
 		.code_lens {
 			params := json2.decode[CodeLensParams](params_json) or {
@@ -1643,19 +1618,16 @@ fn validate_request_params(method Method, params_json string) ?string {
 			if params.text_document.uri == '' {
 				return 'Missing textDocument.uri'
 			}
-			none
 		}
 		.code_lens_resolve {
 			json2.decode[CodeLens](params_json) or {
 				return 'Invalid codeLens/resolve params: ${err.msg()}'
 			}
-			none
 		}
 		.execute_command {
 			json2.decode[ExecuteCommandParams](params_json) or {
 				return 'Invalid executeCommand params: ${err.msg()}'
 			}
-			none
 		}
 		.on_type_formatting {
 			params := json2.decode[OnTypeFormattingParams](params_json) or {
@@ -1664,16 +1636,14 @@ fn validate_request_params(method Method, params_json string) ?string {
 			if params.text_document.uri == '' {
 				return 'Missing textDocument.uri'
 			}
-			none
 		}
-		else {
-			none
-		}
+		else {}
 	}
+	return none
 }
 
 fn validate_notification_params(method Method, params_json string) ?string {
-	return match method {
+	match method {
 		.did_open {
 			params := json2.decode[DidOpenTextDocumentParams](params_json) or {
 				return 'Invalid didOpen params: ${err.msg()}'
@@ -1681,7 +1651,6 @@ fn validate_notification_params(method Method, params_json string) ?string {
 			if params.text_document.uri == '' {
 				return 'Missing textDocument.uri'
 			}
-			none
 		}
 		.did_change {
 			params := json2.decode[DidChangeTextDocumentParams](params_json) or {
@@ -1690,7 +1659,6 @@ fn validate_notification_params(method Method, params_json string) ?string {
 			if params.text_document.uri == '' {
 				return 'Missing textDocument.uri'
 			}
-			none
 		}
 		.did_close {
 			params := json2.decode[DidCloseTextDocumentParams](params_json) or {
@@ -1699,7 +1667,6 @@ fn validate_notification_params(method Method, params_json string) ?string {
 			if params.text_document.uri == '' {
 				return 'Missing textDocument.uri'
 			}
-			none
 		}
 		.did_save {
 			params := json2.decode[DidSaveTextDocumentParams](params_json) or {
@@ -1708,7 +1675,6 @@ fn validate_notification_params(method Method, params_json string) ?string {
 			if params.text_document.uri == '' {
 				return 'Missing textDocument.uri'
 			}
-			none
 		}
 		.did_change_watched_files {
 			params := json2.decode[DidChangeWatchedFilesParams](params_json) or {
@@ -1719,23 +1685,13 @@ fn validate_notification_params(method Method, params_json string) ?string {
 					return 'Missing changes[i].uri'
 				}
 			}
-			none
 		}
-		.workspace_did_change_configuration {
-			// This notification intentionally supports multiple client shapes.
-			none
-		}
-		.workspace_did_change_workspace_folders {
-			// params are decoded in the handler; no pre-validation needed here.
-			none
-		}
-		.initialized, .set_trace, .cancel_request, .exit {
-			none
-		}
-		else {
-			none
-		}
+		.workspace_did_change_configuration {} // Multiple client shapes are supported.
+		.workspace_did_change_workspace_folders {} // Decoded in the handler.
+		.initialized, .set_trace, .cancel_request, .exit {}
+		else {}
 	}
+	return none
 }
 
 fn is_valid_v_identifier_name(name string) bool {

--- a/main.v
+++ b/main.v
@@ -15,7 +15,7 @@ pub struct App {
 mut:
 	text                                        string            // Current file content
 	open_files                                  map[string]string // Map of file URI to file content
-	open_files_versions                         map[string]int    // Per-URI document version from the client
+	open_files_versions                         map[string]i64    // Per-URI document version from the client
 	temp_dir                                    string            // Temporary directory for multi-file compilation
 	workspace_roots                             []string          // Workspace root directories from initialize
 	removed_workspace_roots                     []string          // Roots explicitly removed by the client

--- a/semantic_tokens.v
+++ b/semantic_tokens.v
@@ -385,9 +385,9 @@ fn (mut app App) handle_semantic_tokens_range(request Request) Response {
 	// (line, start) is kept when its start position is >= the range start and <
 	// the range end in (line, char) order; this excludes tokens before the start
 	// character on the first line and at/after the end character on the last line.
-	range_tokens := raw_tokens.filter((it.line > start_line
-		|| (it.line == start_line && it.start >= start_char)) && (it.line < end_line
-		|| (it.line == end_line && it.start < end_char)))
+	range_tokens := raw_tokens.filter(
+		(it.line > start_line || (it.line == start_line && it.start >= start_char))
+		&& (it.line < end_line || (it.line == end_line && it.start < end_char)))
 	encoded := encode_semantic_tokens(range_tokens)
 	return Response{
 		id:     request.id


### PR DESCRIPTION
## Summary

- move diagnostics to V3-native `-check` output and parse flat-AST diagnostics
- update JSON option handling and request validation for the V3 compiler
- resolve safe declarations from the source index before legacy line-info compatibility
- prefer workspace modules and `vlib` when navigating inside a V checkout
- pin CI to the V3-default V revision and enforce V3 builds without fallback

## Testing

- `V_MACOS_V3_NO_FALLBACK=1 v .`
- `VLS_VLANG_V_REPO=<v-checkout> V_MACOS_V3_NO_FALLBACK=1 v test .`
  - 6 passed, 6 total
- `v fmt -verify` on all changed V files
- `git diff --check`
