### PR TITLE
fix: resolve V compiler build error and clean up new checker notices

### DIFF
--- a/call_hierarchy.v
+++ b/call_hierarchy.v
@@ -45,7 +45,7 @@ fn (mut app App) handle_prepare_call_hierarchy(request Request) Response {
 	if item.name == '' {
 		working_dir := os.dir(uri_to_path(uri))
 		search_dirs := app.workspace_search_dirs(working_dir)
-		item = app.find_fn_declaration(word, search_dirs, request.id, uri.ends_with('_test.v'))
+		item = app.find_fn_declaration(word, search_dirs, uri.ends_with('_test.v'))
 	}
 	if item.name == '' {
 		return Response{
@@ -163,8 +163,7 @@ fn (mut app App) handle_call_hierarchy_outgoing(request Request) Response {
 		if called_name == self_name {
 			continue // skip direct recursion
 		}
-		callee := app.find_fn_declaration(called_name, search_dirs, request.id,
-			uri.ends_with('_test.v'))
+		callee := app.find_fn_declaration(called_name, search_dirs, uri.ends_with('_test.v'))
 		if callee.name == '' {
 			continue
 		}
@@ -186,8 +185,8 @@ fn (mut app App) handle_call_hierarchy_outgoing(request Request) Response {
 fn extract_simple_fn_name(full_name string) string {
 	trimmed := full_name.trim_space()
 	if trimmed.starts_with('(') {
-		close := trimmed.index(')') or { return '' }
-		return trimmed[close + 1..].trim_space()
+		close_idx := trimmed.index(')') or { return '' }
+		return trimmed[close_idx + 1..].trim_space()
 	}
 	return trimmed
 }
@@ -214,10 +213,9 @@ fn find_fn_in_content(fn_name string, content string, uri string, enc PositionEn
 	return CallHierarchyItem{}
 }
 
-// find_fn_declaration searches open files and then on-disk files in
-// `search_dirs` for a function/method named `fn_name`. Polls for cancellation
-// between files so callers can return early when the request is cancelled.
-fn (mut app App) find_fn_declaration(fn_name string, search_dirs []string, request_id int, include_tests bool) CallHierarchyItem {
+// find_fn_declaration resolves a function/method named `fn_name` from the
+// persistent symbol index, restricted to `search_dirs`.
+fn (mut app App) find_fn_declaration(fn_name string, search_dirs []string, include_tests bool) CallHierarchyItem {
 	// Answer from the persistent symbol index instead of re-scanning every file.
 	app.ensure_dirs_indexed(search_dirs)
 	// Prefer a declaration in the primary (current module) directory, then widen
@@ -288,14 +286,14 @@ fn scan_for_callers(fn_name string, file_uri string, file_content string, enc Po
 					continue
 				}
 				idx := line[col..].index('${fn_name}(') or { break }
-				abs := col + idx
+				abs_idx := col + idx
 				// Require a word boundary before the name.
-				if abs > 0 && is_ident_char(line[abs - 1]) {
-					col = abs + 1
+				if abs_idx > 0 && is_ident_char(line[abs_idx - 1]) {
+					col = abs_idx + 1
 					continue
 				}
-				start_char := byte_to_encoded_col(line, abs, enc)
-				end_char := byte_to_encoded_col(line, abs + fn_name.len, enc)
+				start_char := byte_to_encoded_col(line, abs_idx, enc)
+				end_char := byte_to_encoded_col(line, abs_idx + fn_name.len, enc)
 				call_ranges << LSPRange{
 					start: Position{
 						line: li
@@ -306,7 +304,7 @@ fn scan_for_callers(fn_name string, file_uri string, file_content string, enc Po
 						char: end_char
 					}
 				}
-				col = abs + fn_name.len + 1
+				col = abs_idx + fn_name.len + 1
 			}
 		}
 		if call_ranges.len > 0 {

--- a/document_highlight.v
+++ b/document_highlight.v
@@ -62,7 +62,7 @@ fn is_for_binding_highlight(line string, start_byte int, end_byte int) bool {
 		|| highlight_has_word(binding_prefix, 'in') {
 		return false
 	}
-	mut binding_suffix := line[end_byte..]
+	mut binding_suffix := line[end_byte..].clone()
 	brace_byte := binding_suffix.index_any('{;')
 	if brace_byte >= 0 {
 		binding_suffix = binding_suffix[..brace_byte]

--- a/handlers.v
+++ b/handlers.v
@@ -854,7 +854,7 @@ fn (mut app App) handle_prepare_rename(request Request) Response {
 	}
 	// Identifiers used for rename must start with a letter or underscore.
 	first := symbol[0]
-	if !((first >= `a` && first <= `z`) || (first >= `A` && first <= `Z`) || first == `_`) {
+	if !is_ident_start(first) {
 		return Response{
 			id:     request.id
 			result: 'null'
@@ -1320,6 +1320,11 @@ fn is_ident_char(c u8) bool {
 	return (c >= `a` && c <= `z`) || (c >= `A` && c <= `Z`) || (c >= `0` && c <= `9`) || c == `_`
 }
 
+// is_ident_start reports whether `c` can begin an identifier (letter or underscore).
+fn is_ident_start(c u8) bool {
+	return (c >= `a` && c <= `z`) || (c >= `A` && c <= `Z`) || c == `_`
+}
+
 // PositionEncoding is the unit the client uses for LSP `character` offsets.
 // LSP defaults to utf16; utf8 (byte offsets) and utf32 (code points) are only
 // used when negotiated via the client's `general.positionEncodings`.
@@ -1327,16 +1332,6 @@ enum PositionEncoding {
 	utf16
 	utf8
 	utf32
-}
-
-// parse_position_encoding maps an LSP encoding string to a PositionEncoding.
-fn parse_position_encoding(s string) ?PositionEncoding {
-	return match s {
-		'utf-16' { PositionEncoding.utf16 }
-		'utf-8' { PositionEncoding.utf8 }
-		'utf-32' { PositionEncoding.utf32 }
-		else { none }
-	}
 }
 
 // position_encoding_string is the LSP wire string for a PositionEncoding.
@@ -2144,7 +2139,7 @@ fn source_occurrence_is_generic_parameter(lines []string, line_idx int, start_by
 	}
 	for parameter in parameter_lines.join('\n').split(',') {
 		name := parameter.trim_space()
-		if name == '' || name[0] >= `0` && name[0] <= `9` {
+		if name == '' || (name[0] >= `0` && name[0] <= `9`) {
 			return false
 		}
 		for c in name {
@@ -2501,8 +2496,8 @@ fn find_declaration_line(lines []string, symbol string) int {
 				rest := stripped[prefix.len..]
 				// Handle method receivers: fn (recv) name(
 				actual_rest := if rest.starts_with('(') {
-					close := rest.index(')') or { break }
-					rest[close + 1..].trim_space()
+					close_idx := rest.index(')') or { break }
+					rest[close_idx + 1..].trim_space()
 				} else {
 					rest
 				}
@@ -3081,7 +3076,8 @@ fn infer_type_from_literal(rhs string) string {
 	if r.contains('.') {
 		mut is_float := true
 		for c in r {
-			if !((c >= `0` && c <= `9`) || c == `.` || c == `-` || c == `_`) {
+			is_float_char := (c >= `0` && c <= `9`) || c == `.` || c == `-` || c == `_`
+			if !is_float_char {
 				is_float = false
 				break
 			}
@@ -3096,7 +3092,8 @@ fn infer_type_from_literal(rhs string) string {
 	}
 	mut is_int := true
 	for c in r {
-		if !((c >= `0` && c <= `9`) || c == `-` || c == `_`) {
+		is_int_char := (c >= `0` && c <= `9`) || c == `-` || c == `_`
+		if !is_int_char {
 			is_int = false
 			break
 		}
@@ -3400,13 +3397,13 @@ fn extract_fn_name(after_fn string) string {
 	}
 	if t.starts_with('(') {
 		// method: (recv) name(params...
-		close := t.index(')') or { return '' }
-		rest := t[close + 1..].trim_space()
+		close_idx := t.index(')') or { return '' }
+		rest := t[close_idx + 1..].trim_space()
 		name := first_word_paren(rest)
 		if name == '' {
 			return ''
 		}
-		receiver := t[1..close]
+		receiver := t[1..close_idx]
 		return '(${receiver}) ${name}'
 	}
 	return first_word_paren(t)
@@ -3913,8 +3910,8 @@ fn build_fn_snippet(fn_name string, params_str string) string {
 		return fn_name + '()'
 	}
 	// Find closing paren of parameter list.
-	close := params_str.index(')') or { return fn_name + '()' }
-	inner := params_str[1..close].trim_space()
+	close_idx := params_str.index(')') or { return fn_name + '()' }
+	inner := params_str[1..close_idx].trim_space()
 	if inner == '' {
 		return fn_name + '()'
 	}
@@ -4640,12 +4637,12 @@ fn (mut app App) handle_linked_editing_range(request Request) Response {
 	mut col := 0
 	for col < line_text.len {
 		idx := line_text[col..].index(symbol) or { break }
-		abs := col + idx
-		before_ok := abs == 0 || !is_ident_char(line_text[abs - 1])
-		after_ok := abs + symbol.len >= line_text.len || !is_ident_char(line_text[abs + symbol.len])
+		abs_idx := col + idx
+		before_ok := abs_idx == 0 || !is_ident_char(line_text[abs_idx - 1])
+		after_ok := abs_idx + symbol.len >= line_text.len || !is_ident_char(line_text[abs_idx + symbol.len])
 		if before_ok && after_ok {
-			sc := byte_to_encoded_col(line_text, abs, app.position_encoding)
-			ec := byte_to_encoded_col(line_text, abs + symbol.len, app.position_encoding)
+			sc := byte_to_encoded_col(line_text, abs_idx, app.position_encoding)
+			ec := byte_to_encoded_col(line_text, abs_idx + symbol.len, app.position_encoding)
 			ranges << LSPRange{
 				start: Position{
 					line: params.position.line
@@ -4657,7 +4654,7 @@ fn (mut app App) handle_linked_editing_range(request Request) Response {
 				}
 			}
 		}
-		col = abs + 1
+		col = abs_idx + 1
 	}
 	if ranges.len == 0 {
 		return Response{

--- a/interop.v
+++ b/interop.v
@@ -100,7 +100,7 @@ fn uri_to_path(uri string) string {
 	if !uri.starts_with('file:') {
 		return uri
 	}
-	mut rest := uri[5..] // strip 'file:'
+	mut rest := uri[5..].clone() // strip 'file:'
 	mut authority := ''
 	if rest.starts_with('//') {
 		rest = rest[2..]

--- a/main.v
+++ b/main.v
@@ -953,7 +953,7 @@ fn decode_json_unicode_escape(content string, i int) ?(int, int) {
 		if i + 12 <= content.len && content[i + 6] == `\\` && content[i + 7] == `u` {
 			lo := hex4_to_int(content[i + 8..i + 12]) or { return none }
 			if lo >= 0xDC00 && lo <= 0xDFFF {
-				return 0x10000 + ((hi - 0xD800) << 10) + (lo - 0xDC00), 12
+				return 0x10000 + int(u32(hi - 0xD800) << 10) + (lo - 0xDC00), 12
 			}
 		}
 		return none
@@ -1700,12 +1700,11 @@ fn is_valid_v_identifier_name(name string) bool {
 		return false
 	}
 	first := t[0]
-	if !((first >= `a` && first <= `z`) || (first >= `A` && first <= `Z`) || first == `_`) {
+	if !is_ident_start(first) {
 		return false
 	}
 	for ch in t {
-		if !((ch >= `a` && ch <= `z`) || (ch >= `A` && ch <= `Z`)
-			|| (ch >= `0` && ch <= `9`) || ch == `_`) {
+		if !is_ident_char(ch) {
 			return false
 		}
 	}


### PR DESCRIPTION
## Summary

`v .` stopped building vls against the current V compiler. The blocker was a
single hard **error** — an ambiguous `||`/`&&` boolean expression in
`handlers.v` that the compiler now rejects. This PR fixes that and then clears
the wall of `notice:` diagnostics the newer checker emits, so `v .` is clean.

## The actual build error

```v
// handlers.v — source_occurrence_is_generic_parameter
if name == '' || name[0] >= `0` && name[0] <= `9` {    // error: ambiguous boolean expression
if name == '' || (name[0] >= `0` && name[0] <= `9`) {  // fixed
```

## Notice cleanups (all behavior-preserving)

- Rename locals `close` / `abs` (which shadow builtins) to `close_idx` / `abs_idx`.
- Add `is_ident_start()` and reuse the existing `is_ident_char()` instead of
  inline `!((a && b) || …)` character-class checks that tripped the
  redundant-parentheses check.
- Add explicit `.clone()` on two intentional slice copies (`document_highlight.v`,
  `interop.v`).
- Cast the UTF-16 surrogate-pair shift through `u32` to silence the
  signed-shift notice (value verified unchanged, e.g. `0x10401`).
- Remove the dead `parse_position_encoding` function (real negotiation lives in
  `negotiate_position_encoding`).
- Remove the now-unused `request_id` parameter from `find_fn_declaration` and
  update both call sites.

Builds cleanly with the stable V compiler (one remaining `request shadows a
function declaration` notice is a V checker false-positive — a lowercase local
colliding with the `Request` type — not addressed here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)