### PR TITLE
fix: handle VSCodium diagnostics compatibility

### DIFF
--- a/handlers.v
+++ b/handlers.v
@@ -3670,7 +3670,8 @@ fn (mut app App) handle_code_action(request Request) Response {
 	// 1. Quick fixes for diagnostics.
 	if code_action_kind_wanted(only, code_action_kind_quickfix) {
 		for diag in diagnostics {
-			if diag.message.contains('unknown module') {
+			message := diag.message.to_lower()
+			if message.contains('unknown module') || message.contains('cannot import module') {
 				line_nr := diag.range.start.line
 				if line_nr >= 0 && line_nr < lines.len
 					&& lines[line_nr].trim_space().starts_with('import ') {
@@ -4208,6 +4209,12 @@ fn resolve_workspace_settings(params_json string) ResolvedWorkspaceSettings {
 			resolved.has_inlay_hints = true
 		}
 	}
+	if !resolved.has_diagnostics {
+		if enabled := sectioned_nested.settings.vls.diagnostics.enabled {
+			resolved.diagnostics = enabled
+			resolved.has_diagnostics = true
+		}
+	}
 
 	direct_nested := json2.decode[DidChangeConfigurationDirectParamsCompat](params_json) or {
 		DidChangeConfigurationDirectParamsCompat{}
@@ -4216,6 +4223,12 @@ fn resolve_workspace_settings(params_json string) ResolvedWorkspaceSettings {
 		if enabled := direct_nested.settings.inlay_hints.enabled {
 			resolved.inlay_hints = enabled
 			resolved.has_inlay_hints = true
+		}
+	}
+	if !resolved.has_diagnostics {
+		if enabled := direct_nested.settings.diagnostics.enabled {
+			resolved.diagnostics = enabled
+			resolved.has_diagnostics = true
 		}
 	}
 

--- a/handlers.v
+++ b/handlers.v
@@ -4169,70 +4169,72 @@ mut:
 fn resolve_workspace_settings(params_json string) ResolvedWorkspaceSettings {
 	mut resolved := ResolvedWorkspaceSettings{}
 
-	// 1) Preferred shape: settings.vls.{inlayHints, diagnostics}
-	sectioned := json2.decode[DidChangeConfigurationParams](params_json) or {
+	sectioned_flat := json2.decode[DidChangeConfigurationParams](params_json) or {
 		DidChangeConfigurationParams{}
 	}
-	if enabled := sectioned.settings.vls.inlay_hints {
-		resolved.inlay_hints = enabled
-		resolved.has_inlay_hints = true
-	}
-	if enabled := sectioned.settings.vls.diagnostics {
-		resolved.diagnostics = enabled
-		resolved.has_diagnostics = true
-	}
+	merge_workspace_settings(mut resolved, sectioned_flat.settings.vls.inlay_hints,
+		sectioned_flat.settings.vls.diagnostics)
 
-	// 2) Direct shape: settings.{inlayHints, diagnostics}
-	direct := json2.decode[DidChangeConfigurationDirectParams](params_json) or {
-		DidChangeConfigurationDirectParams{}
-	}
-	if !resolved.has_inlay_hints {
-		if enabled := direct.settings.inlay_hints {
-			resolved.inlay_hints = enabled
-			resolved.has_inlay_hints = true
-		}
-	}
-	if !resolved.has_diagnostics {
-		if enabled := direct.settings.diagnostics {
-			resolved.diagnostics = enabled
-			resolved.has_diagnostics = true
-		}
-	}
-
-	// 3) Nested compatibility shapes, used only when flat values are absent.
-	sectioned_nested := json2.decode[DidChangeConfigurationParamsCompat](params_json) or {
+	sectioned_inlay_nested := json2.decode[DidChangeConfigurationParamsCompat](params_json) or {
 		DidChangeConfigurationParamsCompat{}
 	}
-	if !resolved.has_inlay_hints {
-		if enabled := sectioned_nested.settings.vls.inlay_hints.enabled {
-			resolved.inlay_hints = enabled
-			resolved.has_inlay_hints = true
-		}
-	}
-	if !resolved.has_diagnostics {
-		if enabled := sectioned_nested.settings.vls.diagnostics.enabled {
-			resolved.diagnostics = enabled
-			resolved.has_diagnostics = true
-		}
-	}
+	merge_workspace_settings(mut resolved,
+		sectioned_inlay_nested.settings.vls.inlay_hints.enabled,
+		sectioned_inlay_nested.settings.vls.diagnostics)
 
-	direct_nested := json2.decode[DidChangeConfigurationDirectParamsCompat](params_json) or {
+	sectioned_diagnostics_nested := json2.decode[DidChangeConfigurationParamsNestedDiagnosticsCompat](params_json) or {
+		DidChangeConfigurationParamsNestedDiagnosticsCompat{}
+	}
+	merge_workspace_settings(mut resolved,
+		sectioned_diagnostics_nested.settings.vls.inlay_hints,
+		sectioned_diagnostics_nested.settings.vls.diagnostics.enabled)
+
+	sectioned_nested := json2.decode[DidChangeConfigurationParamsNestedFeaturesCompat](params_json) or {
+		DidChangeConfigurationParamsNestedFeaturesCompat{}
+	}
+	merge_workspace_settings(mut resolved, sectioned_nested.settings.vls.inlay_hints.enabled,
+		sectioned_nested.settings.vls.diagnostics.enabled)
+
+	direct_flat := json2.decode[DidChangeConfigurationDirectParams](params_json) or {
+		DidChangeConfigurationDirectParams{}
+	}
+	merge_workspace_settings(mut resolved, direct_flat.settings.inlay_hints,
+		direct_flat.settings.diagnostics)
+
+	direct_inlay_nested := json2.decode[DidChangeConfigurationDirectParamsCompat](params_json) or {
 		DidChangeConfigurationDirectParamsCompat{}
 	}
+	merge_workspace_settings(mut resolved, direct_inlay_nested.settings.inlay_hints.enabled,
+		direct_inlay_nested.settings.diagnostics)
+
+	direct_diagnostics_nested := json2.decode[DidChangeConfigurationDirectParamsNestedDiagnosticsCompat](params_json) or {
+		DidChangeConfigurationDirectParamsNestedDiagnosticsCompat{}
+	}
+	merge_workspace_settings(mut resolved, direct_diagnostics_nested.settings.inlay_hints,
+		direct_diagnostics_nested.settings.diagnostics.enabled)
+
+	direct_nested := json2.decode[DidChangeConfigurationDirectParamsNestedFeaturesCompat](params_json) or {
+		DidChangeConfigurationDirectParamsNestedFeaturesCompat{}
+	}
+	merge_workspace_settings(mut resolved, direct_nested.settings.inlay_hints.enabled,
+		direct_nested.settings.diagnostics.enabled)
+	return resolved
+}
+
+fn merge_workspace_settings(mut resolved ResolvedWorkspaceSettings, inlay_hints ?bool,
+	diagnostics ?bool) {
 	if !resolved.has_inlay_hints {
-		if enabled := direct_nested.settings.inlay_hints.enabled {
+		if enabled := inlay_hints {
 			resolved.inlay_hints = enabled
 			resolved.has_inlay_hints = true
 		}
 	}
 	if !resolved.has_diagnostics {
-		if enabled := direct_nested.settings.diagnostics.enabled {
+		if enabled := diagnostics {
 			resolved.diagnostics = enabled
 			resolved.has_diagnostics = true
 		}
 	}
-
-	return resolved
 }
 
 fn (mut app App) on_initialize(request Request) ?string {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -6365,6 +6365,55 @@ fn test_workspace_configuration_toggles_feature_behavior() {
 	assert app.diagnostics_enabled
 }
 
+fn test_workspace_configuration_preserves_mixed_setting_shapes() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+
+	app.on_did_change_configuration(Request{
+		method: 'workspace/didChangeConfiguration'
+		params: '{"settings":{"vls":{"inlayHints":false,"diagnostics":true}}}'
+	})
+	assert !app.inlay_hints_enabled
+	assert app.diagnostics_enabled
+
+	app.on_did_change_configuration(Request{
+		method: 'workspace/didChangeConfiguration'
+		params: '{"settings":{"vls":{"inlayHints":{"enabled":false},"diagnostics":true}}}'
+	})
+	assert !app.inlay_hints_enabled
+	assert app.diagnostics_enabled
+
+	app.on_did_change_configuration(Request{
+		method: 'workspace/didChangeConfiguration'
+		params: '{"settings":{"vls":{"inlayHints":true,"diagnostics":{"enabled":false}}}}'
+	})
+	assert app.inlay_hints_enabled
+	assert !app.diagnostics_enabled
+
+	app.on_did_change_configuration(Request{
+		method: 'workspace/didChangeConfiguration'
+		params: '{"settings":{"inlayHints":{"enabled":false},"diagnostics":true}}'
+	})
+	assert !app.inlay_hints_enabled
+	assert app.diagnostics_enabled
+
+	app.on_did_change_configuration(Request{
+		method: 'workspace/didChangeConfiguration'
+		params: '{"settings":{"inlayHints":true,"diagnostics":{"enabled":false}}}'
+	})
+	assert app.inlay_hints_enabled
+	assert !app.diagnostics_enabled
+
+	app.on_did_change_configuration(Request{
+		method: 'workspace/didChangeConfiguration'
+		params: '{"settings":{"inlayHints":{"enabled":false},"diagnostics":{"enabled":true}}}'
+	})
+	assert !app.inlay_hints_enabled
+	assert app.diagnostics_enabled
+}
+
 fn test_will_save_wait_until_formats_without_mutating_open_document() {
 	mut app := create_test_app()
 	defer {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -5772,7 +5772,7 @@ fn test_remove_unknown_import_range_at_eof_without_newline() {
 	// encoded length instead so clients accept the range (P0-09).
 	app.open_files[uri] = 'module main\nimport foo'
 	diag := LSPDiagnostic{
-		message: 'unknown module `foo`'
+		message: 'cannot import module "foo" (not found)'
 		range:   LSPRange{
 			start: Position{
 				line: 1
@@ -6331,7 +6331,7 @@ fn test_workspace_configuration_toggles_feature_behavior() {
 
 	app.on_did_change_configuration(Request{
 		method: 'workspace/didChangeConfiguration'
-		params: '{"settings":{"vls":{"inlayHints":false,"diagnostics":false}}}'
+		params: '{"settings":{"vls":{"inlayHints":{"enabled":false},"diagnostics":{"enabled":false}}}}'
 	})
 	assert !app.inlay_hints_enabled
 	assert !app.diagnostics_enabled

--- a/interop.v
+++ b/interop.v
@@ -273,8 +273,9 @@ fn build_v_fmt_args(temp_file string) []string {
 
 // parse_v_check_diagnostics converts V3's flat-AST checker output into the
 // compiler-neutral diagnostic representation used by the LSP layer. V3 emits
-// headers as `path:line:column: severity: message`; paths may themselves
-// contain colons, so location fields are peeled from the right.
+// headers as `path:line:column: severity: message`; stage-specific severities
+// such as `builder error` are exposed to LSP clients as errors. Paths may
+// themselves contain colons, so location fields are peeled from the right.
 fn parse_v_check_diagnostics(output string, source_dir string) []JsonError {
 	mut diagnostics := []JsonError{}
 	mut active := -1
@@ -311,7 +312,8 @@ fn diagnostic_source_path_is_valid(path string, source_dir string) bool {
 fn parse_v_check_diagnostic_header(line string, source_dir string) ?JsonError {
 	mut best_marker_idx := -1
 	mut best := JsonError{}
-	for level in ['error', 'warning', 'notice'] {
+	for level in ['builder error', 'parser error', 'checker error', 'cgen error', 'error',
+		'warning', 'notice'] {
 		marker := ': ${level}: '
 		mut search_end := line.len
 		for search_end > 0 {
@@ -341,7 +343,7 @@ fn parse_v_check_diagnostic_header(line string, source_dir string) ?JsonError {
 					message: line[marker_idx + marker.len..]
 					line_nr: line_nr_text.int()
 					col:     col_text.int()
-					level:   level
+					level:   if level.contains('error') { 'error' } else { level }
 				}
 			}
 			break

--- a/interop_test.v
+++ b/interop_test.v
@@ -411,6 +411,22 @@ fn test_parse_v_check_diagnostics_reads_v3_output() {
 	assert diagnostics[1].len == 5
 }
 
+fn test_parse_v_check_diagnostics_maps_v3_builder_error_to_error() {
+	output := '/tmp/main.v:3:1: builder error: cannot import module "missing" (not found)
+    3 | import missing
+      | ~~~~~~~~~~~~~~
+'
+	diagnostics := parse_v_check_diagnostics(output, '')
+	assert diagnostics == [JsonError{
+		path:    '/tmp/main.v'
+		message: 'cannot import module "missing" (not found)'
+		line_nr: 3
+		col:     1
+		len:     14
+		level:   'error'
+	}]
+}
+
 fn test_parse_v_check_diagnostics_preserves_windows_drive_path() {
 	header := r'C:\work\project\main.v:12:9: notice: deprecated declaration'
 	diagnostics := parse_v_check_diagnostics(header, '')

--- a/lsp.v
+++ b/lsp.v
@@ -389,11 +389,17 @@ struct WorkspaceInlayHintsSettings {
 	enabled ?bool
 }
 
+// WorkspaceDiagnosticsSettings supports the nested setting shape contributed
+// by the VS Code/VSCodium extension: `vls.diagnostics.enabled`.
+struct WorkspaceDiagnosticsSettings {
+	enabled ?bool
+}
+
 // WorkspaceVlsSettingsCompat mirrors WorkspaceVlsSettings but with nested
-// inlay-hints shape used by some clients.
+// feature settings used by the VS Code/VSCodium extension.
 struct WorkspaceVlsSettingsCompat {
 	inlay_hints WorkspaceInlayHintsSettings @[json: 'inlayHints']
-	diagnostics ?bool
+	diagnostics WorkspaceDiagnosticsSettings
 }
 
 // WorkspaceSettings is the top-level object inside DidChangeConfigurationParams.

--- a/lsp.v
+++ b/lsp.v
@@ -389,15 +389,29 @@ struct WorkspaceInlayHintsSettings {
 	enabled ?bool
 }
 
-// WorkspaceDiagnosticsSettings supports the nested setting shape contributed
-// by the VS Code/VSCodium extension: `vls.diagnostics.enabled`.
+// WorkspaceDiagnosticsSettings supports client payloads that send
+// `settings.vls.diagnostics.enabled` as a nested object.
 struct WorkspaceDiagnosticsSettings {
 	enabled ?bool
 }
 
 // WorkspaceVlsSettingsCompat mirrors WorkspaceVlsSettings but with nested
-// feature settings used by the VS Code/VSCodium extension.
+// inlay-hints shape used by some clients.
 struct WorkspaceVlsSettingsCompat {
+	inlay_hints WorkspaceInlayHintsSettings @[json: 'inlayHints']
+	diagnostics ?bool
+}
+
+// WorkspaceVlsSettingsNestedDiagnosticsCompat supports flat inlay hints with
+// nested diagnostics.
+struct WorkspaceVlsSettingsNestedDiagnosticsCompat {
+	inlay_hints ?bool @[json: 'inlayHints']
+	diagnostics WorkspaceDiagnosticsSettings
+}
+
+// WorkspaceVlsSettingsNestedFeaturesCompat supports both feature settings as
+// nested objects.
+struct WorkspaceVlsSettingsNestedFeaturesCompat {
 	inlay_hints WorkspaceInlayHintsSettings @[json: 'inlayHints']
 	diagnostics WorkspaceDiagnosticsSettings
 }
@@ -423,6 +437,22 @@ struct DidChangeConfigurationParamsCompat {
 	settings WorkspaceSettingsCompat
 }
 
+struct WorkspaceSettingsNestedDiagnosticsCompat {
+	vls WorkspaceVlsSettingsNestedDiagnosticsCompat
+}
+
+struct DidChangeConfigurationParamsNestedDiagnosticsCompat {
+	settings WorkspaceSettingsNestedDiagnosticsCompat
+}
+
+struct WorkspaceSettingsNestedFeaturesCompat {
+	vls WorkspaceVlsSettingsNestedFeaturesCompat
+}
+
+struct DidChangeConfigurationParamsNestedFeaturesCompat {
+	settings WorkspaceSettingsNestedFeaturesCompat
+}
+
 // DidChangeConfigurationDirectParams covers clients that send the VLS section
 // directly in `settings` (without a nested `settings.vls` object).
 struct DidChangeConfigurationDirectParams {
@@ -433,6 +463,14 @@ struct DidChangeConfigurationDirectParams {
 // when `inlayHints` is itself a nested object with `enabled`.
 struct DidChangeConfigurationDirectParamsCompat {
 	settings WorkspaceVlsSettingsCompat
+}
+
+struct DidChangeConfigurationDirectParamsNestedDiagnosticsCompat {
+	settings WorkspaceVlsSettingsNestedDiagnosticsCompat
+}
+
+struct DidChangeConfigurationDirectParamsNestedFeaturesCompat {
+	settings WorkspaceVlsSettingsNestedFeaturesCompat
 }
 
 // WorkspaceFolder describes a workspace root provided during initialize.


### PR DESCRIPTION
## Summary

- parse V3 stage-qualified compiler errors as LSP errors
- recognize current `cannot import module` diagnostics in the unknown-import quick fix
- accept the nested diagnostics setting shape sent by the VS Code/VSCodium extension

## Testing

- `v -no-memory-limit test .` (6/6 test files passed)
- `v .`
- VSCodium 1.126.04524 extension-host probe against `vlang/v` (6,290 V files,
  42/42 checks passed)
