### PR TITLE
fix: keep completion responsive during diagnostics

### DIFF
--- a/diagnostics_scheduler.v
+++ b/diagnostics_scheduler.v
@@ -35,6 +35,11 @@ struct DiagnosticsTicket {
 	project_generation u64
 }
 
+struct DiagnosticsProjectMutation {
+	project_key string
+	tickets     []DiagnosticsTicket
+}
+
 @[heap]
 struct DiagnosticsScheduler {
 mut:
@@ -69,12 +74,20 @@ fn (mut scheduler DiagnosticsScheduler) next_generation(uri string) (u64, u64) {
 // begin_project_schedule invalidates jobs whose snapshots include an older
 // buffer from the same project, then returns tickets for replacement jobs.
 fn (mut scheduler DiagnosticsScheduler) begin_project_schedule(uri string, project_key string) []DiagnosticsTicket {
+	return scheduler.begin_project_mutation(project_key, uri)
+}
+
+// begin_project_mutation invalidates pending and active jobs in a project. A
+// non-empty requested_uri also schedules diagnostics for that document.
+fn (mut scheduler DiagnosticsScheduler) begin_project_mutation(project_key string, requested_uri string) []DiagnosticsTicket {
 	scheduler.mutex.lock()
 	defer {
 		scheduler.mutex.unlock()
 	}
 	mut affected := map[string]bool{}
-	affected[uri] = true
+	if requested_uri != '' {
+		affected[requested_uri] = true
+	}
 	mut pending_uris := []string{}
 	for pending_uri, job in scheduler.pending_jobs {
 		if job.project_key == project_key {
@@ -206,43 +219,74 @@ fn (mut app App) schedule_diagnostics(uri string, content string) bool {
 	if mut scheduler := app.diagnostics_scheduler {
 		project_key := app.generation_key(uri)
 		tickets := scheduler.begin_project_schedule(uri, project_key)
-		ready_at := time.now().unix_milli() + diagnostics_debounce_ms
-		mut should_start := false
-		for ticket in tickets {
-			job_content := if ticket.uri == uri {
-				content
-			} else {
-				app.open_files[ticket.uri] or { continue }
-			}
-			mut version := ?i64(none)
-			if current_version := app.open_files_versions[ticket.uri] {
-				version = current_version
-			}
-			job := DiagnosticsJob{
-				uri: ticket.uri
-				content: job_content
-				version: version
-				project_key: project_key
-				project_generation: ticket.project_generation
-				position_encoding: app.position_encoding
-				open_files: app.open_files.clone()
-				project_generations: app.project_generations.clone()
-				write_mutex: app.write_mutex
-				tcp_conn: app.tcp_conn
-				global_generation: ticket.global_generation
-				generation: ticket.generation
-				ready_at: ready_at
-			}
-			if scheduler.enqueue(job) {
-				should_start = true
-			}
-		}
-		if should_start {
-			spawn run_diagnostics_worker(mut scheduler)
-		}
+		app.enqueue_diagnostics_tickets(mut scheduler, tickets, project_key, uri, content, '')
 		return true
 	}
 	return false
+}
+
+// begin_diagnostics_project_mutation invalidates existing jobs before App state
+// changes. finish_diagnostics_project_mutation rebuilds them from fresh state.
+fn (mut app App) begin_diagnostics_project_mutation(uri string) DiagnosticsProjectMutation {
+	if mut scheduler := app.diagnostics_scheduler {
+		project_key := app.generation_key(uri)
+		return DiagnosticsProjectMutation{
+			project_key: project_key
+			tickets: scheduler.begin_project_mutation(project_key, '')
+		}
+	}
+	return DiagnosticsProjectMutation{}
+}
+
+fn (mut app App) finish_diagnostics_project_mutation(mutation DiagnosticsProjectMutation, excluded_uri string) {
+	if !app.diagnostics_enabled || mutation.tickets.len == 0 {
+		return
+	}
+	if mut scheduler := app.diagnostics_scheduler {
+		app.enqueue_diagnostics_tickets(mut scheduler, mutation.tickets, mutation.project_key, '', '', excluded_uri)
+	}
+}
+
+fn (mut app App) enqueue_diagnostics_tickets(mut scheduler DiagnosticsScheduler, tickets []DiagnosticsTicket, project_key string, changed_uri string, changed_content string, excluded_uri string) {
+	ready_at := time.now().unix_milli() + diagnostics_debounce_ms
+	mut should_start := false
+	for ticket in tickets {
+		if ticket.uri == excluded_uri {
+			continue
+		}
+		job_content := if ticket.uri == changed_uri {
+			changed_content
+		} else if open_content := app.open_files[ticket.uri] {
+			open_content
+		} else {
+			os.read_file(uri_to_path(ticket.uri)) or { continue }
+		}
+		mut version := ?i64(none)
+		if current_version := app.open_files_versions[ticket.uri] {
+			version = current_version
+		}
+		job := DiagnosticsJob{
+			uri: ticket.uri
+			content: job_content
+			version: version
+			project_key: project_key
+			project_generation: ticket.project_generation
+			position_encoding: app.position_encoding
+			open_files: app.open_files.clone()
+			project_generations: app.project_generations.clone()
+			write_mutex: app.write_mutex
+			tcp_conn: app.tcp_conn
+			global_generation: ticket.global_generation
+			generation: ticket.generation
+			ready_at: ready_at
+		}
+		if scheduler.enqueue(job) {
+			should_start = true
+		}
+	}
+	if should_start {
+		spawn run_diagnostics_worker(mut scheduler)
+	}
 }
 
 fn (mut app App) cancel_scheduled_diagnostics(uri string) {

--- a/diagnostics_scheduler.v
+++ b/diagnostics_scheduler.v
@@ -1,0 +1,144 @@
+// Copyright (c) 2026 Alexander Medvednikov. All rights reserved.
+// Use of this source code is governed by a GPL license that can be found in the LICENSE file.
+module main
+
+import net
+import os
+import sync
+import time
+
+// Wait until typing pauses before starting a compiler process. Completion requests
+// can then overtake diagnostics instead of sitting behind a compile on every key.
+const diagnostics_debounce = 300 * time.millisecond
+
+@[heap]
+struct DiagnosticsScheduler {
+mut:
+	mutex             sync.Mutex
+	generations       map[string]u64
+	global_generation u64
+}
+
+fn new_diagnostics_scheduler() &DiagnosticsScheduler {
+	return &DiagnosticsScheduler{
+		generations: map[string]u64{}
+	}
+}
+
+fn (mut scheduler DiagnosticsScheduler) next_generation(uri string) (u64, u64) {
+	scheduler.mutex.lock()
+	defer {
+		scheduler.mutex.unlock()
+	}
+	scheduler.generations[uri] = scheduler.generations[uri] + 1
+	return scheduler.global_generation, scheduler.generations[uri]
+}
+
+fn (mut scheduler DiagnosticsScheduler) is_current(uri string, global_generation u64, generation u64) bool {
+	scheduler.mutex.lock()
+	defer {
+		scheduler.mutex.unlock()
+	}
+	return scheduler.global_generation == global_generation
+		&& scheduler.generations[uri] == generation
+}
+
+fn (mut scheduler DiagnosticsScheduler) cancel(uri string) {
+	scheduler.mutex.lock()
+	scheduler.generations[uri] = scheduler.generations[uri] + 1
+	scheduler.mutex.unlock()
+}
+
+fn (mut scheduler DiagnosticsScheduler) cancel_all() {
+	scheduler.mutex.lock()
+	scheduler.global_generation++
+	scheduler.mutex.unlock()
+}
+
+struct DiagnosticsJob {
+	uri                 string
+	content             string
+	version             ?i64
+	position_encoding   PositionEncoding
+	open_files          map[string]string
+	project_generations map[string]int
+	scheduler           &DiagnosticsScheduler
+	write_mutex         &sync.Mutex
+	tcp_conn            ?&net.TcpConn
+	global_generation   u64
+	generation          u64
+}
+
+fn (mut app App) schedule_diagnostics(uri string, content string) bool {
+	if !app.diagnostics_enabled {
+		return false
+	}
+	if mut scheduler := app.diagnostics_scheduler {
+		global_generation, generation := scheduler.next_generation(uri)
+		mut version := ?i64(none)
+		if current_version := app.open_files_versions[uri] {
+			version = current_version
+		}
+		job := DiagnosticsJob{
+			uri: uri
+			content: content
+			version: version
+			position_encoding: app.position_encoding
+			open_files: app.open_files.clone()
+			project_generations: app.project_generations.clone()
+			scheduler: scheduler
+			write_mutex: app.write_mutex
+			tcp_conn: app.tcp_conn
+			global_generation: global_generation
+			generation: generation
+		}
+		spawn run_diagnostics_job(job)
+		return true
+	}
+	return false
+}
+
+fn (mut app App) cancel_scheduled_diagnostics(uri string) {
+	if mut scheduler := app.diagnostics_scheduler {
+		scheduler.cancel(uri)
+	}
+}
+
+fn (mut app App) cancel_all_scheduled_diagnostics() {
+	if mut scheduler := app.diagnostics_scheduler {
+		scheduler.cancel_all()
+	}
+}
+
+fn run_diagnostics_job(job DiagnosticsJob) {
+	mut scheduler := job.scheduler
+	time.sleep(diagnostics_debounce)
+	if !scheduler.is_current(job.uri, job.global_generation, job.generation) {
+		return
+	}
+	temp_dir := os.join_path(os.temp_dir(), 'vls_diag_${os.getpid()}_${job.generation}_${time.now().unix_nano()}')
+	os.mkdir_all(temp_dir) or { return }
+	defer {
+		os.rmdir_all(temp_dir) or {}
+	}
+	mut versions := map[string]i64{}
+	if version := job.version {
+		versions[job.uri] = version
+	}
+	mut worker := App{
+		text: job.content
+		open_files: job.open_files
+		open_files_versions: versions
+		temp_dir: temp_dir
+		diagnostics_enabled: true
+		diag_cache: map[string]DiagCacheEntry{}
+		project_generations: job.project_generations
+		position_encoding: job.position_encoding
+		write_mutex: job.write_mutex
+		tcp_conn: job.tcp_conn
+	}
+	notification := worker.build_diagnostics_notification(job.uri, job.content)
+	if scheduler.is_current(job.uri, job.global_generation, job.generation) {
+		worker.write_notification(notification)
+	}
+}

--- a/diagnostics_scheduler.v
+++ b/diagnostics_scheduler.v
@@ -213,13 +213,30 @@ fn (mut scheduler DiagnosticsScheduler) cancel_all() {
 }
 
 fn (mut app App) schedule_diagnostics(uri string, content string) bool {
+	mutation := app.begin_diagnostics_project_schedule(uri)
+	return app.finish_diagnostics_project_schedule(mutation, uri, content)
+}
+
+fn (mut app App) begin_diagnostics_project_schedule(uri string) DiagnosticsProjectMutation {
 	if !app.diagnostics_enabled {
-		return false
+		return DiagnosticsProjectMutation{}
 	}
 	if mut scheduler := app.diagnostics_scheduler {
 		project_key := app.generation_key(uri)
-		tickets := scheduler.begin_project_schedule(uri, project_key)
-		app.enqueue_diagnostics_tickets(mut scheduler, tickets, project_key, uri, content, '')
+		return DiagnosticsProjectMutation{
+			project_key: project_key
+			tickets: scheduler.begin_project_schedule(uri, project_key)
+		}
+	}
+	return DiagnosticsProjectMutation{}
+}
+
+fn (mut app App) finish_diagnostics_project_schedule(mutation DiagnosticsProjectMutation, uri string, content string) bool {
+	if !app.diagnostics_enabled || mutation.tickets.len == 0 {
+		return false
+	}
+	if mut scheduler := app.diagnostics_scheduler {
+		app.enqueue_diagnostics_tickets(mut scheduler, mutation.tickets, mutation.project_key, uri, content, '')
 		return true
 	}
 	return false

--- a/diagnostics_scheduler.v
+++ b/diagnostics_scheduler.v
@@ -16,6 +16,8 @@ struct DiagnosticsJob {
 	uri                 string
 	content             string
 	version             ?i64
+	project_key         string
+	project_generation  u64
 	position_encoding   PositionEncoding
 	open_files          map[string]string
 	project_generations map[string]int
@@ -26,19 +28,31 @@ struct DiagnosticsJob {
 	ready_at            i64
 }
 
+struct DiagnosticsTicket {
+	uri                string
+	global_generation  u64
+	generation         u64
+	project_generation u64
+}
+
 @[heap]
 struct DiagnosticsScheduler {
 mut:
-	mutex             sync.Mutex
-	generations       map[string]u64
-	global_generation u64
-	pending_jobs      map[string]DiagnosticsJob
-	worker_running    bool
+	mutex               sync.Mutex
+	generations         map[string]u64
+	project_generations map[string]u64
+	global_generation   u64
+	pending_jobs        map[string]DiagnosticsJob
+	worker_running      bool
+	active_uri          string
+	active_project_key  string
+	active_generation   u64
 }
 
 fn new_diagnostics_scheduler() &DiagnosticsScheduler {
 	return &DiagnosticsScheduler{
 		generations: map[string]u64{}
+		project_generations: map[string]u64{}
 		pending_jobs: map[string]DiagnosticsJob{}
 	}
 }
@@ -50,6 +64,43 @@ fn (mut scheduler DiagnosticsScheduler) next_generation(uri string) (u64, u64) {
 	}
 	scheduler.generations[uri] = scheduler.generations[uri] + 1
 	return scheduler.global_generation, scheduler.generations[uri]
+}
+
+// begin_project_schedule invalidates jobs whose snapshots include an older
+// buffer from the same project, then returns tickets for replacement jobs.
+fn (mut scheduler DiagnosticsScheduler) begin_project_schedule(uri string, project_key string) []DiagnosticsTicket {
+	scheduler.mutex.lock()
+	defer {
+		scheduler.mutex.unlock()
+	}
+	mut affected := map[string]bool{}
+	affected[uri] = true
+	mut pending_uris := []string{}
+	for pending_uri, job in scheduler.pending_jobs {
+		if job.project_key == project_key {
+			affected[pending_uri] = true
+			pending_uris << pending_uri
+		}
+	}
+	for pending_uri in pending_uris {
+		scheduler.pending_jobs.delete(pending_uri)
+	}
+	if scheduler.active_project_key == project_key && scheduler.active_uri != '' {
+		affected[scheduler.active_uri] = true
+	}
+	scheduler.project_generations[project_key] = scheduler.project_generations[project_key] + 1
+	project_generation := scheduler.project_generations[project_key]
+	mut tickets := []DiagnosticsTicket{cap: affected.len}
+	for affected_uri, _ in affected {
+		scheduler.generations[affected_uri] = scheduler.generations[affected_uri] + 1
+		tickets << DiagnosticsTicket{
+			uri: affected_uri
+			global_generation: scheduler.global_generation
+			generation: scheduler.generations[affected_uri]
+			project_generation: project_generation
+		}
+	}
+	return tickets
 }
 
 fn (mut scheduler DiagnosticsScheduler) is_current(uri string, global_generation u64, generation u64) bool {
@@ -65,6 +116,19 @@ fn (scheduler &DiagnosticsScheduler) is_current_locked(uri string, global_genera
 		&& scheduler.generations[uri] == generation
 }
 
+fn (mut scheduler DiagnosticsScheduler) is_job_current(job DiagnosticsJob) bool {
+	scheduler.mutex.lock()
+	defer {
+		scheduler.mutex.unlock()
+	}
+	return scheduler.is_job_current_locked(job)
+}
+
+fn (scheduler &DiagnosticsScheduler) is_job_current_locked(job DiagnosticsJob) bool {
+	return scheduler.is_current_locked(job.uri, job.global_generation, job.generation)
+		&& scheduler.project_generations[job.project_key] == job.project_generation
+}
+
 // enqueue replaces an older pending job for the same document and returns true
 // only when the caller must start the single diagnostics worker.
 fn (mut scheduler DiagnosticsScheduler) enqueue(job DiagnosticsJob) bool {
@@ -78,29 +142,47 @@ fn (mut scheduler DiagnosticsScheduler) enqueue(job DiagnosticsJob) bool {
 	return should_start
 }
 
-// take_ready_jobs removes jobs whose debounce deadline has passed. The second
-// result tells the worker that the queue is empty and it can stop.
+// take_ready_jobs removes at most one job whose debounce deadline has passed.
+// The second result tells the worker that the queue is empty and it can stop.
 fn (mut scheduler DiagnosticsScheduler) take_ready_jobs(now i64) ([]DiagnosticsJob, bool) {
 	scheduler.mutex.lock()
 	defer {
 		scheduler.mutex.unlock()
 	}
-	mut ready := []DiagnosticsJob{}
-	mut ready_uris := []string{}
-	for uri, job in scheduler.pending_jobs {
-		if job.ready_at <= now {
-			ready << job
-			ready_uris << uri
+	mut ready := []DiagnosticsJob{cap: 1}
+	mut ready_uri := ''
+	if scheduler.active_uri == '' {
+		for uri, job in scheduler.pending_jobs {
+			if job.ready_at <= now {
+				ready << job
+				ready_uri = uri
+				break
+			}
 		}
 	}
-	for uri in ready_uris {
-		scheduler.pending_jobs.delete(uri)
+	if ready_uri != '' {
+		job := ready[0]
+		scheduler.pending_jobs.delete(ready_uri)
+		scheduler.active_uri = job.uri
+		scheduler.active_project_key = job.project_key
+		scheduler.active_generation = job.generation
 	}
 	should_stop := ready.len == 0 && scheduler.pending_jobs.len == 0
+		&& scheduler.active_uri == ''
 	if should_stop {
 		scheduler.worker_running = false
 	}
 	return ready, should_stop
+}
+
+fn (mut scheduler DiagnosticsScheduler) finish(job DiagnosticsJob) {
+	scheduler.mutex.lock()
+	if scheduler.active_uri == job.uri && scheduler.active_generation == job.generation {
+		scheduler.active_uri = ''
+		scheduler.active_project_key = ''
+		scheduler.active_generation = 0
+	}
+	scheduler.mutex.unlock()
 }
 
 fn (mut scheduler DiagnosticsScheduler) cancel(uri string) {
@@ -122,25 +204,40 @@ fn (mut app App) schedule_diagnostics(uri string, content string) bool {
 		return false
 	}
 	if mut scheduler := app.diagnostics_scheduler {
-		global_generation, generation := scheduler.next_generation(uri)
-		mut version := ?i64(none)
-		if current_version := app.open_files_versions[uri] {
-			version = current_version
+		project_key := app.generation_key(uri)
+		tickets := scheduler.begin_project_schedule(uri, project_key)
+		ready_at := time.now().unix_milli() + diagnostics_debounce_ms
+		mut should_start := false
+		for ticket in tickets {
+			job_content := if ticket.uri == uri {
+				content
+			} else {
+				app.open_files[ticket.uri] or { continue }
+			}
+			mut version := ?i64(none)
+			if current_version := app.open_files_versions[ticket.uri] {
+				version = current_version
+			}
+			job := DiagnosticsJob{
+				uri: ticket.uri
+				content: job_content
+				version: version
+				project_key: project_key
+				project_generation: ticket.project_generation
+				position_encoding: app.position_encoding
+				open_files: app.open_files.clone()
+				project_generations: app.project_generations.clone()
+				write_mutex: app.write_mutex
+				tcp_conn: app.tcp_conn
+				global_generation: ticket.global_generation
+				generation: ticket.generation
+				ready_at: ready_at
+			}
+			if scheduler.enqueue(job) {
+				should_start = true
+			}
 		}
-		job := DiagnosticsJob{
-			uri: uri
-			content: content
-			version: version
-			position_encoding: app.position_encoding
-			open_files: app.open_files.clone()
-			project_generations: app.project_generations.clone()
-			write_mutex: app.write_mutex
-			tcp_conn: app.tcp_conn
-			global_generation: global_generation
-			generation: generation
-			ready_at: time.now().unix_milli() + diagnostics_debounce_ms
-		}
-		if scheduler.enqueue(job) {
+		if should_start {
 			spawn run_diagnostics_worker(mut scheduler)
 		}
 		return true
@@ -169,12 +266,13 @@ fn run_diagnostics_worker(mut scheduler DiagnosticsScheduler) {
 		}
 		for job in jobs {
 			run_diagnostics_job(mut scheduler, job)
+			scheduler.finish(job)
 		}
 	}
 }
 
 fn run_diagnostics_job(mut scheduler DiagnosticsScheduler, job DiagnosticsJob) {
-	if !scheduler.is_current(job.uri, job.global_generation, job.generation) {
+	if !scheduler.is_job_current(job) {
 		return
 	}
 	temp_dir := os.join_path(os.temp_dir(), 'vls_diag_${os.getpid()}_${job.generation}_${time.now().unix_nano()}')
@@ -210,7 +308,7 @@ fn (mut scheduler DiagnosticsScheduler) publish_if_current(mut app App, job Diag
 	defer {
 		scheduler.mutex.unlock()
 	}
-	if !scheduler.is_current_locked(job.uri, job.global_generation, job.generation) {
+	if !scheduler.is_job_current_locked(job) {
 		return false
 	}
 	app.write_notification(notification)

--- a/diagnostics_scheduler.v
+++ b/diagnostics_scheduler.v
@@ -9,7 +9,22 @@ import time
 
 // Wait until typing pauses before starting a compiler process. Completion requests
 // can then overtake diagnostics instead of sitting behind a compile on every key.
-const diagnostics_debounce = 300 * time.millisecond
+const diagnostics_debounce_ms = 300
+const diagnostics_worker_poll = 25 * time.millisecond
+
+struct DiagnosticsJob {
+	uri                 string
+	content             string
+	version             ?i64
+	position_encoding   PositionEncoding
+	open_files          map[string]string
+	project_generations map[string]int
+	write_mutex         &sync.Mutex
+	tcp_conn            ?&net.TcpConn
+	global_generation   u64
+	generation          u64
+	ready_at            i64
+}
 
 @[heap]
 struct DiagnosticsScheduler {
@@ -17,11 +32,14 @@ mut:
 	mutex             sync.Mutex
 	generations       map[string]u64
 	global_generation u64
+	pending_jobs      map[string]DiagnosticsJob
+	worker_running    bool
 }
 
 fn new_diagnostics_scheduler() &DiagnosticsScheduler {
 	return &DiagnosticsScheduler{
 		generations: map[string]u64{}
+		pending_jobs: map[string]DiagnosticsJob{}
 	}
 }
 
@@ -39,34 +57,64 @@ fn (mut scheduler DiagnosticsScheduler) is_current(uri string, global_generation
 	defer {
 		scheduler.mutex.unlock()
 	}
+	return scheduler.is_current_locked(uri, global_generation, generation)
+}
+
+fn (scheduler &DiagnosticsScheduler) is_current_locked(uri string, global_generation u64, generation u64) bool {
 	return scheduler.global_generation == global_generation
 		&& scheduler.generations[uri] == generation
+}
+
+// enqueue replaces an older pending job for the same document and returns true
+// only when the caller must start the single diagnostics worker.
+fn (mut scheduler DiagnosticsScheduler) enqueue(job DiagnosticsJob) bool {
+	scheduler.mutex.lock()
+	defer {
+		scheduler.mutex.unlock()
+	}
+	scheduler.pending_jobs[job.uri] = job
+	should_start := !scheduler.worker_running
+	scheduler.worker_running = true
+	return should_start
+}
+
+// take_ready_jobs removes jobs whose debounce deadline has passed. The second
+// result tells the worker that the queue is empty and it can stop.
+fn (mut scheduler DiagnosticsScheduler) take_ready_jobs(now i64) ([]DiagnosticsJob, bool) {
+	scheduler.mutex.lock()
+	defer {
+		scheduler.mutex.unlock()
+	}
+	mut ready := []DiagnosticsJob{}
+	mut ready_uris := []string{}
+	for uri, job in scheduler.pending_jobs {
+		if job.ready_at <= now {
+			ready << job
+			ready_uris << uri
+		}
+	}
+	for uri in ready_uris {
+		scheduler.pending_jobs.delete(uri)
+	}
+	should_stop := ready.len == 0 && scheduler.pending_jobs.len == 0
+	if should_stop {
+		scheduler.worker_running = false
+	}
+	return ready, should_stop
 }
 
 fn (mut scheduler DiagnosticsScheduler) cancel(uri string) {
 	scheduler.mutex.lock()
 	scheduler.generations[uri] = scheduler.generations[uri] + 1
+	scheduler.pending_jobs.delete(uri)
 	scheduler.mutex.unlock()
 }
 
 fn (mut scheduler DiagnosticsScheduler) cancel_all() {
 	scheduler.mutex.lock()
 	scheduler.global_generation++
+	scheduler.pending_jobs.clear()
 	scheduler.mutex.unlock()
-}
-
-struct DiagnosticsJob {
-	uri                 string
-	content             string
-	version             ?i64
-	position_encoding   PositionEncoding
-	open_files          map[string]string
-	project_generations map[string]int
-	scheduler           &DiagnosticsScheduler
-	write_mutex         &sync.Mutex
-	tcp_conn            ?&net.TcpConn
-	global_generation   u64
-	generation          u64
 }
 
 fn (mut app App) schedule_diagnostics(uri string, content string) bool {
@@ -86,13 +134,15 @@ fn (mut app App) schedule_diagnostics(uri string, content string) bool {
 			position_encoding: app.position_encoding
 			open_files: app.open_files.clone()
 			project_generations: app.project_generations.clone()
-			scheduler: scheduler
 			write_mutex: app.write_mutex
 			tcp_conn: app.tcp_conn
 			global_generation: global_generation
 			generation: generation
+			ready_at: time.now().unix_milli() + diagnostics_debounce_ms
 		}
-		spawn run_diagnostics_job(job)
+		if scheduler.enqueue(job) {
+			spawn run_diagnostics_worker(mut scheduler)
+		}
 		return true
 	}
 	return false
@@ -110,9 +160,20 @@ fn (mut app App) cancel_all_scheduled_diagnostics() {
 	}
 }
 
-fn run_diagnostics_job(job DiagnosticsJob) {
-	mut scheduler := job.scheduler
-	time.sleep(diagnostics_debounce)
+fn run_diagnostics_worker(mut scheduler DiagnosticsScheduler) {
+	for {
+		time.sleep(diagnostics_worker_poll)
+		jobs, should_stop := scheduler.take_ready_jobs(time.now().unix_milli())
+		if should_stop {
+			return
+		}
+		for job in jobs {
+			run_diagnostics_job(mut scheduler, job)
+		}
+	}
+}
+
+fn run_diagnostics_job(mut scheduler DiagnosticsScheduler, job DiagnosticsJob) {
 	if !scheduler.is_current(job.uri, job.global_generation, job.generation) {
 		return
 	}
@@ -138,7 +199,20 @@ fn run_diagnostics_job(job DiagnosticsJob) {
 		tcp_conn: job.tcp_conn
 	}
 	notification := worker.build_diagnostics_notification(job.uri, job.content)
-	if scheduler.is_current(job.uri, job.global_generation, job.generation) {
-		worker.write_notification(notification)
+	scheduler.publish_if_current(mut worker, job, notification)
+}
+
+// publish_if_current keeps validation and the transport write atomic with
+// cancellation. A close or disable that wins this lock suppresses the result;
+// one that follows it will publish its clearing notification afterward.
+fn (mut scheduler DiagnosticsScheduler) publish_if_current(mut app App, job DiagnosticsJob, notification Notification) bool {
+	scheduler.mutex.lock()
+	defer {
+		scheduler.mutex.unlock()
 	}
+	if !scheduler.is_current_locked(job.uri, job.global_generation, job.generation) {
+		return false
+	}
+	app.write_notification(notification)
+	return true
 }

--- a/handlers.v
+++ b/handlers.v
@@ -587,8 +587,14 @@ fn (mut app App) on_did_close(request Request) {
 		return
 	}
 	uri := params.text_document.uri
-	app.cancel_scheduled_diagnostics(uri)
-	if uri in app.open_files {
+	is_open := uri in app.open_files
+	mut diagnostics_mutation := DiagnosticsProjectMutation{}
+	if is_open {
+		diagnostics_mutation = app.begin_diagnostics_project_mutation(uri)
+	} else {
+		app.cancel_scheduled_diagnostics(uri)
+	}
+	if is_open {
 		app.open_files.delete(uri)
 		app.bump_generation(uri)
 	}
@@ -597,6 +603,9 @@ fn (mut app App) on_did_close(request Request) {
 	}
 	if uri in app.diag_cache {
 		app.diag_cache.delete(uri)
+	}
+	if is_open {
+		app.finish_diagnostics_project_mutation(diagnostics_mutation, uri)
 	}
 	// The buffer is gone; re-index from disk so the file's symbols remain
 	// discoverable with their on-disk content. Remove the client URI alias and

--- a/handlers.v
+++ b/handlers.v
@@ -716,6 +716,9 @@ fn (mut app App) on_did_change(request Request) ?Notification {
 			content = change.text
 		}
 	}
+	// Invalidate every diagnostic snapshot for this project before publishing
+	// the new buffer state. Replacements are built after the mutation below.
+	diagnostics_mutation := app.begin_diagnostics_project_schedule(uri)
 	app.text = content
 	app.open_files[uri] = content // Update tracked file
 	if version := params.text_document.version {
@@ -723,7 +726,7 @@ fn (mut app App) on_did_change(request Request) ?Notification {
 	}
 	app.bump_generation(uri)
 	app.invalidate_index_uri(uri) // symbols re-parsed lazily on next query
-	if app.schedule_diagnostics(uri, content) {
+	if app.finish_diagnostics_project_schedule(diagnostics_mutation, uri, content) {
 		return none
 	}
 	notification := app.build_diagnostics_notification(uri, content)

--- a/handlers.v
+++ b/handlers.v
@@ -548,11 +548,12 @@ fn parse_public_module_member_completions(content string) []Detail {
 	return items
 }
 
-// on_did_open handles the LSP didOpen notification, loading file content into the server state.
-fn (mut app App) on_did_open(request Request) {
+// on_did_open handles the LSP didOpen notification, loading file content into
+// the server state. It returns true when diagnostics were scheduled.
+fn (mut app App) on_did_open(request Request) bool {
 	params := json2.decode[DidOpenTextDocumentParams](request.params) or {
 		$if debug { log('Failed to decode DidOpenTextDocumentParams: ${err}') }
-		return
+		return false
 	}
 	uri := params.text_document.uri
 	log('on_did_open: ${uri}')
@@ -564,9 +565,10 @@ fn (mut app App) on_did_open(request Request) {
 		real_path := uri_to_path(uri)
 		content = os.read_file(real_path) or {
 			$if debug { log('Failed to read file ${real_path}: ${err}') }
-			return
+			return false
 		}
 	}
+	diagnostics_mutation := app.begin_diagnostics_project_schedule(uri)
 	app.open_files[uri] = content
 	if version := params.text_document.version {
 		app.open_files_versions[uri] = version
@@ -575,6 +577,7 @@ fn (mut app App) on_did_open(request Request) {
 	app.invalidate_index_uri(uri) // re-parse from the buffer on next query
 	app.text = content
 	$if debug { log('STORED CONTENT for uri=${uri}, FILE COUNT: ${app.open_files.len}') }
+	return app.finish_diagnostics_project_schedule(diagnostics_mutation, uri, content)
 }
 
 // on_did_close handles the LSP didClose notification by removing the file from
@@ -777,10 +780,12 @@ fn (mut app App) on_did_save(request Request) ?Notification {
 	// tracked as open (P0-07 item 6). When the client includes save text and
 	// the document is open, prefer the client's text as the new source of truth.
 	mut content := ''
+	mut diagnostics_mutation := DiagnosticsProjectMutation{}
 	if existing := app.open_files[uri] {
 		content = existing
 		if text := params.text {
 			content = text
+			diagnostics_mutation = app.begin_diagnostics_project_schedule(uri)
 			app.open_files[uri] = text
 			app.text = text
 			app.bump_generation(uri)
@@ -801,7 +806,11 @@ fn (mut app App) on_did_save(request Request) ?Notification {
 			}
 		}
 	}
-	if app.schedule_diagnostics(uri, content) {
+	if diagnostics_mutation.tickets.len > 0 {
+		if app.finish_diagnostics_project_schedule(diagnostics_mutation, uri, content) {
+			return none
+		}
+	} else if app.schedule_diagnostics(uri, content) {
 		return none
 	}
 	notification := app.build_diagnostics_notification(uri, content)

--- a/handlers.v
+++ b/handlers.v
@@ -587,6 +587,7 @@ fn (mut app App) on_did_close(request Request) {
 		return
 	}
 	uri := params.text_document.uri
+	app.cancel_scheduled_diagnostics(uri)
 	if uri in app.open_files {
 		app.open_files.delete(uri)
 		app.bump_generation(uri)
@@ -713,6 +714,9 @@ fn (mut app App) on_did_change(request Request) ?Notification {
 	}
 	app.bump_generation(uri)
 	app.invalidate_index_uri(uri) // symbols re-parsed lazily on next query
+	if app.schedule_diagnostics(uri, content) {
+		return none
+	}
 	notification := app.build_diagnostics_notification(uri, content)
 	$if debug { log('returning notification: ${notification}') }
 	return notification
@@ -784,6 +788,9 @@ fn (mut app App) on_did_save(request Request) ?Notification {
 				return none
 			}
 		}
+	}
+	if app.schedule_diagnostics(uri, content) {
+		return none
 	}
 	notification := app.build_diagnostics_notification(uri, content)
 	return notification
@@ -4153,6 +4160,9 @@ fn (mut app App) on_did_change_configuration(request Request) {
 	if resolved.has_diagnostics {
 		if enabled := resolved.diagnostics {
 			app.diagnostics_enabled = enabled
+			if !enabled {
+				app.cancel_all_scheduled_diagnostics()
+			}
 			log('VLS: diagnostics_enabled=${enabled}')
 		}
 	}

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -576,6 +576,91 @@ fn test_diagnostics_scheduler_requeues_pending_sibling_with_latest_buffers() {
 	assert new_job_a.project_generation > old_job_a.project_generation
 }
 
+fn test_diagnostics_scheduler_requeues_sibling_after_open() {
+	mut app := create_test_app()
+	defer {
+		app.cancel_all_scheduled_diagnostics()
+		cleanup_test_app(app)
+	}
+	mut scheduler := new_diagnostics_scheduler()
+	app.diagnostics_scheduler = scheduler
+	project_dir := os.join_path(app.temp_dir, 'open_sibling_project')
+	must_mkdir_all(project_dir)
+	uri_a := path_to_uri(os.join_path(project_dir, 'a.v'))
+	uri_b := path_to_uri(os.join_path(project_dir, 'b.v'))
+	content_a := 'module main\n\nfn uses_b() { opened_in_b() }\n'
+	content_b := 'module main\n\nfn opened_in_b() {}\n'
+	app.open_files[uri_a] = content_a
+	assert app.schedule_diagnostics(uri_a, content_a)
+	old_job_a := diagnostics_test_pending_job(mut scheduler, uri_a) or {
+		assert false, 'expected pending diagnostics for a.v'
+		return
+	}
+	assert uri_b !in old_job_a.open_files
+
+	assert app.on_did_open(Request{
+		params: json2.encode(DidOpenTextDocumentParams{
+			text_document: DidOpenTextDocumentItem{
+				uri: uri_b
+				text: content_b
+			}
+		},
+			escape_unicode: true
+		)
+	})
+
+	assert !scheduler.is_job_current(old_job_a)
+	new_job_a := diagnostics_test_pending_job(mut scheduler, uri_a) or {
+		assert false, 'expected replacement diagnostics for a.v'
+		return
+	}
+	assert new_job_a.open_files[uri_b] == content_b
+	assert new_job_a.project_generation > old_job_a.project_generation
+}
+
+fn test_diagnostics_scheduler_requeues_sibling_after_save_text() {
+	mut app := create_test_app()
+	defer {
+		app.cancel_all_scheduled_diagnostics()
+		cleanup_test_app(app)
+	}
+	mut scheduler := new_diagnostics_scheduler()
+	app.diagnostics_scheduler = scheduler
+	project_dir := os.join_path(app.temp_dir, 'save_sibling_project')
+	must_mkdir_all(project_dir)
+	uri_a := path_to_uri(os.join_path(project_dir, 'a.v'))
+	uri_b := path_to_uri(os.join_path(project_dir, 'b.v'))
+	content_a := 'module main\n\nfn uses_b() { saved_in_b() }\n'
+	old_content_b := 'module main\n\nfn old_in_b() {}\n'
+	new_content_b := 'module main\n\nfn saved_in_b() {}\n'
+	app.open_files[uri_a] = content_a
+	app.open_files[uri_b] = old_content_b
+	assert app.schedule_diagnostics(uri_a, content_a)
+	old_job_a := diagnostics_test_pending_job(mut scheduler, uri_a) or {
+		assert false, 'expected pending diagnostics for a.v'
+		return
+	}
+
+	result := app.on_did_save(Request{
+		params: json2.encode(DidSaveTextDocumentParams{
+			text_document: TextDocumentIdentifier{
+				uri: uri_b
+			}
+			text: new_content_b
+		},
+			escape_unicode: true
+		)
+	})
+	assert result == none
+	assert !scheduler.is_job_current(old_job_a)
+	new_job_a := diagnostics_test_pending_job(mut scheduler, uri_a) or {
+		assert false, 'expected replacement diagnostics for a.v'
+		return
+	}
+	assert new_job_a.open_files[uri_b] == new_content_b
+	assert new_job_a.project_generation > old_job_a.project_generation
+}
+
 fn test_diagnostics_scheduler_requeues_sibling_after_close() {
 	mut app := create_test_app()
 	defer {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -492,6 +492,71 @@ fn test_diagnostics_scheduler_invalidates_only_changed_document() {
 	assert !scheduler.is_current('file:///b.v', global_b, generation_b)
 }
 
+fn test_diagnostics_scheduler_coalesces_pending_jobs() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	mut scheduler := new_diagnostics_scheduler()
+	uri := 'file:///pending.v'
+	global_first, generation_first := scheduler.next_generation(uri)
+	assert scheduler.enqueue(DiagnosticsJob{
+		uri: uri
+		content: 'first'
+		global_generation: global_first
+		generation: generation_first
+		ready_at: 100
+		write_mutex: app.write_mutex
+	})
+	global_latest, generation_latest := scheduler.next_generation(uri)
+	assert !scheduler.enqueue(DiagnosticsJob{
+		uri: uri
+		content: 'latest'
+		global_generation: global_latest
+		generation: generation_latest
+		ready_at: 100
+		write_mutex: app.write_mutex
+	})
+
+	jobs, should_stop := scheduler.take_ready_jobs(100)
+	assert !should_stop
+	assert jobs.len == 1
+	assert jobs[0].content == 'latest'
+	assert scheduler.is_current(jobs[0].uri, jobs[0].global_generation, jobs[0].generation)
+
+	_, should_stop_after_drain := scheduler.take_ready_jobs(100)
+	assert should_stop_after_drain
+}
+
+fn test_diagnostics_scheduler_checks_staleness_while_publishing() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	app.capture_output = true
+	mut scheduler := new_diagnostics_scheduler()
+	uri := 'file:///publish.v'
+	global_generation, generation := scheduler.next_generation(uri)
+	job := DiagnosticsJob{
+		uri: uri
+		global_generation: global_generation
+		generation: generation
+		write_mutex: app.write_mutex
+	}
+	notification := Notification{
+		method: 'textDocument/publishDiagnostics'
+		params: PublishDiagnosticsParams{
+			uri: uri
+		}
+	}
+
+	assert scheduler.publish_if_current(mut app, job, notification)
+	assert app.captured_output.len == 1
+	scheduler.cancel(uri)
+	assert !scheduler.publish_if_current(mut app, job, notification)
+	assert app.captured_output.len == 1
+}
+
 fn test_on_did_change_multiple_changes() {
 	mut app := create_test_app()
 	defer {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -524,8 +524,87 @@ fn test_diagnostics_scheduler_coalesces_pending_jobs() {
 	assert jobs[0].content == 'latest'
 	assert scheduler.is_current(jobs[0].uri, jobs[0].global_generation, jobs[0].generation)
 
+	scheduler.finish(jobs[0])
 	_, should_stop_after_drain := scheduler.take_ready_jobs(100)
 	assert should_stop_after_drain
+}
+
+fn test_diagnostics_scheduler_requeues_pending_sibling_with_latest_buffers() {
+	mut app := create_test_app()
+	defer {
+		app.cancel_all_scheduled_diagnostics()
+		cleanup_test_app(app)
+	}
+	mut scheduler := new_diagnostics_scheduler()
+	app.diagnostics_scheduler = scheduler
+	project_dir := os.join_path(app.temp_dir, 'sibling_project')
+	must_mkdir_all(project_dir)
+	uri_a := path_to_uri(os.join_path(project_dir, 'a.v'))
+	uri_b := path_to_uri(os.join_path(project_dir, 'b.v'))
+	content_a := 'module main\n\nfn uses_b() { changed_in_b() }\n'
+	old_content_b := 'module main\n\nfn old_in_b() {}\n'
+	new_content_b := 'module main\n\nfn changed_in_b() {}\n'
+	app.open_files[uri_a] = content_a
+	app.open_files[uri_b] = old_content_b
+	assert app.schedule_diagnostics(uri_a, content_a)
+	old_job_a := diagnostics_test_pending_job(mut scheduler, uri_a) or {
+		assert false, 'expected pending diagnostics for a.v'
+		return
+	}
+
+	app.open_files[uri_b] = new_content_b
+	app.bump_generation(uri_b)
+	assert app.schedule_diagnostics(uri_b, new_content_b)
+	assert !scheduler.is_job_current(old_job_a)
+	new_job_a := diagnostics_test_pending_job(mut scheduler, uri_a) or {
+		assert false, 'expected replacement diagnostics for a.v'
+		return
+	}
+	assert new_job_a.open_files[uri_b] == new_content_b
+	assert new_job_a.project_generation > old_job_a.project_generation
+}
+
+fn test_diagnostics_scheduler_requeues_active_sibling() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	mut scheduler := new_diagnostics_scheduler()
+	uri_a := 'file:///project/a.v'
+	uri_b := 'file:///project/b.v'
+	project_key := 'file:///project'
+	tickets_a := scheduler.begin_project_schedule(uri_a, project_key)
+	assert tickets_a.len == 1
+	active_job := DiagnosticsJob{
+		uri: uri_a
+		project_key: project_key
+		project_generation: tickets_a[0].project_generation
+		global_generation: tickets_a[0].global_generation
+		generation: tickets_a[0].generation
+		ready_at: 0
+		write_mutex: app.write_mutex
+	}
+	assert scheduler.enqueue(active_job)
+	jobs, should_stop := scheduler.take_ready_jobs(0)
+	assert !should_stop
+	assert jobs.len == 1
+
+	tickets_b := scheduler.begin_project_schedule(uri_b, project_key)
+	assert !scheduler.is_job_current(active_job)
+	assert tickets_b.any(it.uri == uri_a)
+	assert tickets_b.any(it.uri == uri_b)
+	scheduler.finish(active_job)
+	_, should_stop_after_finish := scheduler.take_ready_jobs(0)
+	assert should_stop_after_finish
+}
+
+fn diagnostics_test_pending_job(mut scheduler DiagnosticsScheduler, uri string) ?DiagnosticsJob {
+	scheduler.mutex.lock()
+	defer {
+		scheduler.mutex.unlock()
+	}
+	job := scheduler.pending_jobs[uri] or { return none }
+	return job
 }
 
 fn test_diagnostics_scheduler_checks_staleness_while_publishing() {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -564,6 +564,96 @@ fn test_diagnostics_scheduler_requeues_pending_sibling_with_latest_buffers() {
 	assert new_job_a.project_generation > old_job_a.project_generation
 }
 
+fn test_diagnostics_scheduler_requeues_sibling_after_close() {
+	mut app := create_test_app()
+	defer {
+		app.cancel_all_scheduled_diagnostics()
+		cleanup_test_app(app)
+	}
+	mut scheduler := new_diagnostics_scheduler()
+	app.diagnostics_scheduler = scheduler
+	project_dir := os.join_path(app.temp_dir, 'close_sibling_project')
+	must_mkdir_all(project_dir)
+	path_a := os.join_path(project_dir, 'a.v')
+	path_b := os.join_path(project_dir, 'b.v')
+	uri_a := path_to_uri(path_a)
+	uri_b := path_to_uri(path_b)
+	content_a := 'module main\n\nfn uses_b() { disk_in_b() }\n'
+	open_content_b := 'module main\n\nfn unsaved_in_b() {}\n'
+	must_write_file(path_a, content_a)
+	must_write_file(path_b, 'module main\n\nfn disk_in_b() {}\n')
+	app.open_files[uri_a] = content_a
+	app.open_files[uri_b] = open_content_b
+	assert app.schedule_diagnostics(uri_a, content_a)
+	old_job_a := diagnostics_test_pending_job(mut scheduler, uri_a) or {
+		assert false, 'expected pending diagnostics for a.v'
+		return
+	}
+	assert old_job_a.open_files[uri_b] == open_content_b
+
+	app.on_did_close(Request{
+		params: json2.encode(DidCloseTextDocumentParams{
+			text_document: TextDocumentIdentifier{
+				uri: uri_b
+			}
+		},
+			escape_unicode: true
+		)
+	})
+
+	assert !scheduler.is_job_current(old_job_a)
+	new_job_a := diagnostics_test_pending_job(mut scheduler, uri_a) or {
+		assert false, 'expected replacement diagnostics for a.v'
+		return
+	}
+	assert uri_b !in new_job_a.open_files
+	assert new_job_a.project_generation > old_job_a.project_generation
+}
+
+fn test_diagnostics_scheduler_requeues_job_after_watched_file_change() {
+	mut app := create_test_app()
+	defer {
+		app.cancel_all_scheduled_diagnostics()
+		cleanup_test_app(app)
+	}
+	mut scheduler := new_diagnostics_scheduler()
+	app.diagnostics_scheduler = scheduler
+	project_dir := os.join_path(app.temp_dir, 'watched_sibling_project')
+	must_mkdir_all(project_dir)
+	path_a := os.join_path(project_dir, 'a.v')
+	path_b := os.join_path(project_dir, 'b.v')
+	uri_a := path_to_uri(path_a)
+	uri_b := path_to_uri(path_b)
+	content_a := 'module main\n\nfn uses_b() { changed_in_b() }\n'
+	must_write_file(path_a, content_a)
+	must_write_file(path_b, 'module main\n\nfn old_in_b() {}\n')
+	app.open_files[uri_a] = content_a
+	assert app.schedule_diagnostics(uri_a, content_a)
+	old_job_a := diagnostics_test_pending_job(mut scheduler, uri_a) or {
+		assert false, 'expected pending diagnostics for a.v'
+		return
+	}
+	old_cache_generation := old_job_a.project_generations[app.generation_key(uri_a)]
+	must_write_file(path_b, 'module main\n\nfn changed_in_b() {}\n')
+
+	app.on_did_change_watched_files(Request{
+		params: json2.encode(DidChangeWatchedFilesParams{
+			changes: [FileEvent{
+				uri: uri_b
+				event_type: 2
+			}]
+		})
+	})
+
+	assert !scheduler.is_job_current(old_job_a)
+	new_job_a := diagnostics_test_pending_job(mut scheduler, uri_a) or {
+		assert false, 'expected replacement diagnostics for a.v'
+		return
+	}
+	assert new_job_a.project_generation > old_job_a.project_generation
+	assert new_job_a.project_generations[app.generation_key(uri_a)] > old_cache_generation
+}
+
 fn test_diagnostics_scheduler_requeues_active_sibling() {
 	mut app := create_test_app()
 	defer {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -546,15 +546,27 @@ fn test_diagnostics_scheduler_requeues_pending_sibling_with_latest_buffers() {
 	new_content_b := 'module main\n\nfn changed_in_b() {}\n'
 	app.open_files[uri_a] = content_a
 	app.open_files[uri_b] = old_content_b
+	app.open_files_versions[uri_b] = 1
 	assert app.schedule_diagnostics(uri_a, content_a)
 	old_job_a := diagnostics_test_pending_job(mut scheduler, uri_a) or {
 		assert false, 'expected pending diagnostics for a.v'
 		return
 	}
 
-	app.open_files[uri_b] = new_content_b
-	app.bump_generation(uri_b)
-	assert app.schedule_diagnostics(uri_b, new_content_b)
+	result := app.on_did_change(Request{
+		params: json2.encode(DidChangeTextDocumentParams{
+			text_document: VersionedTextDocumentIdentifier{
+				uri: uri_b
+				version: 2
+			}
+			content_changes: [ContentChange{
+				text: new_content_b
+			}]
+		},
+			escape_unicode: true
+		)
+	})
+	assert result == none
 	assert !scheduler.is_job_current(old_job_a)
 	new_job_a := diagnostics_test_pending_job(mut scheduler, uri_a) or {
 		assert false, 'expected replacement diagnostics for a.v'

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -446,6 +446,52 @@ fn test_on_did_change_returns_notification() {
 	}
 }
 
+fn test_on_did_change_schedules_diagnostics_without_blocking() {
+	mut app := create_test_app()
+	defer {
+		app.cancel_all_scheduled_diagnostics()
+		cleanup_test_app(app)
+	}
+	app.diagnostics_scheduler = new_diagnostics_scheduler()
+	uri := 'file:///tmp/scheduled.v'
+	content := 'module main\n'
+	app.open_files[uri] = content
+	app.open_files_versions[uri] = 1
+
+	result := app.on_did_change(Request{
+		params: json2.encode(DidChangeTextDocumentParams{
+			text_document:   VersionedTextDocumentIdentifier{
+				uri:     uri
+				version: 2
+			}
+			content_changes: [ContentChange{
+				text: content + '\nfn changed() {}\n'
+			}]
+		},
+			escape_unicode: true
+		)
+	})
+
+	assert result == none
+	assert app.open_files_versions[uri] == 2
+	assert app.open_files[uri].contains('fn changed()')
+}
+
+fn test_diagnostics_scheduler_invalidates_only_changed_document() {
+	mut scheduler := new_diagnostics_scheduler()
+	global_a, generation_a := scheduler.next_generation('file:///a.v')
+	global_b, generation_b := scheduler.next_generation('file:///b.v')
+	assert scheduler.is_current('file:///a.v', global_a, generation_a)
+	assert scheduler.is_current('file:///b.v', global_b, generation_b)
+
+	scheduler.cancel('file:///a.v')
+	assert !scheduler.is_current('file:///a.v', global_a, generation_a)
+	assert scheduler.is_current('file:///b.v', global_b, generation_b)
+
+	scheduler.cancel_all()
+	assert !scheduler.is_current('file:///b.v', global_b, generation_b)
+}
+
 fn test_on_did_change_multiple_changes() {
 	mut app := create_test_app()
 	defer {

--- a/integration_test.v
+++ b/integration_test.v
@@ -1657,6 +1657,24 @@ fn test_integration_shutdown_response() {
 	assert transport_encoded.contains('"result":null')
 }
 
+fn test_integration_shutdown_cancels_diagnostics_before_response() {
+	mut app, project_dir := create_integration_test_env()
+	defer {
+		cleanup_integration_test_env(app, project_dir)
+	}
+	app.capture_output = true
+	mut scheduler := new_diagnostics_scheduler()
+	app.diagnostics_scheduler = scheduler
+	global_generation, generation := scheduler.next_generation('file:///shutdown.v')
+
+	app.accept_shutdown(2)
+
+	assert app.is_shutdown
+	assert !scheduler.is_current('file:///shutdown.v', global_generation, generation)
+	assert app.captured_output.len == 1
+	assert app.captured_output[0].contains('"id":2')
+}
+
 fn test_integration_malformed_json_request_writes_parse_error_response() {
 	mut app, project_dir := create_integration_test_env()
 	defer {

--- a/interop.v
+++ b/interop.v
@@ -1283,6 +1283,8 @@ fn (mut app App) on_did_change_watched_files(request Request) {
 		}
 		match change.event_type {
 			3 {
+				diagnostics_mutation := app.begin_diagnostics_project_mutation(uri)
+				is_open := uri in app.open_files
 				// Deleted on disk. Invalidate cached diagnostics, but do NOT drop
 				// an open editor buffer: the editor still owns the in-memory
 				// document even if the on-disk file was removed (P0-07 item 8).
@@ -1295,9 +1297,15 @@ fn (mut app App) on_did_change_watched_files(request Request) {
 				if uri !in app.open_files {
 					app.reindex_uri(uri)
 				}
+				app.finish_diagnostics_project_mutation(diagnostics_mutation, if is_open {
+					''
+				} else {
+					uri
+				})
 				log('on_did_change_watched_files: disk delete for ${uri}')
 			}
 			1, 2 {
+				diagnostics_mutation := app.begin_diagnostics_project_mutation(uri)
 				// Created or Changed on disk. The editor buffer is authoritative
 				// for any open document, so we must never overwrite open_files
 				// with disk content — doing so would erase unsaved edits (P0-07
@@ -1313,6 +1321,7 @@ fn (mut app App) on_did_change_watched_files(request Request) {
 					app.diag_cache.delete(uri)
 				}
 				app.bump_generation(uri)
+				app.finish_diagnostics_project_mutation(diagnostics_mutation, '')
 			}
 			else {}
 		}

--- a/main.v
+++ b/main.v
@@ -725,13 +725,11 @@ fn (mut app App) handle_requests(mut reader io.BufferedReader) {
 				}
 			}
 			.did_open {
-				app.on_did_open(lsp_request)
-				if params := json2.decode[DidOpenTextDocumentParams](lsp_request.params) {
+				if !app.on_did_open(lsp_request) {
+					params := json2.decode[DidOpenTextDocumentParams](lsp_request.params) or { continue }
 					uri := params.text_document.uri
 					if doc_content := app.open_files[uri] {
-						if !app.schedule_diagnostics(uri, doc_content) {
-							app.write_notification(app.build_diagnostics_notification(uri, doc_content))
-						}
+						app.write_notification(app.build_diagnostics_notification(uri, doc_content))
 					}
 				}
 			}

--- a/main.v
+++ b/main.v
@@ -767,13 +767,7 @@ fn (mut app App) handle_requests(mut reader io.BufferedReader) {
 				app.on_cancel_request(lsp_request)
 			}
 			.shutdown {
-				log('Received shutdown request.')
-				app.is_shutdown = true
-				shutdown_resp := Response{
-					id:     lsp_request.id
-					result: 'null'
-				}
-				app.write_response(shutdown_resp)
+				app.accept_shutdown(lsp_request.id)
 			}
 			.exit {
 				log('Received exit notification. Terminating.')
@@ -1237,6 +1231,16 @@ fn matches_needle_at(s string, i int, needle string) bool {
 
 fn (mut app App) write_notification(notification Notification) {
 	app.send_framed(json2.encode(notification, escape_unicode: true))
+}
+
+fn (mut app App) accept_shutdown(id int) {
+	log('Received shutdown request.')
+	app.cancel_all_scheduled_diagnostics()
+	app.is_shutdown = true
+	app.write_response(Response{
+		id:     id
+		result: 'null'
+	})
 }
 
 fn (mut app App) write_error_response(response ErrorResponse) {

--- a/main.v
+++ b/main.v
@@ -5,6 +5,7 @@ module main
 import json2
 import net
 import os
+import sync
 import time
 import io
 
@@ -47,6 +48,8 @@ mut:
 	exit_was_requested                          bool                         // True when the exit notification was received
 	received_initialize                         bool                         // True after initialize request was processed
 	next_request_id                             int = 1 // Counter for server-initiated request ids
+	diagnostics_scheduler                       ?&DiagnosticsScheduler // Production-only async diagnostics
+	write_mutex                                 &sync.Mutex = sync.new_mutex() // Serializes worker and request-loop writes
 }
 
 struct JsonError {
@@ -166,9 +169,10 @@ fn main() {
 		return
 	}
 	mut app := &App{
-		text:       ''
-		open_files: map[string]string{}
-		temp_dir:   temp_dir
+		text:                  ''
+		open_files:            map[string]string{}
+		temp_dir:              temp_dir
+		diagnostics_scheduler: new_diagnostics_scheduler()
 	}
 	// os.File.read uses C fread, which waits for the entire buffer on an open
 	// pipe. LSP clients keep stdin open, so use the raw descriptor-backed pipe
@@ -240,10 +244,11 @@ fn handle_tcp_client(mut conn net.TcpConn) {
 		return
 	}
 	mut app := &App{
-		text:       ''
-		open_files: map[string]string{}
-		temp_dir:   temp_dir
-		tcp_conn:   &conn
+		text:                  ''
+		open_files:            map[string]string{}
+		temp_dir:              temp_dir
+		tcp_conn:              &conn
+		diagnostics_scheduler: new_diagnostics_scheduler()
 	}
 	mut reader := io.new_buffered_reader(reader: conn, cap: transport_buffer_cap)
 	app.handle_requests(mut reader)
@@ -257,6 +262,10 @@ fn handle_tcp_client(mut conn net.TcpConn) {
 // write_data sends raw data to the client — either via the TCP connection when
 // in multi-client mode, or to stdout in stdio mode.
 fn (mut app App) write_data(data string) {
+	app.write_mutex.lock()
+	defer {
+		app.write_mutex.unlock()
+	}
 	if app.capture_output {
 		app.captured_output << data
 		return
@@ -470,6 +479,9 @@ fn parse_content_length_header(s string) !int {
 
 // handle_requests is the main request handler loop for both stdio and TCP modes.
 fn (mut app App) handle_requests(mut reader io.BufferedReader) {
+	defer {
+		app.cancel_all_scheduled_diagnostics()
+	}
 	for {
 		// Reset the per-request raw id so a stale id can never leak into an
 		// error response emitted before a new message is fully read.
@@ -714,18 +726,12 @@ fn (mut app App) handle_requests(mut reader io.BufferedReader) {
 			}
 			.did_open {
 				app.on_did_open(lsp_request)
-				// Publish diagnostics on open (P0-07 item 10). This compiles inline in
-				// the request loop, so opening many files serially blocks other
-				// requests until each compile returns. Moving it off the loop is the
-				// async-diagnostics scheduler (P0-04), which is blocked by the
-				// synchronous test harness and V's non-thread-safe shared state; until
-				// then each compile is bounded by compiler_timeout_ms so a single
-				// invocation cannot hang the loop indefinitely, and diag_cache avoids
-				// recompiling unchanged content.
 				if params := json2.decode[DidOpenTextDocumentParams](lsp_request.params) {
 					uri := params.text_document.uri
 					if doc_content := app.open_files[uri] {
-						app.write_notification(app.build_diagnostics_notification(uri, doc_content))
+						if !app.schedule_diagnostics(uri, doc_content) {
+							app.write_notification(app.build_diagnostics_notification(uri, doc_content))
+						}
 					}
 				}
 			}


### PR DESCRIPTION
## Summary

- debounce diagnostics and run compiler checks outside the LSP request loop
- serialize protocol writes from diagnostic workers and request handling
- discard stale diagnostic jobs when a document changes, closes, or diagnostics are disabled
- add regression coverage for non-blocking changes and per-document cancellation

## Why

`textDocument/didChange` ran `v check` synchronously. On the `vlang/v` workspace, each keystroke could block the request loop for about five seconds. Automatic completion requests were therefore delayed or cancelled, while Ctrl+Space appeared to work once the server became idle.

## Validation

- `v .`
- `v -silent test .` — 6/6 test suites passed
- `v fmt -verify diagnostics_scheduler.v`
- VSCodium 1.126.04524 on `/Users/alex/code/v`:
  - typing `os.` automatically sent a trigger-kind 2 completion request and returned 241 items
  - typing `prin` automatically sent a trigger-kind 1 completion request and returned 258 items, including `println`
  - diagnostics were still published for the final document version