### PR TITLE
feat: add runnable code lenses

### DIFF
--- a/handlers.v
+++ b/handlers.v
@@ -4474,8 +4474,42 @@ fn (mut app App) on_did_change_workspace_folders(request Request) {
 	log('VLS: workspace roots updated to ${app.workspace_roots}')
 }
 
+// code_lens_fn_name returns the name of a free-function declaration on one line.
+fn code_lens_fn_name(line string) string {
+	mut declaration := line.trim_space()
+	if declaration.starts_with('pub ') {
+		declaration = declaration[4..].trim_space()
+	}
+	if !declaration.starts_with('fn ') {
+		return ''
+	}
+	after_fn := declaration[3..].trim_space()
+	if after_fn.starts_with('(') {
+		return ''
+	}
+	paren_idx := after_fn.index('(') or { return '' }
+	name := after_fn[..paren_idx].trim_space()
+	if !is_valid_v_identifier_name(name) {
+		return ''
+	}
+	return name
+}
+
+fn code_lens_range(line int, raw_line string) LSPRange {
+	return LSPRange{
+		start: Position{
+			line: line
+			char: 0
+		}
+		end:   Position{
+			line: line
+			char: raw_line.len
+		}
+	}
+}
+
 // handle_code_lens handles textDocument/codeLens requests.
-// Returns run/test lens items for fn main() and fn test_* declarations.
+// It returns Run Main for main and Run File plus Run Test for test functions.
 fn (mut app App) handle_code_lens(request Request) Response {
 	params := json2.decode[CodeLensParams](request.params) or {
 		$if debug { log('Failed to decode CodeLensParams: ${err}') }
@@ -4488,53 +4522,36 @@ fn (mut app App) handle_code_lens(request Request) Response {
 	content := app.open_files[uri] or { os.read_file(uri_to_path(uri)) or { '' } }
 	lines := content.split_into_lines()
 	mut lenses := []CodeLens{}
+	mut scan_state := ImportScanState{}
+	is_test_file := uri_to_path(uri).ends_with('_test.v')
 	for i, raw_line in lines {
-		trimmed := raw_line.trim_space()
-		// fn main() → offer a "Run" lens.
-		if trimmed == 'fn main() {' || trimmed.starts_with('fn main()') {
+		code := source_line_import_code(raw_line, mut scan_state)
+		fn_name := code_lens_fn_name(code)
+		if fn_name == 'main' {
 			lenses << CodeLens{
-				range:   LSPRange{
-					start: Position{
-						line: i
-						char: 0
-					}
-					end:   Position{
-						line: i
-						char: raw_line.len
-					}
-				}
+				range:   code_lens_range(i, raw_line)
 				command: Command{
-					title:     '▶ Run'
+					title:     'Run Main'
 					command:   'vls.runFile'
 					arguments: [uri]
 				}
 			}
 		}
-		// fn test_* → offer a "Run Test" lens.
-		if (trimmed.starts_with('fn test_') || trimmed.starts_with('pub fn test_'))
-			&& trimmed.contains('(') {
-			fn_name := if trimmed.starts_with('pub ') {
-				first_word_paren(trimmed[7..])
-			} else {
-				first_word_paren(trimmed[3..])
+		if is_test_file && fn_name.starts_with('test_') {
+			lenses << CodeLens{
+				range:   code_lens_range(i, raw_line)
+				command: Command{
+					title:     'Run File'
+					command:   'vls.runTests'
+					arguments: [uri]
+				}
 			}
-			if fn_name != '' {
-				lenses << CodeLens{
-					range:   LSPRange{
-						start: Position{
-							line: i
-							char: 0
-						}
-						end:   Position{
-							line: i
-							char: raw_line.len
-						}
-					}
-					command: Command{
-						title:     '▶ Run Test'
-						command:   'vls.runTests'
-						arguments: [uri, fn_name]
-					}
+			lenses << CodeLens{
+				range:   code_lens_range(i, raw_line)
+				command: Command{
+					title:     'Run Test'
+					command:   'vls.runTests'
+					arguments: [uri, fn_name]
 				}
 			}
 		}
@@ -4561,8 +4578,47 @@ fn (mut app App) handle_code_lens_resolve(request Request) Response {
 	}
 }
 
-// handle_execute_command handles workspace/executeCommand.
-// Currently supports vls.runFile and vls.runTests by echoing a log message.
+fn code_lens_command_path(arguments []string) (string, string) {
+	if arguments.len == 0 || arguments[0].trim_space() == '' {
+		return '', 'missing file argument'
+	}
+	raw_path := arguments[0]
+	if raw_path.contains('://') && !raw_path.starts_with('file:') {
+		return '', 'only local files can be run'
+	}
+	path := os.real_path(uri_to_path(raw_path))
+	if !os.is_file(path) {
+		return '', 'file does not exist: ${path}'
+	}
+	if !path.ends_with('.v') && !path.ends_with('.vsh') {
+		return '', 'not a V source file: ${path}'
+	}
+	return path, ''
+}
+
+fn (mut app App) run_code_lens_command(title string, args []string, work_dir string) {
+	if !compiler_is_available() {
+		app.send_show_message('vls: the V compiler (`v`) was not found on PATH.', 1)
+		return
+	}
+	app.send_log_message('vls: ${title}: v ${args.join(' ')}', 3)
+	result := run_v_argv(args, work_dir)
+	output := result.output.trim_space()
+	if output != '' {
+		level := if result.exit_code == 0 { 3 } else { 1 }
+		app.send_log_message(output, level)
+	}
+	if result.exit_code == compiler_exit_timeout {
+		app.send_show_message('vls: ${title} timed out after ${resolve_compiler_timeout_ms()} ms.',
+			1)
+	} else if result.exit_code != 0 {
+		app.send_show_message('vls: ${title} failed with exit code ${result.exit_code}.', 1)
+	} else {
+		app.send_show_message('vls: ${title} finished successfully.', 3)
+	}
+}
+
+// handle_execute_command handles workspace/executeCommand by invoking the V compiler.
 fn (mut app App) handle_execute_command(request Request) Response {
 	params := json2.decode[ExecuteCommandParams](request.params) or {
 		$if debug { log('Failed to decode ExecuteCommandParams: ${err}') }
@@ -4574,13 +4630,30 @@ fn (mut app App) handle_execute_command(request Request) Response {
 	match params.command {
 		'vls.runFile' {
 			args := params.arguments or { [] }
-			uri := if args.len > 0 { args[0] } else { '' }
-			app.send_show_message('vls: run file not yet implemented (${uri})', 3)
+			path, path_error := code_lens_command_path(args)
+			if path_error != '' {
+				app.send_show_message('vls: cannot run main: ${path_error}', 1)
+			} else {
+				app.run_code_lens_command('Run Main', build_v_run_args(path), os.dir(path))
+			}
 		}
 		'vls.runTests' {
 			args := params.arguments or { [] }
-			uri := if args.len > 0 { args[0] } else { '' }
-			app.send_show_message('vls: run tests not yet implemented (${uri})', 3)
+			path, path_error := code_lens_command_path(args)
+			if path_error != '' {
+				app.send_show_message('vls: cannot run tests: ${path_error}', 1)
+			} else if !path.ends_with('_test.v') {
+				app.send_show_message('vls: tests can only be run from a _test.v file.', 1)
+			} else {
+				fn_name := if args.len > 1 { args[1] } else { '' }
+				if fn_name != ''
+					&& (!fn_name.starts_with('test_') || !is_valid_v_identifier_name(fn_name)) {
+					app.send_show_message('vls: invalid test function: ${fn_name}', 1)
+				} else {
+					title := if fn_name == '' { 'Run File' } else { 'Run Test' }
+					app.run_code_lens_command(title, build_v_test_args(path, fn_name), os.dir(path))
+				}
+			}
 		}
 		else {
 			app.send_show_message('vls: unknown command ${params.command}', 2)

--- a/handlers.v
+++ b/handlers.v
@@ -4495,7 +4495,7 @@ fn code_lens_fn_name(line string) string {
 	return name
 }
 
-fn code_lens_range(line int, raw_line string) LSPRange {
+fn code_lens_range(line int, raw_line string, encoding PositionEncoding) LSPRange {
 	return LSPRange{
 		start: Position{
 			line: line
@@ -4503,7 +4503,7 @@ fn code_lens_range(line int, raw_line string) LSPRange {
 		}
 		end:   Position{
 			line: line
-			char: raw_line.len
+			char: byte_to_encoded_col(raw_line, raw_line.len, encoding)
 		}
 	}
 }
@@ -4529,7 +4529,7 @@ fn (mut app App) handle_code_lens(request Request) Response {
 		fn_name := code_lens_fn_name(code)
 		if fn_name == 'main' {
 			lenses << CodeLens{
-				range:   code_lens_range(i, raw_line)
+				range:   code_lens_range(i, raw_line, app.position_encoding)
 				command: Command{
 					title:     'Run Main'
 					command:   'vls.runFile'
@@ -4539,7 +4539,7 @@ fn (mut app App) handle_code_lens(request Request) Response {
 		}
 		if is_test_file && fn_name.starts_with('test_') {
 			lenses << CodeLens{
-				range:   code_lens_range(i, raw_line)
+				range:   code_lens_range(i, raw_line, app.position_encoding)
 				command: Command{
 					title:     'Run File'
 					command:   'vls.runTests'
@@ -4547,7 +4547,7 @@ fn (mut app App) handle_code_lens(request Request) Response {
 				}
 			}
 			lenses << CodeLens{
-				range:   code_lens_range(i, raw_line)
+				range:   code_lens_range(i, raw_line, app.position_encoding)
 				command: Command{
 					title:     'Run Test'
 					command:   'vls.runTests'

--- a/handlers.v
+++ b/handlers.v
@@ -4578,44 +4578,34 @@ fn (mut app App) handle_code_lens_resolve(request Request) Response {
 	}
 }
 
-fn code_lens_command_path(arguments []string) (string, string) {
+fn (app &App) code_lens_command_target(arguments []string) (string, string, string) {
 	if arguments.len == 0 || arguments[0].trim_space() == '' {
-		return '', 'missing file argument'
+		return '', '', 'missing file argument'
 	}
 	raw_path := arguments[0]
 	if raw_path.contains('://') && !raw_path.starts_with('file:') {
-		return '', 'only local files can be run'
+		return '', '', 'only local files can be run'
 	}
-	path := os.real_path(uri_to_path(raw_path))
-	if !os.is_file(path) {
-		return '', 'file does not exist: ${path}'
+	path := normalize_overlay_path(os.abs_path(uri_to_path(raw_path)))
+	mut uri := if raw_path.starts_with('file:') { raw_path } else { path_to_uri(path) }
+	mut is_open := uri in app.open_files
+	if !is_open {
+		path_key := normalized_index_path(path)
+		for open_uri, _ in app.open_files {
+			if normalized_index_path(uri_to_path(open_uri)) == path_key {
+				uri = open_uri
+				is_open = true
+				break
+			}
+		}
+	}
+	if !is_open && !os.is_file(path) {
+		return '', '', 'file does not exist: ${path}'
 	}
 	if !path.ends_with('.v') && !path.ends_with('.vsh') {
-		return '', 'not a V source file: ${path}'
+		return '', '', 'not a V source file: ${path}'
 	}
-	return path, ''
-}
-
-fn (mut app App) run_code_lens_command(title string, args []string, work_dir string) {
-	if !compiler_is_available() {
-		app.send_show_message('vls: the V compiler (`v`) was not found on PATH.', 1)
-		return
-	}
-	app.send_log_message('vls: ${title}: v ${args.join(' ')}', 3)
-	result := run_v_argv(args, work_dir)
-	output := result.output.trim_space()
-	if output != '' {
-		level := if result.exit_code == 0 { 3 } else { 1 }
-		app.send_log_message(output, level)
-	}
-	if result.exit_code == compiler_exit_timeout {
-		app.send_show_message('vls: ${title} timed out after ${resolve_compiler_timeout_ms()} ms.',
-			1)
-	} else if result.exit_code != 0 {
-		app.send_show_message('vls: ${title} failed with exit code ${result.exit_code}.', 1)
-	} else {
-		app.send_show_message('vls: ${title} finished successfully.', 3)
-	}
+	return uri, path, ''
 }
 
 // handle_execute_command handles workspace/executeCommand by invoking the V compiler.
@@ -4630,16 +4620,27 @@ fn (mut app App) handle_execute_command(request Request) Response {
 	match params.command {
 		'vls.runFile' {
 			args := params.arguments or { [] }
-			path, path_error := code_lens_command_path(args)
+			uri, path, path_error := app.code_lens_command_target(args)
 			if path_error != '' {
 				app.send_show_message('vls: cannot run main: ${path_error}', 1)
+			} else if !compiler_is_available() {
+				app.send_show_message('vls: the V compiler (`v`) was not found on PATH.', 1)
 			} else {
-				app.run_code_lens_command('Run Main', build_v_run_args(path), os.dir(path))
+				app.start_code_lens_run(CodeLensRunJob{
+					kind:           .main
+					title:          'Run Main'
+					uri:            uri
+					path:           path
+					open_files:     app.open_files.clone()
+					write_mutex:    app.write_mutex
+					tcp_conn:       app.tcp_conn
+					capture_output: app.capture_output
+				})
 			}
 		}
 		'vls.runTests' {
 			args := params.arguments or { [] }
-			path, path_error := code_lens_command_path(args)
+			uri, path, path_error := app.code_lens_command_target(args)
 			if path_error != '' {
 				app.send_show_message('vls: cannot run tests: ${path_error}', 1)
 			} else if !path.ends_with('_test.v') {
@@ -4651,7 +4652,27 @@ fn (mut app App) handle_execute_command(request Request) Response {
 					app.send_show_message('vls: invalid test function: ${fn_name}', 1)
 				} else {
 					title := if fn_name == '' { 'Run File' } else { 'Run Test' }
-					app.run_code_lens_command(title, build_v_test_args(path, fn_name), os.dir(path))
+					kind := if fn_name == '' {
+						CodeLensRunKind.test_file
+					} else {
+						CodeLensRunKind.test_function
+					}
+					if !compiler_is_available() {
+						app.send_show_message('vls: the V compiler (`v`) was not found on PATH.',
+							1)
+					} else {
+						app.start_code_lens_run(CodeLensRunJob{
+							kind:           kind
+							title:          title
+							uri:            uri
+							path:           path
+							fn_name:        fn_name
+							open_files:     app.open_files.clone()
+							write_mutex:    app.write_mutex
+							tcp_conn:       app.tcp_conn
+							capture_output: app.capture_output
+						})
+					}
 				}
 			}
 		}

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -4,6 +4,7 @@ module main
 
 import os
 import json2
+import time
 
 fn must_mkdir_all(path string) {
 	os.mkdir_all(path) or {
@@ -5718,12 +5719,79 @@ fn test_execute_run_file_invokes_compiler() {
 	defer {
 		cleanup_test_app(app)
 	}
-	path := os.join_path(app.temp_dir, 'code_lens_main.v')
-	must_write_file(path, 'module main\n\nfn main() {\n\tprintln("code-lens-ran")\n}\n')
+	project_dir := os.join_path(app.temp_dir, 'code_lens_module')
+	must_mkdir_all(project_dir)
+	path := os.join_path(project_dir, 'main.v')
+	must_write_file(path, 'module main\n\nfn main() {\n\tprintln("stale-disk")\n}\n')
+	must_write_file(os.join_path(project_dir, 'helper.v'),
+		'module main\n\nfn code_lens_message() string {\n\treturn "module-sibling"\n}\n')
+	uri := path_to_uri(path)
+	app.open_files[uri] = 'module main\n\nfn main() {\n\tprintln(code_lens_message() + "-fresh-buffer")\n}\n'
 	app.capture_output = true
+	app.execute_commands_synchronously = true
 
 	resp := app.handle_execute_command(Request{
 		id:     822
+		method: 'workspace/executeCommand'
+		params: json2.encode(ExecuteCommandParams{
+			command:   'vls.runFile'
+			arguments: [uri]
+		},
+			escape_unicode: true
+		)
+	})
+
+	assert resp.result is string
+	assert (resp.result as string) == 'null'
+	assert app.captured_output.any(it.contains('module-sibling-fresh-buffer'))
+	assert app.captured_output.all(!it.contains('stale-disk'))
+	assert app.captured_output.any(it.contains('Run Main finished successfully'))
+}
+
+fn test_execute_run_file_materializes_new_unsaved_buffer() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	project_dir := os.join_path(app.temp_dir, 'code_lens_unsaved')
+	must_mkdir_all(project_dir)
+	path := os.join_path(project_dir, 'new_main.v')
+	uri := path_to_uri(path)
+	app.open_files[uri] = 'module main\n\nfn main() {\n\tprintln("new-unsaved-buffer")\n}\n'
+	app.capture_output = true
+	app.execute_commands_synchronously = true
+
+	resp := app.handle_execute_command(Request{
+		id:     824
+		method: 'workspace/executeCommand'
+		params: json2.encode(ExecuteCommandParams{
+			command:   'vls.runFile'
+			arguments: [uri]
+		},
+			escape_unicode: true
+		)
+	})
+
+	assert resp.result is string
+	assert (resp.result as string) == 'null'
+	assert app.captured_output.any(it.contains('new-unsaved-buffer'))
+	assert app.captured_output.any(it.contains('Run Main finished successfully'))
+}
+
+fn test_execute_run_file_returns_before_long_running_program_finishes() {
+	mut app := create_test_app()
+	defer {
+		app.stop_run_commands()
+		cleanup_test_app(app)
+	}
+	path := os.join_path(app.temp_dir, 'code_lens_long_running.v')
+	marker_path := os.join_path(app.temp_dir, 'code_lens_long_running.started')
+	must_write_file(path, 'module main\n\nimport os\nimport time\n\nfn main() {\n\tos.write_file("${marker_path}", "started") or {}\n\ttime.sleep(5 * time.second)\n}\n')
+	app.capture_output = true
+
+	started_at := time.now().unix_milli()
+	resp := app.handle_execute_command(Request{
+		id:     825
 		method: 'workspace/executeCommand'
 		params: json2.encode(ExecuteCommandParams{
 			command:   'vls.runFile'
@@ -5732,11 +5800,19 @@ fn test_execute_run_file_invokes_compiler() {
 			escape_unicode: true
 		)
 	})
+	elapsed_ms := time.now().unix_milli() - started_at
 
 	assert resp.result is string
 	assert (resp.result as string) == 'null'
-	assert app.captured_output.any(it.contains('code-lens-ran'))
-	assert app.captured_output.any(it.contains('Run Main finished successfully'))
+	assert elapsed_ms < 1000
+	deadline := time.now().unix_milli() + 10_000
+	for !os.exists(marker_path) && time.now().unix_milli() < deadline {
+		time.sleep(10 * time.millisecond)
+	}
+	assert os.exists(marker_path)
+	stop_started_at := time.now().unix_milli()
+	app.stop_run_commands()
+	assert time.now().unix_milli() - stop_started_at < 1000
 }
 
 fn test_execute_run_test_selects_one_function() {
@@ -5745,15 +5821,18 @@ fn test_execute_run_test_selects_one_function() {
 		cleanup_test_app(app)
 	}
 	path := os.join_path(app.temp_dir, 'code_lens_selected_test.v')
-	must_write_file(path, 'module main\n\nfn test_selected() {\n\tassert true\n}\n\nfn test_other() {\n\tassert false\n}\n')
+	must_write_file(path, 'module main\n\nfn test_selected() {\n\tassert false\n}\n')
+	uri := path_to_uri(path)
+	app.open_files[uri] = 'module main\n\nfn test_selected() {\n\tassert true\n}\n\nfn test_other() {\n\tassert false\n}\n'
 	app.capture_output = true
+	app.execute_commands_synchronously = true
 
 	resp := app.handle_execute_command(Request{
 		id:     823
 		method: 'workspace/executeCommand'
 		params: json2.encode(ExecuteCommandParams{
 			command:   'vls.runTests'
-			arguments: [path_to_uri(path), 'test_selected']
+			arguments: [uri, 'test_selected']
 		},
 			escape_unicode: true
 		)

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -5721,13 +5721,17 @@ fn test_execute_run_file_invokes_compiler() {
 	}
 	project_dir := os.join_path(app.temp_dir, 'code_lens_module')
 	must_mkdir_all(project_dir)
+	must_write_file(os.join_path(project_dir, 'v.mod'),
+		"Module {\n\tname: 'code_lens_module'\n}\n")
 	path := os.join_path(project_dir, 'main.v')
 	must_write_file(path, 'module main\n\nfn main() {\n\tprintln("stale-disk")\n}\n')
-	must_write_file(os.join_path(project_dir, 'helper.v'),
-		'module main\n\nfn code_lens_message() string {\n\treturn "module-sibling"\n}\n')
+	helper_path := os.join_path(project_dir, 'helper.v')
+	helper_source := 'module main\n\nfn code_lens_message() string {\n\treturn "module-sibling"\n}\n\nfn code_lens_sibling_paths() string {\n\treturn @VMODROOT + "\\n" + @FILE\n}\n'
+	must_write_file(helper_path, helper_source)
 	uri := path_to_uri(path)
 	runtime_output_path := os.join_path(project_dir, 'code_lens_runtime_cwd.txt')
-	app.open_files[uri] = 'module main\n\nimport os\n\nfn main() {\n\tprintln(code_lens_message() + "-fresh-buffer")\n\tos.write_file("code_lens_runtime_cwd.txt", "real-module") or { panic(err) }\n}\n'
+	compile_time_output_path := os.join_path(project_dir, 'code_lens_compile_time_paths.txt')
+	app.open_files[uri] = 'module main\n\nimport os\n\nfn main() {\n\tprintln(code_lens_message() + "-fresh-buffer")\n\tos.write_file("code_lens_runtime_cwd.txt", "real-module") or { panic(err) }\n\tos.write_file(os.join_path(@VMODROOT, "code_lens_compile_time_paths.txt"), code_lens_sibling_paths() + "\\n" + @FILE) or { panic(err) }\n}\n'
 	app.capture_output = true
 	app.execute_commands_synchronously = true
 
@@ -5748,6 +5752,9 @@ fn test_execute_run_file_invokes_compiler() {
 	assert app.captured_output.all(!it.contains('stale-disk'))
 	assert app.captured_output.any(it.contains('Run Main finished successfully'))
 	assert (os.read_file(runtime_output_path) or { '' }) == 'real-module'
+	expected_paths := [os.real_path(project_dir), os.real_path(helper_path), os.real_path(path)]
+	assert (os.read_file(compile_time_output_path) or { '' }) == expected_paths.join('\n')
+	assert (os.read_file(helper_path) or { '' }) == helper_source
 }
 
 fn test_execute_run_file_materializes_new_unsaved_buffer() {
@@ -5788,7 +5795,7 @@ fn test_execute_run_file_returns_before_long_running_program_finishes() {
 	}
 	path := os.join_path(app.temp_dir, 'code_lens_long_running.v')
 	marker_path := os.join_path(app.temp_dir, 'code_lens_long_running.started')
-	must_write_file(path, 'module main\n\nimport os\nimport time\n\nfn main() {\n\tos.write_file("${marker_path}", "started") or {}\n\ttime.sleep(5 * time.second)\n}\n')
+	must_write_file(path, 'module main\n\nimport os\nimport time\n\nfn main() {\n\t_ := os.input("")\n\tos.write_file("${marker_path}", "started") or {}\n\ttime.sleep(5 * time.second)\n}\n')
 	app.capture_output = true
 
 	started_at := time.now().unix_milli()
@@ -5828,6 +5835,26 @@ fn test_code_lens_process_output_is_bounded() {
 	result := output.str()
 	assert result.len == code_lens_output_limit_bytes + code_lens_output_truncation_notice.len
 	assert result.ends_with(code_lens_output_truncation_notice)
+}
+
+fn test_code_lens_source_paths_are_rewritten_only_in_code() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	project_dir := os.join_path(app.temp_dir, 'code_lens_source_paths')
+	must_mkdir_all(project_dir)
+	must_write_file(os.join_path(project_dir, 'v.mod'), 'Module {}\n')
+	source_path := os.join_path(project_dir, 'main.v')
+	source := 'const source_file = @FILE\nconst source_dir = @DIR\nconst project = @VMODROOT\nconst literal = "@FILE @DIR @VMODROOT"\n// @FILE @DIR @VMODROOT\n#flag -I @VMODROOT/thirdparty\n'
+	rewritten := code_lens_source_with_real_paths(source, source_path)
+
+	assert rewritten.contains('const source_file = ${code_lens_v_string_literal(os.real_path(source_path))}')
+	assert rewritten.contains('const source_dir = ${code_lens_v_string_literal(os.real_path(project_dir))}')
+	assert rewritten.contains('const project = ${code_lens_v_string_literal(os.real_path(project_dir))}')
+	assert rewritten.contains('const literal = "@FILE @DIR @VMODROOT"')
+	assert rewritten.contains('// @FILE @DIR @VMODROOT')
+	assert rewritten.contains('#flag -I @VMODROOT/thirdparty')
 }
 
 fn test_execute_run_test_selects_one_function() {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -5726,7 +5726,8 @@ fn test_execute_run_file_invokes_compiler() {
 	must_write_file(os.join_path(project_dir, 'helper.v'),
 		'module main\n\nfn code_lens_message() string {\n\treturn "module-sibling"\n}\n')
 	uri := path_to_uri(path)
-	app.open_files[uri] = 'module main\n\nfn main() {\n\tprintln(code_lens_message() + "-fresh-buffer")\n}\n'
+	runtime_output_path := os.join_path(project_dir, 'code_lens_runtime_cwd.txt')
+	app.open_files[uri] = 'module main\n\nimport os\n\nfn main() {\n\tprintln(code_lens_message() + "-fresh-buffer")\n\tos.write_file("code_lens_runtime_cwd.txt", "real-module") or { panic(err) }\n}\n'
 	app.capture_output = true
 	app.execute_commands_synchronously = true
 
@@ -5746,6 +5747,7 @@ fn test_execute_run_file_invokes_compiler() {
 	assert app.captured_output.any(it.contains('module-sibling-fresh-buffer'))
 	assert app.captured_output.all(!it.contains('stale-disk'))
 	assert app.captured_output.any(it.contains('Run Main finished successfully'))
+	assert (os.read_file(runtime_output_path) or { '' }) == 'real-module'
 }
 
 fn test_execute_run_file_materializes_new_unsaved_buffer() {
@@ -5815,6 +5817,19 @@ fn test_execute_run_file_returns_before_long_running_program_finishes() {
 	assert time.now().unix_milli() - stop_started_at < 1000
 }
 
+fn test_code_lens_process_output_is_bounded() {
+	mut output := new_run_output_buffer()
+	output.write('prefix')
+	output.write('x'.repeat(code_lens_output_limit_bytes))
+	output.write('ignored')
+
+	assert output.output.len == code_lens_output_limit_bytes
+	assert output.truncated
+	result := output.str()
+	assert result.len == code_lens_output_limit_bytes + code_lens_output_truncation_notice.len
+	assert result.ends_with(code_lens_output_truncation_notice)
+}
+
 fn test_execute_run_test_selects_one_function() {
 	mut app := create_test_app()
 	defer {
@@ -5823,7 +5838,8 @@ fn test_execute_run_test_selects_one_function() {
 	path := os.join_path(app.temp_dir, 'code_lens_selected_test.v')
 	must_write_file(path, 'module main\n\nfn test_selected() {\n\tassert false\n}\n')
 	uri := path_to_uri(path)
-	app.open_files[uri] = 'module main\n\nfn test_selected() {\n\tassert true\n}\n\nfn test_other() {\n\tassert false\n}\n'
+	test_runtime_output_path := os.join_path(app.temp_dir, 'code_lens_test_runtime_cwd.txt')
+	app.open_files[uri] = 'module main\n\nimport os\n\nfn test_selected() {\n\tos.write_file("code_lens_test_runtime_cwd.txt", "real-module") or { assert false }\n\tassert true\n}\n\nfn test_other() {\n\tassert false\n}\n'
 	app.capture_output = true
 	app.execute_commands_synchronously = true
 
@@ -5841,6 +5857,7 @@ fn test_execute_run_test_selects_one_function() {
 	assert resp.result is string
 	assert (resp.result as string) == 'null'
 	assert app.captured_output.any(it.contains('Run Test finished successfully'))
+	assert (os.read_file(test_runtime_output_path) or { '' }) == 'real-module'
 }
 
 fn test_execute_command_unknown_still_returns_null() {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -5726,12 +5726,12 @@ fn test_execute_run_file_invokes_compiler() {
 	path := os.join_path(project_dir, 'main.v')
 	must_write_file(path, 'module main\n\nfn main() {\n\tprintln("stale-disk")\n}\n')
 	helper_path := os.join_path(project_dir, 'helper.v')
-	helper_source := 'module main\n\nfn code_lens_message() string {\n\treturn "module-sibling"\n}\n\nfn code_lens_sibling_paths() string {\n\treturn @VMODROOT + "\\n" + @FILE\n}\n'
+	helper_source := 'module main\n\nfn code_lens_message() string {\n\treturn "module-sibling"\n}\n\nfn code_lens_sibling_paths() string {\n\treturn @VMODROOT + "\\n" + @FILE + "\\n" + @FILE_LINE + "\\n" + @LOCATION\n}\n'
 	must_write_file(helper_path, helper_source)
 	uri := path_to_uri(path)
 	runtime_output_path := os.join_path(project_dir, 'code_lens_runtime_cwd.txt')
 	compile_time_output_path := os.join_path(project_dir, 'code_lens_compile_time_paths.txt')
-	app.open_files[uri] = 'module main\n\nimport os\n\nfn main() {\n\tprintln(code_lens_message() + "-fresh-buffer")\n\tos.write_file("code_lens_runtime_cwd.txt", "real-module") or { panic(err) }\n\tos.write_file(os.join_path(@VMODROOT, "code_lens_compile_time_paths.txt"), code_lens_sibling_paths() + "\\n" + @FILE) or { panic(err) }\n}\n'
+	app.open_files[uri] = 'module main\n\nimport os\n\nfn main() {\n\tprintln(code_lens_message() + "-fresh-buffer")\n\tos.write_file("code_lens_runtime_cwd.txt", "real-module") or { panic(err) }\n\tos.write_file(os.join_path(@VMODROOT, "code_lens_compile_time_paths.txt"), code_lens_sibling_paths() + "\\n" + @FILE + "\\n" + @FILE_LINE + "\\n" + @LOCATION) or { panic(err) }\n}\n'
 	app.capture_output = true
 	app.execute_commands_synchronously = true
 
@@ -5752,7 +5752,9 @@ fn test_execute_run_file_invokes_compiler() {
 	assert app.captured_output.all(!it.contains('stale-disk'))
 	assert app.captured_output.any(it.contains('Run Main finished successfully'))
 	assert (os.read_file(runtime_output_path) or { '' }) == 'real-module'
-	expected_paths := [os.real_path(project_dir), os.real_path(helper_path), os.real_path(path)]
+	expected_paths := [os.real_path(project_dir), os.real_path(helper_path), 'helper.v:8',
+		'${os.real_path(helper_path)}:8, main.code_lens_sibling_paths', os.real_path(path),
+		'main.v:8', '${os.real_path(path)}:8, main.main']
 	assert (os.read_file(compile_time_output_path) or { '' }) == expected_paths.join('\n')
 	assert (os.read_file(helper_path) or { '' }) == helper_source
 }
@@ -5837,6 +5839,22 @@ fn test_code_lens_process_output_is_bounded() {
 	assert result.ends_with(code_lens_output_truncation_notice)
 }
 
+fn test_code_lens_process_output_truncates_at_utf8_boundary() {
+	mut output := new_run_output_buffer()
+	prefix := 'x'.repeat(code_lens_output_limit_bytes - 1)
+	output.write(prefix)
+	output.write('€')
+
+	assert output.truncated
+	assert output.str() == prefix + code_lens_output_truncation_notice
+
+	mut exact_output := new_run_output_buffer()
+	exact_prefix := 'x'.repeat(code_lens_output_limit_bytes - '€'.len) + '€'
+	exact_output.write(exact_prefix)
+	exact_output.write('ignored')
+	assert exact_output.str() == exact_prefix + code_lens_output_truncation_notice
+}
+
 fn test_code_lens_source_paths_are_rewritten_only_in_code() {
 	mut app := create_test_app()
 	defer {
@@ -5846,14 +5864,17 @@ fn test_code_lens_source_paths_are_rewritten_only_in_code() {
 	must_mkdir_all(project_dir)
 	must_write_file(os.join_path(project_dir, 'v.mod'), 'Module {}\n')
 	source_path := os.join_path(project_dir, 'main.v')
-	source := 'const source_file = @FILE\nconst source_dir = @DIR\nconst project = @VMODROOT\nconst literal = "@FILE @DIR @VMODROOT"\n// @FILE @DIR @VMODROOT\n#flag -I @VMODROOT/thirdparty\n'
-	rewritten := code_lens_source_with_real_paths(source, source_path)
+	temp_source_path := os.join_path(app.temp_dir, 'overlay', 'main.v')
+	source := 'const source_file = @FILE\nconst source_dir = @DIR\nconst project = @VMODROOT\nconst file_line = @FILE_LINE\nconst location = @LOCATION\nconst literal = "@FILE @DIR @VMODROOT @FILE_LINE @LOCATION"\n// @FILE @DIR @VMODROOT @FILE_LINE @LOCATION\n#flag -I @VMODROOT/thirdparty\n'
+	rewritten := code_lens_source_with_real_paths(source, source_path, temp_source_path)
 
 	assert rewritten.contains('const source_file = ${code_lens_v_string_literal(os.real_path(source_path))}')
 	assert rewritten.contains('const source_dir = ${code_lens_v_string_literal(os.real_path(project_dir))}')
 	assert rewritten.contains('const project = ${code_lens_v_string_literal(os.real_path(project_dir))}')
-	assert rewritten.contains('const literal = "@FILE @DIR @VMODROOT"')
-	assert rewritten.contains('// @FILE @DIR @VMODROOT')
+	assert rewritten.contains("const file_line = 'main.v:4'")
+	assert rewritten.contains('const location = (@LOCATION.replace(${code_lens_v_string_literal(temp_source_path)}, ${code_lens_v_string_literal(os.real_path(source_path))}))')
+	assert rewritten.contains('const literal = "@FILE @DIR @VMODROOT @FILE_LINE @LOCATION"')
+	assert rewritten.contains('// @FILE @DIR @VMODROOT @FILE_LINE @LOCATION')
 	assert rewritten.contains('#flag -I @VMODROOT/thirdparty')
 }
 

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -5574,7 +5574,15 @@ fn test_code_lens_returns_run_lens_for_main() {
 	assert resp.id == 810
 	assert resp.result is []CodeLens
 	lenses := resp.result as []CodeLens
-	assert lenses.any(it.command?.command == 'vls.runFile')
+	assert lenses.len == 1
+	command := lenses[0].command or {
+		assert false, 'expected Run Main command'
+		return
+	}
+	command_args := command.arguments or { [] }
+	assert command.title == 'Run Main'
+	assert command.command == 'vls.runFile'
+	assert command_args == [uri]
 }
 
 fn test_code_lens_returns_test_lens_for_test_fn() {
@@ -5601,7 +5609,47 @@ fn test_code_lens_returns_test_lens_for_test_fn() {
 	assert resp.id == 811
 	assert resp.result is []CodeLens
 	lenses := resp.result as []CodeLens
-	assert lenses.any(it.command?.command == 'vls.runTests')
+	assert lenses.len == 2
+	file_command := lenses[0].command or {
+		assert false, 'expected Run File command'
+		return
+	}
+	test_command := lenses[1].command or {
+		assert false, 'expected Run Test command'
+		return
+	}
+	file_args := file_command.arguments or { [] }
+	test_args := test_command.arguments or { [] }
+	assert file_command.title == 'Run File'
+	assert file_command.command == 'vls.runTests'
+	assert file_args == [uri]
+	assert test_command.title == 'Run Test'
+	assert test_command.command == 'vls.runTests'
+	assert test_args == [uri, 'test_something']
+}
+
+fn test_code_lens_ignores_declarations_in_comments_and_non_test_files() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	uri := 'file:///tmp/ordinary.v'
+	app.open_files[uri] = 'module main\n\n/*\nfn main() {}\nfn test_hidden() {}\n*/\nfn helper() {}\n'
+
+	resp := app.handle_code_lens(Request{
+		id:     813
+		method: 'textDocument/codeLens'
+		params: json2.encode(CodeLensParams{
+			text_document: TextDocumentIdentifier{
+				uri: uri
+			}
+		},
+			escape_unicode: true
+		)
+	})
+
+	assert resp.result is []CodeLens
+	assert (resp.result as []CodeLens).len == 0
 }
 
 fn test_code_lens_resolve_returns_same_lens() {
@@ -5647,6 +5695,7 @@ fn test_execute_command_returns_null_result() {
 		cleanup_test_app(app)
 	}
 
+	app.capture_output = true
 	resp := app.handle_execute_command(Request{
 		id:     820
 		method: 'workspace/executeCommand'
@@ -5660,6 +5709,59 @@ fn test_execute_command_returns_null_result() {
 	assert resp.id == 820
 	assert resp.result is string
 	assert (resp.result as string) == 'null'
+	assert app.captured_output.len == 1
+	assert app.captured_output[0].contains('missing file argument')
+}
+
+fn test_execute_run_file_invokes_compiler() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	path := os.join_path(app.temp_dir, 'code_lens_main.v')
+	must_write_file(path, 'module main\n\nfn main() {\n\tprintln("code-lens-ran")\n}\n')
+	app.capture_output = true
+
+	resp := app.handle_execute_command(Request{
+		id:     822
+		method: 'workspace/executeCommand'
+		params: json2.encode(ExecuteCommandParams{
+			command:   'vls.runFile'
+			arguments: [path_to_uri(path)]
+		},
+			escape_unicode: true
+		)
+	})
+
+	assert resp.result is string
+	assert (resp.result as string) == 'null'
+	assert app.captured_output.any(it.contains('code-lens-ran'))
+	assert app.captured_output.any(it.contains('Run Main finished successfully'))
+}
+
+fn test_execute_run_test_selects_one_function() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	path := os.join_path(app.temp_dir, 'code_lens_selected_test.v')
+	must_write_file(path, 'module main\n\nfn test_selected() {\n\tassert true\n}\n\nfn test_other() {\n\tassert false\n}\n')
+	app.capture_output = true
+
+	resp := app.handle_execute_command(Request{
+		id:     823
+		method: 'workspace/executeCommand'
+		params: json2.encode(ExecuteCommandParams{
+			command:   'vls.runTests'
+			arguments: [path_to_uri(path), 'test_selected']
+		},
+			escape_unicode: true
+		)
+	})
+
+	assert resp.result is string
+	assert (resp.result as string) == 'null'
+	assert app.captured_output.any(it.contains('Run Test finished successfully'))
 }
 
 fn test_execute_command_unknown_still_returns_null() {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -5721,17 +5721,19 @@ fn test_execute_run_file_invokes_compiler() {
 	}
 	project_dir := os.join_path(app.temp_dir, 'code_lens_module')
 	must_mkdir_all(project_dir)
-	must_write_file(os.join_path(project_dir, 'v.mod'),
-		"Module {\n\tname: 'code_lens_module'\n}\n")
+	vmod_source := "Module {\n\tname: 'code_lens_module'\n}\n"
+	must_write_file(os.join_path(project_dir, 'v.mod'), vmod_source)
 	path := os.join_path(project_dir, 'main.v')
 	must_write_file(path, 'module main\n\nfn main() {\n\tprintln("stale-disk")\n}\n')
 	helper_path := os.join_path(project_dir, 'helper.v')
-	helper_source := 'module main\n\nfn code_lens_message() string {\n\treturn "module-sibling"\n}\n\nfn code_lens_sibling_paths() string {\n\treturn @VMODROOT + "\\n" + @FILE + "\\n" + @FILE_LINE + "\\n" + @LOCATION\n}\n'
+	helper_source := 'module main\n\nfn code_lens_message() string {\n\treturn "module-sibling"\n}\n\nfn code_lens_sibling_paths() string {\n\treturn @VMODROOT + "\\n" + @FILE + "\\n" + @FILE_LINE + "\\n" + @LOCATION + "\\n" + @COLUMN\n}\n'
 	must_write_file(helper_path, helper_source)
 	uri := path_to_uri(path)
 	runtime_output_path := os.join_path(project_dir, 'code_lens_runtime_cwd.txt')
 	compile_time_output_path := os.join_path(project_dir, 'code_lens_compile_time_paths.txt')
-	app.open_files[uri] = 'module main\n\nimport os\n\nfn main() {\n\tprintln(code_lens_message() + "-fresh-buffer")\n\tos.write_file("code_lens_runtime_cwd.txt", "real-module") or { panic(err) }\n\tos.write_file(os.join_path(@VMODROOT, "code_lens_compile_time_paths.txt"), code_lens_sibling_paths() + "\\n" + @FILE + "\\n" + @FILE_LINE + "\\n" + @LOCATION) or { panic(err) }\n}\n'
+	vmod_output_path := os.join_path(project_dir, 'code_lens_vmod.txt')
+	main_source := 'module main\n\nimport os\n\nfn main() {\n\tprintln(code_lens_message() + "-fresh-buffer")\n\tos.write_file("code_lens_runtime_cwd.txt", "real-module") or { panic(err) }\n\tos.write_file(os.join_path(@VMODROOT, "code_lens_compile_time_paths.txt"), code_lens_sibling_paths() + "\\n" + @FILE + "\\n" + @FILE_LINE + "\\n" + @LOCATION + "\\n" + @COLUMN) or { panic(err) }\n\tos.write_file("code_lens_vmod.txt", @VMOD_FILE) or { panic(err) }\n}\n'
+	app.open_files[uri] = main_source
 	app.capture_output = true
 	app.execute_commands_synchronously = true
 
@@ -5752,10 +5754,14 @@ fn test_execute_run_file_invokes_compiler() {
 	assert app.captured_output.all(!it.contains('stale-disk'))
 	assert app.captured_output.any(it.contains('Run Main finished successfully'))
 	assert (os.read_file(runtime_output_path) or { '' }) == 'real-module'
+	helper_column := helper_source.split_into_lines()[7].index('@COLUMN') or { 0 }
+	main_column := main_source.split_into_lines()[7].index('@COLUMN') or { 0 }
 	expected_paths := [os.real_path(project_dir), os.real_path(helper_path), 'helper.v:8',
-		'${os.real_path(helper_path)}:8, main.code_lens_sibling_paths', os.real_path(path),
-		'main.v:8', '${os.real_path(path)}:8, main.main']
+		'${os.real_path(helper_path)}:8, main.code_lens_sibling_paths', (helper_column + 1).str(),
+		os.real_path(path), 'main.v:8', '${os.real_path(path)}:8, main.main',
+		(main_column + 1).str()]
 	assert (os.read_file(compile_time_output_path) or { '' }) == expected_paths.join('\n')
+	assert (os.read_file(vmod_output_path) or { '' }) == vmod_source
 	assert (os.read_file(helper_path) or { '' }) == helper_source
 }
 
@@ -5862,19 +5868,22 @@ fn test_code_lens_source_paths_are_rewritten_only_in_code() {
 	}
 	project_dir := os.join_path(app.temp_dir, 'code_lens_source_paths')
 	must_mkdir_all(project_dir)
-	must_write_file(os.join_path(project_dir, 'v.mod'), 'Module {}\n')
+	vmod_source := 'Module {}\n'
+	must_write_file(os.join_path(project_dir, 'v.mod'), vmod_source)
 	source_path := os.join_path(project_dir, 'main.v')
 	temp_source_path := os.join_path(app.temp_dir, 'overlay', 'main.v')
-	source := 'const source_file = @FILE\nconst source_dir = @DIR\nconst project = @VMODROOT\nconst file_line = @FILE_LINE\nconst location = @LOCATION\nconst literal = "@FILE @DIR @VMODROOT @FILE_LINE @LOCATION"\n// @FILE @DIR @VMODROOT @FILE_LINE @LOCATION\n#flag -I @VMODROOT/thirdparty\n'
-	rewritten := code_lens_source_with_real_paths(source, source_path, temp_source_path)
+	source := 'const source_file = @FILE\nconst source_dir = @DIR\nconst project = @VMODROOT\nconst manifest = @VMOD_FILE\nconst file_line = @FILE_LINE\nconst location = @LOCATION\nconst column = @FILE + @COLUMN\nconst literal = "@FILE @DIR @VMODROOT @VMOD_FILE @FILE_LINE @LOCATION @COLUMN"\n// @FILE @DIR @VMODROOT @VMOD_FILE @FILE_LINE @LOCATION @COLUMN\n#flag -I @VMODROOT/thirdparty\n'
+	rewritten := code_lens_source_with_original_pseudos(source, source_path, temp_source_path)
 
 	assert rewritten.contains('const source_file = ${code_lens_v_string_literal(os.real_path(source_path))}')
 	assert rewritten.contains('const source_dir = ${code_lens_v_string_literal(os.real_path(project_dir))}')
 	assert rewritten.contains('const project = ${code_lens_v_string_literal(os.real_path(project_dir))}')
-	assert rewritten.contains("const file_line = 'main.v:4'")
+	assert rewritten.contains('const manifest = ${code_lens_v_string_literal(vmod_source)}')
+	assert rewritten.contains("const file_line = 'main.v:5'")
 	assert rewritten.contains('const location = (@LOCATION.replace(${code_lens_v_string_literal(temp_source_path)}, ${code_lens_v_string_literal(os.real_path(source_path))}))')
-	assert rewritten.contains('const literal = "@FILE @DIR @VMODROOT @FILE_LINE @LOCATION"')
-	assert rewritten.contains('// @FILE @DIR @VMODROOT @FILE_LINE @LOCATION')
+	assert rewritten.contains("const column = ${code_lens_v_string_literal(os.real_path(source_path))} + '24'")
+	assert rewritten.contains('const literal = "@FILE @DIR @VMODROOT @VMOD_FILE @FILE_LINE @LOCATION @COLUMN"')
+	assert rewritten.contains('// @FILE @DIR @VMODROOT @VMOD_FILE @FILE_LINE @LOCATION @COLUMN')
 	assert rewritten.contains('#flag -I @VMODROOT/thirdparty')
 }
 

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -5586,6 +5586,47 @@ fn test_code_lens_returns_run_lens_for_main() {
 	assert command_args == [uri]
 }
 
+fn test_code_lens_range_uses_negotiated_position_encoding() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	uri := 'file:///tmp/codelens_unicode.v'
+	app.open_files[uri] = 'module main\n\nfn main() {} // 🚀\n'
+	request := Request{
+		id:     814
+		method: 'textDocument/codeLens'
+		params: json2.encode(CodeLensParams{
+			text_document: TextDocumentIdentifier{
+				uri: uri
+			}
+		},
+			escape_unicode: true
+		)
+	}
+
+	for encoding in [PositionEncoding.utf8, .utf16, .utf32] {
+		app.position_encoding = encoding
+		resp := app.handle_code_lens(request)
+		assert resp.result is []CodeLens
+		lenses := resp.result as []CodeLens
+		assert lenses.len == 1
+		assert lenses[0].range.start == Position{
+			line: 2
+			char: 0
+		}
+		expected_end := match encoding {
+			.utf8 { 20 }
+			.utf16 { 18 }
+			.utf32 { 17 }
+		}
+		assert lenses[0].range.end == Position{
+			line: 2
+			char: expected_end
+		}
+	}
+}
+
 fn test_code_lens_returns_test_lens_for_test_fn() {
 	mut app := create_test_app()
 	defer {
@@ -5830,6 +5871,67 @@ fn test_execute_run_file_returns_before_long_running_program_finishes() {
 	stop_started_at := time.now().unix_milli()
 	app.stop_run_commands()
 	assert time.now().unix_milli() - stop_started_at < 1000
+}
+
+fn test_execute_run_file_replaces_active_target() {
+	mut app := create_test_app()
+	defer {
+		app.stop_run_commands()
+		cleanup_test_app(app)
+	}
+	path := os.join_path(app.temp_dir, 'code_lens_replaced.v')
+	marker_path := os.join_path(app.temp_dir, 'code_lens_replaced.txt')
+	marker_literal := code_lens_v_string_literal(marker_path)
+	first_source := 'module main\n\nimport os\nimport time\n\nfn main() {\n\tfor {\n\t\tmut marker := os.open_append(${marker_literal}) or { return }\n\t\tmarker.writeln("first") or {\n\t\t\tmarker.close()\n\t\t\treturn\n\t\t}\n\t\tmarker.close()\n\t\ttime.sleep(10 * time.millisecond)\n\t}\n}\n'
+	must_write_file(path, first_source)
+	uri := path_to_uri(path)
+	app.open_files[uri] = first_source
+	app.capture_output = true
+
+	first_resp := app.handle_execute_command(Request{
+		id:     826
+		method: 'workspace/executeCommand'
+		params: json2.encode(ExecuteCommandParams{
+			command:   'vls.runFile'
+			arguments: [uri]
+		},
+			escape_unicode: true
+		)
+	})
+	assert first_resp.result is string
+	assert (first_resp.result as string) == 'null'
+	first_deadline := time.now().unix_milli() + 10_000
+	for time.now().unix_milli() < first_deadline {
+		if (os.read_file(marker_path) or { '' }).contains('first') {
+			break
+		}
+		time.sleep(10 * time.millisecond)
+	}
+	assert (os.read_file(marker_path) or { '' }).contains('first')
+
+	app.open_files[uri] = 'module main\n\nimport os\nimport time\n\nfn main() {\n\tos.write_file(${marker_literal}, "second") or { return }\n\ttime.sleep(5 * time.second)\n}\n'
+	second_resp := app.handle_execute_command(Request{
+		id:     827
+		method: 'workspace/executeCommand'
+		params: json2.encode(ExecuteCommandParams{
+			command:   'vls.runFile'
+			arguments: [uri]
+		},
+			escape_unicode: true
+		)
+	})
+	assert second_resp.result is string
+	assert (second_resp.result as string) == 'null'
+	second_deadline := time.now().unix_milli() + 10_000
+	for time.now().unix_milli() < second_deadline {
+		if (os.read_file(marker_path) or { '' }) == 'second' {
+			break
+		}
+		time.sleep(10 * time.millisecond)
+	}
+	assert (os.read_file(marker_path) or { '' }) == 'second'
+	time.sleep(200 * time.millisecond)
+	assert (os.read_file(marker_path) or { '' }) == 'second'
 }
 
 fn test_code_lens_process_output_is_bounded() {

--- a/integration_test.v
+++ b/integration_test.v
@@ -2503,6 +2503,19 @@ fn test_integration_string_request_id_is_echoed() {
 	assert out[0].contains('"result"')
 }
 
+fn test_integration_initialize_advertises_runnable_code_lenses() {
+	mut app, project_dir := create_integration_test_env()
+	defer {
+		cleanup_integration_test_env(app, project_dir)
+	}
+	out := integration_run_frames(mut app, project_dir, 'code_lens_capabilities', [
+		'{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}',
+	])
+	assert out.len >= 1
+	assert out[0].contains('"codeLensProvider":{}')
+	assert out[0].contains('"executeCommandProvider":{"commands":["vls.runFile","vls.runTests"]}')
+}
+
 fn test_integration_client_response_is_consumed_not_dispatched() {
 	mut app, project_dir := create_integration_test_env()
 	defer {

--- a/interop.v
+++ b/interop.v
@@ -270,8 +270,9 @@ fn build_v_fmt_args(temp_file string) []string {
 }
 
 // build_v_run_args builds the compiler arguments used by the Run Main code lens.
-fn build_v_run_args(file_path string) []string {
-	return ['-nocolor', 'run', file_path]
+// Run Main executes the whole containing module from its working directory.
+fn build_v_run_args() []string {
+	return ['-nocolor', 'run', '.']
 }
 
 // build_v_test_args builds the compiler arguments used by the Run File and Run Test lenses.

--- a/interop.v
+++ b/interop.v
@@ -269,6 +269,21 @@ fn build_v_fmt_args(temp_file string) []string {
 	return ['fmt', '-inprocess', '-w', temp_file]
 }
 
+// build_v_run_args builds the compiler arguments used by the Run Main code lens.
+fn build_v_run_args(file_path string) []string {
+	return ['-nocolor', 'run', file_path]
+}
+
+// build_v_test_args builds the compiler arguments used by the Run File and Run Test lenses.
+// An empty function name runs every test in the file; otherwise only that test is selected.
+fn build_v_test_args(file_path string, fn_name string) []string {
+	mut args := ['-nocolor', 'test', file_path]
+	if fn_name != '' {
+		args << ['-run-only', fn_name]
+	}
+	return args
+}
+
 // parse_v_check_diagnostics converts V3's flat-AST checker output into the
 // compiler-neutral diagnostic representation used by the LSP layer. V3 emits
 // headers as `path:line:column: severity: message`; stage-specific severities

--- a/interop.v
+++ b/interop.v
@@ -275,10 +275,22 @@ fn build_v_run_args() []string {
 	return ['-nocolor', 'run', '.']
 }
 
+fn build_v_run_compile_args(executable_path string) []string {
+	return ['-nocolor', '-o', executable_path, '.']
+}
+
 // build_v_test_args builds the compiler arguments used by the Run File and Run Test lenses.
 // An empty function name runs every test in the file; otherwise only that test is selected.
 fn build_v_test_args(file_path string, fn_name string) []string {
 	mut args := ['-nocolor', 'test', file_path]
+	if fn_name != '' {
+		args << ['-run-only', fn_name]
+	}
+	return args
+}
+
+fn build_v_test_compile_args(file_path string, fn_name string, executable_path string) []string {
+	mut args := ['-nocolor', '-skip-running', '-o', executable_path, file_path]
 	if fn_name != '' {
 		args << ['-run-only', fn_name]
 	}

--- a/interop_test.v
+++ b/interop_test.v
@@ -380,6 +380,12 @@ fn test_build_v_fmt_args_passes_temp_file_literally() {
 
 fn test_build_v_run_args_targets_containing_module() {
 	assert build_v_run_args() == ['-nocolor', 'run', '.']
+	assert build_v_run_compile_args('/tmp/code lens program') == [
+		'-nocolor',
+		'-o',
+		'/tmp/code lens program',
+		'.',
+	]
 }
 
 fn test_build_v_test_args_selects_one_test_without_a_shell() {
@@ -387,6 +393,15 @@ fn test_build_v_test_args_selects_one_test_without_a_shell() {
 	args := build_v_test_args(file_path, 'test_one')
 	assert args == ['-nocolor', 'test', file_path, '-run-only', 'test_one']
 	assert build_v_test_args(file_path, '') == ['-nocolor', 'test', file_path]
+	assert build_v_test_compile_args(file_path, 'test_one', '/tmp/test program') == [
+		'-nocolor',
+		'-skip-running',
+		'-o',
+		'/tmp/test program',
+		file_path,
+		'-run-only',
+		'test_one',
+	]
 }
 
 fn test_build_v_line_info_args_single_embeds_line_info() {

--- a/interop_test.v
+++ b/interop_test.v
@@ -378,9 +378,8 @@ fn test_build_v_fmt_args_passes_temp_file_literally() {
 	assert args == ['fmt', '-inprocess', '-w', '/tmp/fmt file.v']
 }
 
-fn test_build_v_run_args_passes_source_file_literally() {
-	args := build_v_run_args('/tmp/main file; untouched.v')
-	assert args == ['-nocolor', 'run', '/tmp/main file; untouched.v']
+fn test_build_v_run_args_targets_containing_module() {
+	assert build_v_run_args() == ['-nocolor', 'run', '.']
 }
 
 fn test_build_v_test_args_selects_one_test_without_a_shell() {

--- a/interop_test.v
+++ b/interop_test.v
@@ -378,6 +378,18 @@ fn test_build_v_fmt_args_passes_temp_file_literally() {
 	assert args == ['fmt', '-inprocess', '-w', '/tmp/fmt file.v']
 }
 
+fn test_build_v_run_args_passes_source_file_literally() {
+	args := build_v_run_args('/tmp/main file; untouched.v')
+	assert args == ['-nocolor', 'run', '/tmp/main file; untouched.v']
+}
+
+fn test_build_v_test_args_selects_one_test_without_a_shell() {
+	file_path := '/tmp/file with spaces_test.v'
+	args := build_v_test_args(file_path, 'test_one')
+	assert args == ['-nocolor', 'test', file_path, '-run-only', 'test_one']
+	assert build_v_test_args(file_path, '') == ['-nocolor', 'test', file_path]
+}
+
 fn test_build_v_line_info_args_single_embeds_line_info() {
 	args := build_v_line_info_args_single('/tmp/a.v', '10:gd^5', '/tmp/a.v')
 	assert '/tmp/a.v:10:gd^5' in args

--- a/main.v
+++ b/main.v
@@ -49,6 +49,8 @@ mut:
 	received_initialize                         bool                         // True after initialize request was processed
 	next_request_id                             int = 1 // Counter for server-initiated request ids
 	diagnostics_scheduler                       ?&DiagnosticsScheduler // Production-only async diagnostics
+	run_command_manager                         ?&RunCommandManager // Async code-lens process lifecycle
+	execute_commands_synchronously              bool // Test hook for deterministic command assertions
 	write_mutex                                 &sync.Mutex = sync.new_mutex() // Serializes worker and request-loop writes
 }
 
@@ -481,6 +483,7 @@ fn parse_content_length_header(s string) !int {
 fn (mut app App) handle_requests(mut reader io.BufferedReader) {
 	defer {
 		app.cancel_all_scheduled_diagnostics()
+		app.stop_run_commands()
 	}
 	for {
 		// Reset the per-request raw id so a stale id can never leak into an
@@ -1237,6 +1240,7 @@ fn (mut app App) write_notification(notification Notification) {
 fn (mut app App) accept_shutdown(id int) {
 	log('Received shutdown request.')
 	app.cancel_all_scheduled_diagnostics()
+	app.stop_run_commands()
 	app.is_shutdown = true
 	app.write_response(Response{
 		id:     id

--- a/main.v
+++ b/main.v
@@ -650,10 +650,9 @@ fn (mut app App) handle_requests(mut reader io.BufferedReader) {
 							// NOTE: Placeholder/stub capabilities are intentionally NOT
 							// advertised (P1-07 / Stage 0): on-type formatting (always
 							// empty), inline values (wrong abstraction), linked editing
-							// (wrong abstraction), file-operation hooks (no-ops), the
-							// run/test executeCommand + codeLens stubs, and willSave
-							// (never dispatched). Advertising only working features gives
-							// a better editor experience than exposing broken UI.
+							// (wrong abstraction), file-operation hooks (no-ops), and
+							// willSave (never dispatched). Advertising only working
+							// features gives a better editor experience than broken UI.
 							text_document_sync:           TextDocumentSyncOptions{
 								open_close:           true
 								change:               2 // Incremental
@@ -683,6 +682,10 @@ fn (mut app App) handle_requests(mut reader io.BufferedReader) {
 							workspace_symbol_provider:    true
 							inlay_hint_provider:          true
 							code_action_provider:         true
+							execute_command_provider:     ExecuteCommandOptions{
+								commands: ['vls.runFile', 'vls.runTests']
+							}
+							code_lens_provider:           CodeLensOptions{}
 							semantic_tokens_provider:     SemanticTokensOptions{
 								legend: SemanticTokensLegend{
 									token_types:     semantic_token_types()

--- a/run_command.v
+++ b/run_command.v
@@ -1,0 +1,272 @@
+// Copyright (c) 2026 Alexander Medvednikov. All rights reserved.
+// Use of this source code is governed by a GPL license that can be found in the LICENSE file.
+module main
+
+import net
+import os
+import strings
+import sync
+import time
+
+enum CodeLensRunKind {
+	main
+	test_file
+	test_function
+}
+
+struct CodeLensRunJob {
+	kind           CodeLensRunKind
+	title          string
+	uri            string
+	path           string
+	fn_name        string
+	open_files     map[string]string
+	write_mutex    &sync.Mutex
+	tcp_conn       ?&net.TcpConn
+	capture_output bool
+}
+
+struct ManagedRunResult {
+	result    os.Result
+	cancelled bool
+}
+
+@[heap]
+struct RunCommandManager {
+	workers &sync.WaitGroup
+mut:
+	mutex     sync.Mutex
+	processes map[u64]&os.Process
+	next_id   u64
+	stopping  bool
+}
+
+fn new_run_command_manager() &RunCommandManager {
+	return &RunCommandManager{
+		workers:   sync.new_waitgroup()
+		processes: map[u64]&os.Process{}
+	}
+}
+
+// begin_job reserves an id and increments the worker count while holding the lifecycle lock.
+// Once stopping is set, no new worker can race with wait().
+fn (mut manager RunCommandManager) begin_job() (u64, bool) {
+	manager.mutex.lock()
+	defer {
+		manager.mutex.unlock()
+	}
+	if manager.stopping {
+		return 0, false
+	}
+	manager.next_id++
+	manager.workers.add(1)
+	return manager.next_id, true
+}
+
+fn (mut manager RunCommandManager) launch(job CodeLensRunJob) bool {
+	id, accepted := manager.begin_job()
+	if !accepted {
+		return false
+	}
+	spawn run_code_lens_job(mut manager, id, job)
+	return true
+}
+
+// run_sync is only used by tests that need to inspect worker notifications deterministically.
+fn (mut manager RunCommandManager) run_sync(job CodeLensRunJob) []string {
+	id, accepted := manager.begin_job()
+	if !accepted {
+		return []
+	}
+	return run_code_lens_job(mut manager, id, job)
+}
+
+fn (mut manager RunCommandManager) register_process(id u64, process &os.Process) bool {
+	manager.mutex.lock()
+	defer {
+		manager.mutex.unlock()
+	}
+	if manager.stopping {
+		return false
+	}
+	manager.processes[id] = process
+	return true
+}
+
+fn (mut manager RunCommandManager) unregister_process(id u64) {
+	manager.mutex.lock()
+	manager.processes.delete(id)
+	manager.mutex.unlock()
+}
+
+fn (mut manager RunCommandManager) is_stopping() bool {
+	manager.mutex.lock()
+	stopping := manager.stopping
+	manager.mutex.unlock()
+	return stopping
+}
+
+// cancel_all_and_wait prevents new runs, kills active children, and joins every worker.
+fn (mut manager RunCommandManager) cancel_all_and_wait() {
+	manager.mutex.lock()
+	manager.stopping = true
+	for _, mut process in manager.processes {
+		if process.is_alive() {
+			process.signal_pgkill()
+		}
+	}
+	manager.mutex.unlock()
+	manager.workers.wait()
+}
+
+// run_managed_v_argv runs a user-requested program without the diagnostics timeout. The manager
+// owns cancellation instead, so a long-running main stays alive while VLS remains active and is
+// terminated when its client shuts down or disconnects.
+fn run_managed_v_argv(mut manager RunCommandManager, id u64, args []string,
+	work_folder string) ManagedRunResult {
+	if work_folder != '' && !os.is_dir(work_folder) {
+		return ManagedRunResult{
+			result: os.Result{
+				exit_code: 1
+				output:    'Working dir does not exist: ${work_folder}'
+			}
+		}
+	}
+	mut process := os.new_process(resolve_v_compiler_exe())
+	process.set_args(args)
+	process.use_pgroup = true
+	if work_folder != '' {
+		process.set_work_folder(work_folder)
+	}
+	process.set_redirect_stdio()
+	process.run()
+	registered := manager.register_process(id, process)
+	if !registered && process.is_alive() {
+		process.signal_pgkill()
+	}
+
+	mut output := strings.new_builder(1024)
+	for process.is_alive() {
+		mut got_data := false
+		if chunk := process.pipe_read(.stdout) {
+			output.write_string(chunk)
+			got_data = true
+		}
+		if chunk := process.pipe_read(.stderr) {
+			output.write_string(chunk)
+			got_data = true
+		}
+		if !got_data {
+			time.sleep(time.millisecond)
+		}
+	}
+	output.write_string(process.stdout_slurp())
+	output.write_string(process.stderr_slurp())
+	process.wait()
+	if registered {
+		manager.unregister_process(id)
+	}
+	exit_code := process.code
+	process.close()
+	return ManagedRunResult{
+		result: os.Result{
+			exit_code: exit_code
+			output:    output.str()
+		}
+		cancelled: !registered || manager.is_stopping()
+	}
+}
+
+fn code_lens_display_args(job CodeLensRunJob) []string {
+	return match job.kind {
+		.main { build_v_run_args() }
+		.test_file { build_v_test_args(job.path, '') }
+		.test_function { build_v_test_args(job.path, job.fn_name) }
+	}
+}
+
+fn run_code_lens_job(mut manager RunCommandManager, id u64, job CodeLensRunJob) []string {
+	defer {
+		manager.workers.done()
+	}
+	temp_dir := os.join_path(os.temp_dir(), 'vls_run_${os.getpid()}_${id}_${time.now().unix_nano()}')
+	mut worker := App{
+		open_files:      job.open_files
+		temp_dir:        temp_dir
+		capture_output:  job.capture_output
+		write_mutex:     job.write_mutex
+		tcp_conn:        job.tcp_conn
+	}
+	os.mkdir_all(temp_dir) or {
+		worker.send_show_message('vls: ${job.title} could not create a temporary directory: ${err}',
+			1)
+		return worker.captured_output.clone()
+	}
+	defer {
+		os.rmdir_all(temp_dir) or { log('Failed to clean up run command directory: ${err}') }
+	}
+
+	mut target_path := job.path
+	mut exec_dir := os.dir(job.path)
+	mut overlay := CompilationOverlay{}
+	if job.uri in job.open_files {
+		overlay = worker.prepare_compilation_overlay(job.path) or {
+			worker.send_show_message('vls: ${job.title} could not prepare the open buffer: ${err}',
+				1)
+			return worker.captured_output.clone()
+		}
+		target_path = overlay.temp_source_file
+		exec_dir = overlay.temp_work_dir
+	}
+
+	args := match job.kind {
+		.main { build_v_run_args() }
+		.test_file { build_v_test_args(target_path, '') }
+		.test_function { build_v_test_args(target_path, job.fn_name) }
+	}
+	display_args := code_lens_display_args(job)
+	worker.send_log_message('vls: ${job.title}: v ${display_args.join(' ')}', 3)
+	managed_result := run_managed_v_argv(mut manager, id, args, exec_dir)
+	if managed_result.cancelled {
+		return worker.captured_output.clone()
+	}
+	mut output := managed_result.result.output.trim_space()
+	if overlay.temp_root != '' {
+		output = output.replace(overlay.temp_root, overlay.source_display_root)
+	}
+	if output != '' {
+		level := if managed_result.result.exit_code == 0 { 3 } else { 1 }
+		worker.send_log_message(output, level)
+	}
+	if managed_result.result.exit_code != 0 {
+		worker.send_show_message(
+			'vls: ${job.title} failed with exit code ${managed_result.result.exit_code}.', 1)
+	} else {
+		worker.send_show_message('vls: ${job.title} finished successfully.', 3)
+	}
+	return worker.captured_output.clone()
+}
+
+fn (mut app App) start_code_lens_run(job CodeLensRunJob) {
+	mut manager := app.get_run_command_manager()
+	if app.execute_commands_synchronously {
+		app.captured_output << manager.run_sync(job)
+	} else if !manager.launch(job) {
+		app.send_show_message('vls: cannot start ${job.title}; the server is shutting down.', 1)
+	}
+}
+
+fn (mut app App) get_run_command_manager() &RunCommandManager {
+	if manager := app.run_command_manager {
+		return manager
+	}
+	manager := new_run_command_manager()
+	app.run_command_manager = manager
+	return manager
+}
+
+fn (mut app App) stop_run_commands() {
+	if mut manager := app.run_command_manager {
+		manager.cancel_all_and_wait()
+	}
+}

--- a/run_command.v
+++ b/run_command.v
@@ -8,6 +8,9 @@ import strings
 import sync
 import time
 
+const code_lens_output_limit_bytes = 256 * 1024
+const code_lens_output_truncation_notice = '\n[vls: additional process output was truncated]'
+
 enum CodeLensRunKind {
 	main
 	test_file
@@ -29,6 +32,42 @@ struct CodeLensRunJob {
 struct ManagedRunResult {
 	result    os.Result
 	cancelled bool
+}
+
+struct RunOutputBuffer {
+mut:
+	output    strings.Builder
+	truncated bool
+}
+
+fn new_run_output_buffer() RunOutputBuffer {
+	return RunOutputBuffer{
+		output: strings.new_builder(1024)
+	}
+}
+
+fn (mut output RunOutputBuffer) write(chunk string) {
+	remaining := code_lens_output_limit_bytes - output.output.len
+	if remaining <= 0 {
+		if chunk.len > 0 {
+			output.truncated = true
+		}
+		return
+	}
+	if chunk.len <= remaining {
+		output.output.write_string(chunk)
+		return
+	}
+	output.output.write_string(chunk[..remaining])
+	output.truncated = true
+}
+
+fn (mut output RunOutputBuffer) str() string {
+	mut result := output.output.str()
+	if output.truncated {
+		result += code_lens_output_truncation_notice
+	}
+	return result
 }
 
 @[heap]
@@ -119,10 +158,10 @@ fn (mut manager RunCommandManager) cancel_all_and_wait() {
 	manager.workers.wait()
 }
 
-// run_managed_v_argv runs a user-requested program without the diagnostics timeout. The manager
-// owns cancellation instead, so a long-running main stays alive while VLS remains active and is
-// terminated when its client shuts down or disconnects.
-fn run_managed_v_argv(mut manager RunCommandManager, id u64, args []string,
+// run_managed_process runs a code-lens subprocess without the diagnostics timeout. The manager
+// owns cancellation instead, so a long-running program stays alive while VLS remains active and
+// is terminated when its client shuts down or disconnects.
+fn run_managed_process(mut manager RunCommandManager, id u64, executable string, args []string,
 	work_folder string) ManagedRunResult {
 	if work_folder != '' && !os.is_dir(work_folder) {
 		return ManagedRunResult{
@@ -132,7 +171,7 @@ fn run_managed_v_argv(mut manager RunCommandManager, id u64, args []string,
 			}
 		}
 	}
-	mut process := os.new_process(resolve_v_compiler_exe())
+	mut process := os.new_process(executable)
 	process.set_args(args)
 	process.use_pgroup = true
 	if work_folder != '' {
@@ -145,23 +184,23 @@ fn run_managed_v_argv(mut manager RunCommandManager, id u64, args []string,
 		process.signal_pgkill()
 	}
 
-	mut output := strings.new_builder(1024)
+	mut output := new_run_output_buffer()
 	for process.is_alive() {
 		mut got_data := false
 		if chunk := process.pipe_read(.stdout) {
-			output.write_string(chunk)
+			output.write(chunk)
 			got_data = true
 		}
 		if chunk := process.pipe_read(.stderr) {
-			output.write_string(chunk)
+			output.write(chunk)
 			got_data = true
 		}
 		if !got_data {
 			time.sleep(time.millisecond)
 		}
 	}
-	output.write_string(process.stdout_slurp())
-	output.write_string(process.stderr_slurp())
+	output.write(process.stdout_slurp())
+	output.write(process.stderr_slurp())
 	process.wait()
 	if registered {
 		manager.unregister_process(id)
@@ -174,6 +213,33 @@ fn run_managed_v_argv(mut manager RunCommandManager, id u64, args []string,
 			output:    output.str()
 		}
 		cancelled: !registered || manager.is_stopping()
+	}
+}
+
+fn code_lens_executable_path(temp_dir string) string {
+	$if windows {
+		return os.join_path(temp_dir, 'code_lens_program.exe')
+	}
+	return os.join_path(temp_dir, 'code_lens_program')
+}
+
+fn code_lens_compile_args(job CodeLensRunJob, target_path string,
+	executable_path string) []string {
+	return match job.kind {
+		.main { build_v_run_compile_args(executable_path) }
+		.test_file { build_v_test_compile_args(target_path, '', executable_path) }
+		.test_function { build_v_test_compile_args(target_path, job.fn_name, executable_path) }
+	}
+}
+
+fn log_code_lens_output(mut worker App, result os.Result, overlay CompilationOverlay) {
+	mut output := result.output.trim_space()
+	if overlay.temp_root != '' {
+		output = output.replace(overlay.temp_root, overlay.source_display_root)
+	}
+	if output != '' {
+		level := if result.exit_code == 0 { 3 } else { 1 }
+		worker.send_log_message(output, level)
 	}
 }
 
@@ -207,7 +273,8 @@ fn run_code_lens_job(mut manager RunCommandManager, id u64, job CodeLensRunJob) 
 	}
 
 	mut target_path := job.path
-	mut exec_dir := os.dir(job.path)
+	source_work_dir := os.dir(job.path)
+	mut compile_dir := source_work_dir
 	mut overlay := CompilationOverlay{}
 	if job.uri in job.open_files {
 		overlay = worker.prepare_compilation_overlay(job.path) or {
@@ -216,34 +283,36 @@ fn run_code_lens_job(mut manager RunCommandManager, id u64, job CodeLensRunJob) 
 			return worker.captured_output.clone()
 		}
 		target_path = overlay.temp_source_file
-		exec_dir = overlay.temp_work_dir
+		compile_dir = overlay.temp_work_dir
 	}
 
-	args := match job.kind {
-		.main { build_v_run_args() }
-		.test_file { build_v_test_args(target_path, '') }
-		.test_function { build_v_test_args(target_path, job.fn_name) }
-	}
+	executable_path := code_lens_executable_path(temp_dir)
+	compile_args := code_lens_compile_args(job, target_path, executable_path)
 	display_args := code_lens_display_args(job)
 	worker.send_log_message('vls: ${job.title}: v ${display_args.join(' ')}', 3)
-	managed_result := run_managed_v_argv(mut manager, id, args, exec_dir)
-	if managed_result.cancelled {
+	compile_result := run_managed_process(mut manager, id, resolve_v_compiler_exe(), compile_args,
+		compile_dir)
+	if compile_result.cancelled {
 		return worker.captured_output.clone()
 	}
-	mut output := managed_result.result.output.trim_space()
-	if overlay.temp_root != '' {
-		output = output.replace(overlay.temp_root, overlay.source_display_root)
-	}
-	if output != '' {
-		level := if managed_result.result.exit_code == 0 { 3 } else { 1 }
-		worker.send_log_message(output, level)
-	}
-	if managed_result.result.exit_code != 0 {
+	log_code_lens_output(mut worker, compile_result.result, overlay)
+	if compile_result.result.exit_code != 0 {
 		worker.send_show_message(
-			'vls: ${job.title} failed with exit code ${managed_result.result.exit_code}.', 1)
-	} else {
-		worker.send_show_message('vls: ${job.title} finished successfully.', 3)
+			'vls: ${job.title} failed with exit code ${compile_result.result.exit_code}.', 1)
+		return worker.captured_output.clone()
 	}
+
+	run_result := run_managed_process(mut manager, id, executable_path, [], source_work_dir)
+	if run_result.cancelled {
+		return worker.captured_output.clone()
+	}
+	log_code_lens_output(mut worker, run_result.result, overlay)
+	if run_result.result.exit_code != 0 {
+		worker.send_show_message(
+			'vls: ${job.title} failed with exit code ${run_result.result.exit_code}.', 1)
+		return worker.captured_output.clone()
+	}
+	worker.send_show_message('vls: ${job.title} finished successfully.', 3)
 	return worker.captured_output.clone()
 }
 

--- a/run_command.v
+++ b/run_command.v
@@ -70,6 +70,211 @@ fn (mut output RunOutputBuffer) str() string {
 	return result
 }
 
+// code_lens_source_code_mask keeps code bytes in place while hiding strings and comments.
+// Interpolation expressions remain visible because they can contain compile-time path tokens.
+fn code_lens_source_code_mask(source string) []u8 {
+	mut mask := []u8{len: source.len, init: ` `}
+	mut state := ImportScanState{}
+	mut in_line_comment := false
+	mut pos := 0
+	for pos < source.len {
+		if in_line_comment {
+			if source[pos] == `\n` {
+				in_line_comment = false
+				mask[pos] = `\n`
+			}
+			pos++
+			continue
+		}
+		if state.block_comment_depth > 0 {
+			if pos + 1 < source.len && source[pos] == `/` && source[pos + 1] == `*` {
+				state.block_comment_depth++
+				pos += 2
+				continue
+			}
+			if pos + 1 < source.len && source[pos] == `*` && source[pos + 1] == `/` {
+				state.block_comment_depth--
+				pos += 2
+				continue
+			}
+			if source[pos] == `\n` {
+				mask[pos] = `\n`
+			}
+			pos++
+			continue
+		}
+		if state.quote != 0 {
+			if !state.raw_string && source[pos] == `\\` && pos + 1 < source.len {
+				pos += 2
+				continue
+			}
+			if !state.raw_string && source[pos] == `$` && pos + 1 < source.len
+				&& source[pos + 1] == `{` {
+				state.interpolations << ImportInterpolationState{
+					quote: state.quote
+				}
+				state.quote = 0
+				pos += 2
+				continue
+			}
+			if source[pos] == state.quote {
+				state.quote = 0
+				state.raw_string = false
+			}
+			if source[pos] == `\n` {
+				mask[pos] = `\n`
+			}
+			pos++
+			continue
+		}
+		if pos + 1 < source.len && source[pos] == `/` && source[pos + 1] == `/` {
+			in_line_comment = true
+			pos += 2
+			continue
+		}
+		if pos + 1 < source.len && source[pos] == `/` && source[pos + 1] == `*` {
+			state.block_comment_depth = 1
+			pos += 2
+			continue
+		}
+		if source[pos] == `{` && state.interpolations.len > 0 {
+			last := state.interpolations.len - 1
+			state.interpolations[last].brace_depth++
+			mask[pos] = source[pos]
+			pos++
+			continue
+		}
+		if source[pos] == `}` && state.interpolations.len > 0 {
+			last := state.interpolations.len - 1
+			if state.interpolations[last].brace_depth == 0 {
+				interpolation := state.interpolations.pop()
+				state.quote = interpolation.quote
+				state.raw_string = false
+			} else {
+				state.interpolations[last].brace_depth--
+				mask[pos] = source[pos]
+			}
+			pos++
+			continue
+		}
+		if source[pos] == `r` && pos + 1 < source.len
+			&& source[pos + 1] in [`'`, `"`] {
+			state.quote = source[pos + 1]
+			state.raw_string = true
+			pos += 2
+			continue
+		}
+		if source[pos] in [`'`, `"`, 96] {
+			state.quote = source[pos]
+			state.raw_string = false
+			pos++
+			continue
+		}
+		mask[pos] = source[pos]
+		pos++
+	}
+	return mask
+}
+
+fn code_lens_mask_has_at_token(mask []u8, pos int, token string) bool {
+	if pos + token.len > mask.len {
+		return false
+	}
+	for i in 0 .. token.len {
+		if mask[pos + i] != token[i] {
+			return false
+		}
+	}
+	return pos + token.len == mask.len || !is_ident_char(mask[pos + token.len])
+}
+
+fn code_lens_token_is_in_hash_directive(mask []u8, pos int) bool {
+	mut line_start := pos
+	for line_start > 0 && mask[line_start - 1] != `\n` {
+		line_start--
+	}
+	for line_start < pos && mask[line_start].is_space() {
+		line_start++
+	}
+	return line_start < pos && mask[line_start] == `#`
+}
+
+fn code_lens_v_string_literal(value string) string {
+	escaped := value.replace('\\', '\\\\').replace("'", "\\'").replace('$', '\\$').replace('\n',
+		'\\n').replace('\r', '\\r').replace('\t', '\\t')
+	return "'${escaped}'"
+}
+
+// code_lens_source_with_real_paths prevents the temporary overlay location from being compiled
+// into path pseudo variables. Hash directives retain their tokens so the compiler can resolve
+// native inputs from the materialized overlay.
+fn code_lens_source_with_real_paths(source string, source_path string) string {
+	mask := code_lens_source_code_mask(source)
+	file_path := os.real_path(source_path)
+	file_dir := os.real_path(os.dir(source_path))
+	vmod_root := find_project_root(os.dir(source_path))
+	mut rewritten := strings.new_builder(source.len + 64)
+	mut pos := 0
+	for pos < source.len {
+		if mask[pos] == `@` && !code_lens_token_is_in_hash_directive(mask, pos) {
+			if vmod_root != '' && code_lens_mask_has_at_token(mask, pos, '@VMODROOT') {
+				rewritten.write_string(code_lens_v_string_literal(os.real_path(vmod_root)))
+				pos += '@VMODROOT'.len
+				continue
+			}
+			if code_lens_mask_has_at_token(mask, pos, '@FILE') {
+				rewritten.write_string(code_lens_v_string_literal(file_path))
+				pos += '@FILE'.len
+				continue
+			}
+			if code_lens_mask_has_at_token(mask, pos, '@DIR') {
+				rewritten.write_string(code_lens_v_string_literal(file_dir))
+				pos += '@DIR'.len
+				continue
+			}
+		}
+		rewritten.write_u8(source[pos])
+		pos++
+	}
+	return rewritten.str()
+}
+
+// preserve_code_lens_overlay_dir rewrites both open buffers and linked sibling module files.
+fn preserve_code_lens_overlay_dir(overlay CompilationOverlay, temp_dir string,
+	open_sources map[string]string) ! {
+	for entry in os.ls(temp_dir)! {
+		temp_path := os.join_path(temp_dir, entry)
+		if !os.is_link(temp_path) && os.is_dir(temp_path) {
+			preserve_code_lens_overlay_dir(overlay, temp_path, open_sources)!
+			continue
+		}
+		if !os.is_file(temp_path) || (!temp_path.ends_with('.v') && !temp_path.ends_with('.vsh')) {
+			continue
+		}
+		rel_path := overlay_relative_path(temp_path, overlay.temp_root) or { continue }
+		source_path := normalize_overlay_path(os.join_path(overlay.source_root, rel_path))
+		source := open_sources[source_path] or { os.read_file(temp_path)! }
+		rewritten := code_lens_source_with_real_paths(source, source_path)
+		if rewritten == source {
+			continue
+		}
+		// Unlink first: unchanged overlay files may be links to the user's source tree.
+		os.rm(temp_path)!
+		os.write_file(temp_path, rewritten) or {
+			return error('Failed to preserve source paths for ${source_path}: ${err}')
+		}
+	}
+}
+
+fn preserve_code_lens_overlay_source_paths(overlay CompilationOverlay,
+	open_files map[string]string) ! {
+	mut open_sources := map[string]string{}
+	for uri, source in open_files {
+		open_sources[normalize_overlay_path(uri_to_path(uri))] = source
+	}
+	preserve_code_lens_overlay_dir(overlay, overlay.temp_root, open_sources)!
+}
+
 @[heap]
 struct RunCommandManager {
 	workers &sync.WaitGroup
@@ -177,6 +382,7 @@ fn run_managed_process(mut manager RunCommandManager, id u64, executable string,
 	if work_folder != '' {
 		process.set_work_folder(work_folder)
 	}
+	process.set_stdin_path(os.path_devnull)
 	process.set_redirect_stdio()
 	process.run()
 	registered := manager.register_process(id, process)
@@ -279,6 +485,11 @@ fn run_code_lens_job(mut manager RunCommandManager, id u64, job CodeLensRunJob) 
 	if job.uri in job.open_files {
 		overlay = worker.prepare_compilation_overlay(job.path) or {
 			worker.send_show_message('vls: ${job.title} could not prepare the open buffer: ${err}',
+				1)
+			return worker.captured_output.clone()
+		}
+		preserve_code_lens_overlay_source_paths(overlay, job.open_files) or {
+			worker.send_show_message('vls: ${job.title} could not preserve source paths: ${err}',
 				1)
 			return worker.captured_output.clone()
 		}

--- a/run_command.v
+++ b/run_command.v
@@ -62,9 +62,36 @@ fn (mut output RunOutputBuffer) write(chunk string) {
 	output.truncated = true
 }
 
+fn code_lens_complete_utf8_prefix_len(value string) int {
+	if value.len == 0 {
+		return 0
+	}
+	mut start := value.len - 1
+	for start > 0 && value[start] & 0xc0 == 0x80 {
+		start--
+	}
+	first := value[start]
+	expected_len := if first & 0x80 == 0 {
+		1
+	} else if first & 0xe0 == 0xc0 {
+		2
+	} else if first & 0xf0 == 0xe0 {
+		3
+	} else if first & 0xf8 == 0xf0 {
+		4
+	} else {
+		1
+	}
+	if value.len - start < expected_len {
+		return start
+	}
+	return value.len
+}
+
 fn (mut output RunOutputBuffer) str() string {
 	mut result := output.output.str()
 	if output.truncated {
+		result = result[..code_lens_complete_utf8_prefix_len(result)]
 		result += code_lens_output_truncation_notice
 	}
 	return result
@@ -208,18 +235,33 @@ fn code_lens_v_string_literal(value string) string {
 // code_lens_source_with_real_paths prevents the temporary overlay location from being compiled
 // into path pseudo variables. Hash directives retain their tokens so the compiler can resolve
 // native inputs from the materialized overlay.
-fn code_lens_source_with_real_paths(source string, source_path string) string {
+fn code_lens_source_with_real_paths(source string, source_path string,
+	temp_source_path string) string {
 	mask := code_lens_source_code_mask(source)
 	file_path := os.real_path(source_path)
 	file_dir := os.real_path(os.dir(source_path))
 	vmod_root := find_project_root(os.dir(source_path))
 	mut rewritten := strings.new_builder(source.len + 64)
 	mut pos := 0
+	mut line_nr := 1
 	for pos < source.len {
 		if mask[pos] == `@` && !code_lens_token_is_in_hash_directive(mask, pos) {
 			if vmod_root != '' && code_lens_mask_has_at_token(mask, pos, '@VMODROOT') {
 				rewritten.write_string(code_lens_v_string_literal(os.real_path(vmod_root)))
 				pos += '@VMODROOT'.len
+				continue
+			}
+			if code_lens_mask_has_at_token(mask, pos, '@FILE_LINE') {
+				file_line := '${os.file_name(source_path)}:${line_nr}'
+				rewritten.write_string(code_lens_v_string_literal(file_line))
+				pos += '@FILE_LINE'.len
+				continue
+			}
+			if code_lens_mask_has_at_token(mask, pos, '@LOCATION') {
+				temp_literal := code_lens_v_string_literal(temp_source_path)
+				file_literal := code_lens_v_string_literal(file_path)
+				rewritten.write_string('(@LOCATION.replace(${temp_literal}, ${file_literal}))')
+				pos += '@LOCATION'.len
 				continue
 			}
 			if code_lens_mask_has_at_token(mask, pos, '@FILE') {
@@ -234,6 +276,9 @@ fn code_lens_source_with_real_paths(source string, source_path string) string {
 			}
 		}
 		rewritten.write_u8(source[pos])
+		if source[pos] == `\n` {
+			line_nr++
+		}
 		pos++
 	}
 	return rewritten.str()
@@ -254,7 +299,7 @@ fn preserve_code_lens_overlay_dir(overlay CompilationOverlay, temp_dir string,
 		rel_path := overlay_relative_path(temp_path, overlay.temp_root) or { continue }
 		source_path := normalize_overlay_path(os.join_path(overlay.source_root, rel_path))
 		source := open_sources[source_path] or { os.read_file(temp_path)! }
-		rewritten := code_lens_source_with_real_paths(source, source_path)
+		rewritten := code_lens_source_with_real_paths(source, source_path, temp_path)
 		if rewritten == source {
 			continue
 		}

--- a/run_command.v
+++ b/run_command.v
@@ -232,20 +232,40 @@ fn code_lens_v_string_literal(value string) string {
 	return "'${escaped}'"
 }
 
-// code_lens_source_with_real_paths prevents the temporary overlay location from being compiled
-// into path pseudo variables. Hash directives retain their tokens so the compiler can resolve
+// code_lens_source_with_original_pseudos prevents temporary overlay layout from changing
+// compile-time pseudo values. Hash directives retain their tokens so the compiler can resolve
 // native inputs from the materialized overlay.
-fn code_lens_source_with_real_paths(source string, source_path string,
+fn code_lens_source_with_original_pseudos(source string, source_path string,
 	temp_source_path string) string {
 	mask := code_lens_source_code_mask(source)
 	file_path := os.real_path(source_path)
 	file_dir := os.real_path(os.dir(source_path))
 	vmod_root := find_project_root(os.dir(source_path))
+	temp_vmod_root := find_project_root(os.dir(temp_source_path))
+	vmod_file_path := if temp_vmod_root != '' {
+		os.join_path(temp_vmod_root, 'v.mod')
+	} else if vmod_root != '' {
+		os.join_path(vmod_root, 'v.mod')
+	} else {
+		''
+	}
+	vmod_file_content := if vmod_file_path != '' {
+		(os.read_file(vmod_file_path) or { '' }).replace('\r\n', '\n')
+	} else {
+		''
+	}
 	mut rewritten := strings.new_builder(source.len + 64)
 	mut pos := 0
 	mut line_nr := 1
+	mut line_start := 0
 	for pos < source.len {
 		if mask[pos] == `@` && !code_lens_token_is_in_hash_directive(mask, pos) {
+			if vmod_file_path != '' && code_lens_mask_has_at_token(mask, pos, '@VMOD_FILE') {
+				// V defines @VMOD_FILE as the manifest contents, not the manifest path.
+				rewritten.write_string(code_lens_v_string_literal(vmod_file_content))
+				pos += '@VMOD_FILE'.len
+				continue
+			}
 			if vmod_root != '' && code_lens_mask_has_at_token(mask, pos, '@VMODROOT') {
 				rewritten.write_string(code_lens_v_string_literal(os.real_path(vmod_root)))
 				pos += '@VMODROOT'.len
@@ -264,6 +284,11 @@ fn code_lens_source_with_real_paths(source string, source_path string,
 				pos += '@LOCATION'.len
 				continue
 			}
+			if code_lens_mask_has_at_token(mask, pos, '@COLUMN') {
+				rewritten.write_string(code_lens_v_string_literal((pos - line_start + 1).str()))
+				pos += '@COLUMN'.len
+				continue
+			}
 			if code_lens_mask_has_at_token(mask, pos, '@FILE') {
 				rewritten.write_string(code_lens_v_string_literal(file_path))
 				pos += '@FILE'.len
@@ -278,6 +303,7 @@ fn code_lens_source_with_real_paths(source string, source_path string,
 		rewritten.write_u8(source[pos])
 		if source[pos] == `\n` {
 			line_nr++
+			line_start = pos + 1
 		}
 		pos++
 	}
@@ -299,7 +325,7 @@ fn preserve_code_lens_overlay_dir(overlay CompilationOverlay, temp_dir string,
 		rel_path := overlay_relative_path(temp_path, overlay.temp_root) or { continue }
 		source_path := normalize_overlay_path(os.join_path(overlay.source_root, rel_path))
 		source := open_sources[source_path] or { os.read_file(temp_path)! }
-		rewritten := code_lens_source_with_real_paths(source, source_path, temp_path)
+		rewritten := code_lens_source_with_original_pseudos(source, source_path, temp_path)
 		if rewritten == source {
 			continue
 		}

--- a/run_command.v
+++ b/run_command.v
@@ -350,22 +350,45 @@ fn preserve_code_lens_overlay_source_paths(overlay CompilationOverlay,
 struct RunCommandManager {
 	workers &sync.WaitGroup
 mut:
-	mutex     sync.Mutex
-	processes map[u64]&os.Process
-	next_id   u64
-	stopping  bool
+	mutex          sync.Mutex
+	processes      map[u64]&os.Process
+	active_targets map[string]u64
+	next_id        u64
+	stopping       bool
 }
 
 fn new_run_command_manager() &RunCommandManager {
 	return &RunCommandManager{
-		workers:   sync.new_waitgroup()
-		processes: map[u64]&os.Process{}
+		workers:        sync.new_waitgroup()
+		processes:      map[u64]&os.Process{}
+		active_targets: map[string]u64{}
+	}
+}
+
+fn code_lens_run_target(job CodeLensRunJob) string {
+	kind := match job.kind {
+		.main { 'main' }
+		.test_file { 'test-file' }
+		.test_function { 'test-function' }
+	}
+	path := normalized_index_path(job.path)
+	return '${kind}:${path.len}:${path}:${job.fn_name}'
+}
+
+// cancel_process_locked stops the current subprocess for a job while the lifecycle lock is held.
+fn (mut manager RunCommandManager) cancel_process_locked(id u64) {
+	for process_id, mut process in manager.processes {
+		if process_id == id && process.is_alive() {
+			process.signal_pgkill()
+			return
+		}
 	}
 }
 
 // begin_job reserves an id and increments the worker count while holding the lifecycle lock.
-// Once stopping is set, no new worker can race with wait().
-fn (mut manager RunCommandManager) begin_job() (u64, bool) {
+// A newer run replaces the active job for the same target. Once stopping is set, no new worker
+// can race with wait().
+fn (mut manager RunCommandManager) begin_job(target string) (u64, bool) {
 	manager.mutex.lock()
 	defer {
 		manager.mutex.unlock()
@@ -373,35 +396,46 @@ fn (mut manager RunCommandManager) begin_job() (u64, bool) {
 	if manager.stopping {
 		return 0, false
 	}
+	if previous_id := manager.active_targets[target] {
+		manager.cancel_process_locked(previous_id)
+	}
 	manager.next_id++
 	manager.workers.add(1)
+	manager.active_targets[target] = manager.next_id
 	return manager.next_id, true
 }
 
 fn (mut manager RunCommandManager) launch(job CodeLensRunJob) bool {
-	id, accepted := manager.begin_job()
+	target := code_lens_run_target(job)
+	id, accepted := manager.begin_job(target)
 	if !accepted {
 		return false
 	}
-	spawn run_code_lens_job(mut manager, id, job)
+	spawn run_code_lens_job(mut manager, id, target, job)
 	return true
 }
 
 // run_sync is only used by tests that need to inspect worker notifications deterministically.
 fn (mut manager RunCommandManager) run_sync(job CodeLensRunJob) []string {
-	id, accepted := manager.begin_job()
+	target := code_lens_run_target(job)
+	id, accepted := manager.begin_job(target)
 	if !accepted {
 		return []
 	}
-	return run_code_lens_job(mut manager, id, job)
+	return run_code_lens_job(mut manager, id, target, job)
 }
 
-fn (mut manager RunCommandManager) register_process(id u64, process &os.Process) bool {
+fn (mut manager RunCommandManager) register_process(id u64, target string,
+	process &os.Process) bool {
 	manager.mutex.lock()
 	defer {
 		manager.mutex.unlock()
 	}
 	if manager.stopping {
+		return false
+	}
+	active_id := manager.active_targets[target] or { return false }
+	if active_id != id {
 		return false
 	}
 	manager.processes[id] = process
@@ -414,11 +448,29 @@ fn (mut manager RunCommandManager) unregister_process(id u64) {
 	manager.mutex.unlock()
 }
 
-fn (mut manager RunCommandManager) is_stopping() bool {
+fn (mut manager RunCommandManager) job_is_cancelled(id u64, target string) bool {
 	manager.mutex.lock()
-	stopping := manager.stopping
+	mut cancelled := manager.stopping
+	if !cancelled {
+		if active_id := manager.active_targets[target] {
+			cancelled = active_id != id
+		} else {
+			cancelled = true
+		}
+	}
 	manager.mutex.unlock()
-	return stopping
+	return cancelled
+}
+
+fn (mut manager RunCommandManager) finish_job(id u64, target string) {
+	manager.mutex.lock()
+	if active_id := manager.active_targets[target] {
+		if active_id == id {
+			manager.active_targets.delete(target)
+		}
+	}
+	manager.mutex.unlock()
+	manager.workers.done()
 }
 
 // cancel_all_and_wait prevents new runs, kills active children, and joins every worker.
@@ -437,8 +489,13 @@ fn (mut manager RunCommandManager) cancel_all_and_wait() {
 // run_managed_process runs a code-lens subprocess without the diagnostics timeout. The manager
 // owns cancellation instead, so a long-running program stays alive while VLS remains active and
 // is terminated when its client shuts down or disconnects.
-fn run_managed_process(mut manager RunCommandManager, id u64, executable string, args []string,
-	work_folder string) ManagedRunResult {
+fn run_managed_process(mut manager RunCommandManager, id u64, target string, executable string,
+	args []string, work_folder string) ManagedRunResult {
+	if manager.job_is_cancelled(id, target) {
+		return ManagedRunResult{
+			cancelled: true
+		}
+	}
 	if work_folder != '' && !os.is_dir(work_folder) {
 		return ManagedRunResult{
 			result: os.Result{
@@ -456,7 +513,7 @@ fn run_managed_process(mut manager RunCommandManager, id u64, executable string,
 	process.set_stdin_path(os.path_devnull)
 	process.set_redirect_stdio()
 	process.run()
-	registered := manager.register_process(id, process)
+	registered := manager.register_process(id, target, process)
 	if !registered && process.is_alive() {
 		process.signal_pgkill()
 	}
@@ -489,7 +546,7 @@ fn run_managed_process(mut manager RunCommandManager, id u64, executable string,
 			exit_code: exit_code
 			output:    output.str()
 		}
-		cancelled: !registered || manager.is_stopping()
+		cancelled: !registered || manager.job_is_cancelled(id, target)
 	}
 }
 
@@ -528,9 +585,10 @@ fn code_lens_display_args(job CodeLensRunJob) []string {
 	}
 }
 
-fn run_code_lens_job(mut manager RunCommandManager, id u64, job CodeLensRunJob) []string {
+fn run_code_lens_job(mut manager RunCommandManager, id u64, target string,
+	job CodeLensRunJob) []string {
 	defer {
-		manager.workers.done()
+		manager.finish_job(id, target)
 	}
 	temp_dir := os.join_path(os.temp_dir(), 'vls_run_${os.getpid()}_${id}_${time.now().unix_nano()}')
 	mut worker := App{
@@ -572,8 +630,8 @@ fn run_code_lens_job(mut manager RunCommandManager, id u64, job CodeLensRunJob) 
 	compile_args := code_lens_compile_args(job, target_path, executable_path)
 	display_args := code_lens_display_args(job)
 	worker.send_log_message('vls: ${job.title}: v ${display_args.join(' ')}', 3)
-	compile_result := run_managed_process(mut manager, id, resolve_v_compiler_exe(), compile_args,
-		compile_dir)
+	compile_result := run_managed_process(mut manager, id, target, resolve_v_compiler_exe(),
+		compile_args, compile_dir)
 	if compile_result.cancelled {
 		return worker.captured_output.clone()
 	}
@@ -584,7 +642,7 @@ fn run_code_lens_job(mut manager RunCommandManager, id u64, job CodeLensRunJob) 
 		return worker.captured_output.clone()
 	}
 
-	run_result := run_managed_process(mut manager, id, executable_path, [], source_work_dir)
+	run_result := run_managed_process(mut manager, id, target, executable_path, [], source_work_dir)
 	if run_result.cancelled {
 		return worker.captured_output.clone()
 	}


### PR DESCRIPTION
## Summary

- advertise code-lens and execute-command support
- show Run Main above main and Run File | Run Test above test functions
- invoke the V compiler with shell-free arguments and report command results through LSP
- ignore commented declarations and validate runnable local paths

## Testing

- v test handlers_test.v interop_test.v integration_test.v
- v -old-compiler .

Plain v . currently hits a V3 C-generator segfault that also reproduces from a clean archive of master.