### PR TITLE
fix: save dirty V buffers before tasks

### DIFF
--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## 0.0.4 — CodeLens buffer consistency (2026-09-10)
+
+- CodeLens and Command Palette task runs now save every dirty V buffer in the active workspace
+  before invoking the compiler, so multi-file modules and workspace imports run the code shown in
+  the editor.
+- Standalone files save dirty V buffers in the target module tree without touching unrelated files.
+
 ## 0.0.3 — Interim release (2026-09-10)
 
 V development commands are now first-class VS Code tasks:

--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -5,7 +5,8 @@
 - CodeLens and Command Palette task runs now save every dirty V buffer in the active workspace
   before invoking the compiler, so multi-file modules and workspace imports run the code shown in
   the editor.
-- Standalone files save dirty V buffers in the target module tree without touching unrelated files.
+- Standalone files use the nearest `v.mod` project root, falling back to the target module tree,
+  without touching unrelated files.
 
 ## 0.0.3 — Interim release (2026-09-10)
 

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vls",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vls",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "license": "GPL-2.0-only",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -3,7 +3,7 @@
   "publisher": "vlang",
   "displayName": "vls",
   "description": "V language support powered by VLS, with built-in build, run, and test tasks.",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "license": "GPL-2.0-only",
   "engines": {
     "vscode": "^1.95.0"

--- a/vscode-extension/src/taskSpec.ts
+++ b/vscode-extension/src/taskSpec.ts
@@ -1,9 +1,39 @@
+import * as path from 'path';
+
 export type VTaskAction = 'build' | 'run' | 'test';
 
 export interface VTaskSpec {
   action: VTaskAction;
   args: string[];
   name: string;
+}
+
+export interface TaskDocumentSpec {
+  filePath: string;
+  languageId: string;
+  isDirty: boolean;
+}
+
+export function shouldSaveTaskDocument(
+  targetFilePath: string,
+  workspaceFolderPath: string | undefined,
+  document: TaskDocumentSpec
+): boolean {
+  if (!document.isDirty) {
+    return false;
+  }
+  const extension = path.extname(document.filePath).toLowerCase();
+  if (document.languageId !== 'v' && extension !== '.v' && extension !== '.vsh') {
+    return false;
+  }
+  const scopeRoot = path.resolve(workspaceFolderPath || path.dirname(targetFilePath));
+  const relativePath = path.relative(scopeRoot, path.resolve(document.filePath));
+  return (
+    relativePath === '' ||
+    (relativePath !== '..' &&
+      !relativePath.startsWith(`..${path.sep}`) &&
+      !path.isAbsolute(relativePath))
+  );
 }
 
 export function taskActionTitle(action: VTaskAction): string {

--- a/vscode-extension/src/taskSpec.ts
+++ b/vscode-extension/src/taskSpec.ts
@@ -1,3 +1,4 @@
+import * as fs from 'fs';
 import * as path from 'path';
 
 export type VTaskAction = 'build' | 'run' | 'test';
@@ -12,6 +13,24 @@ export interface TaskDocumentSpec {
   filePath: string;
   languageId: string;
   isDirty: boolean;
+}
+
+export function standaloneTaskScope(
+  targetFilePath: string,
+  exists: (filePath: string) => boolean = fs.existsSync
+): string {
+  const targetDirectory = path.dirname(path.resolve(targetFilePath));
+  let directory = targetDirectory;
+  while (true) {
+    if (exists(path.join(directory, 'v.mod'))) {
+      return directory;
+    }
+    const parent = path.dirname(directory);
+    if (parent === directory) {
+      return targetDirectory;
+    }
+    directory = parent;
+  }
 }
 
 export function shouldSaveTaskDocument(

--- a/vscode-extension/src/test/extension.test.ts
+++ b/vscode-extension/src/test/extension.test.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import {
   codeLensTaskSpec,
   shouldSaveTaskDocument,
+  standaloneTaskScope,
   workspaceTaskSpec,
 } from '../taskSpec';
 
@@ -88,6 +89,25 @@ describe('VLS VS Code extension', () => {
     );
     assert.ok(
       !shouldSaveTaskDocument(target, undefined, dirtyVDocument('/project/other/dirty.v'))
+    );
+  });
+
+  it('uses the nearest V project root for standalone CodeLens saves', () => {
+    const target = '/project/cmd/app/main.v';
+    const projectRoot = standaloneTaskScope(target, (filePath) => {
+      return filePath === path.normalize('/project/v.mod');
+    });
+    const dirtyImport = {
+      filePath: '/project/lib/foo/foo.v',
+      languageId: 'v',
+      isDirty: true,
+    };
+
+    assert.strictEqual(projectRoot, path.normalize('/project'));
+    assert.ok(shouldSaveTaskDocument(target, projectRoot, dirtyImport));
+    assert.strictEqual(
+      standaloneTaskScope(target, () => false),
+      path.normalize('/project/cmd/app')
     );
   });
 });

--- a/vscode-extension/src/test/extension.test.ts
+++ b/vscode-extension/src/test/extension.test.ts
@@ -1,7 +1,11 @@
 import * as assert from 'assert';
 import * as fs from 'fs';
 import * as path from 'path';
-import { codeLensTaskSpec, workspaceTaskSpec } from '../taskSpec';
+import {
+  codeLensTaskSpec,
+  shouldSaveTaskDocument,
+  workspaceTaskSpec,
+} from '../taskSpec';
 
 describe('VLS VS Code extension', () => {
   it('contributes build, run, and test commands and tasks', () => {
@@ -52,5 +56,38 @@ describe('VLS VS Code extension', () => {
       args: ['-nocolor', 'test', '/tmp/main_test.v', '-run-only', 'test_one'],
       name: 'Run Test: test_one',
     });
+  });
+
+  it('saves dirty V buffers in the CodeLens workspace before running', () => {
+    const target = '/workspace/app/main.v';
+    const workspace = '/workspace';
+    const document = (filePath: string, languageId = 'v', isDirty = true) => ({
+      filePath,
+      languageId,
+      isDirty,
+    });
+
+    assert.ok(shouldSaveTaskDocument(target, workspace, document(target)));
+    assert.ok(shouldSaveTaskDocument(target, workspace, document('/workspace/app/sibling.v')));
+    assert.ok(shouldSaveTaskDocument(target, workspace, document('/workspace/lib/imported.v')));
+    assert.ok(shouldSaveTaskDocument(target, workspace, document('/workspace/tool.vsh', 'shellscript')));
+    assert.ok(!shouldSaveTaskDocument(target, workspace, document('/workspace/app/clean.v', 'v', false)));
+    assert.ok(!shouldSaveTaskDocument(target, workspace, document('/workspace/notes.txt', 'plaintext')));
+    assert.ok(!shouldSaveTaskDocument(target, workspace, document('/other/workspace/dirty.v')));
+  });
+
+  it('limits standalone CodeLens saves to the target module tree', () => {
+    const target = '/project/module/main.v';
+    const dirtyVDocument = (filePath: string) => ({ filePath, languageId: 'v', isDirty: true });
+
+    assert.ok(
+      shouldSaveTaskDocument(target, undefined, dirtyVDocument('/project/module/sibling.v'))
+    );
+    assert.ok(
+      shouldSaveTaskDocument(target, undefined, dirtyVDocument('/project/module/lib/imported.v'))
+    );
+    assert.ok(
+      !shouldSaveTaskDocument(target, undefined, dirtyVDocument('/project/other/dirty.v'))
+    );
   });
 });

--- a/vscode-extension/src/vTasks.ts
+++ b/vscode-extension/src/vTasks.ts
@@ -189,15 +189,16 @@ function activeWorkspaceTarget(): VTaskTarget | undefined {
   return folder ? folderTarget(folder) : undefined;
 }
 
-async function saveTaskDocuments(uri?: vscode.Uri): Promise<boolean> {
-  if (!uri) {
-    return true;
-  }
-  const folder = vscode.workspace.getWorkspaceFolder(uri);
+async function saveTaskDocuments(
+  target: VTaskTarget,
+  targetFilePath = target.cwd
+): Promise<boolean> {
+  const folder = workspaceFolderForScope(target.scope);
+  const scopeRoot = folder?.uri.fsPath || target.cwd;
   const documents = vscode.workspace.textDocuments.filter((document) => {
     return (
       document.uri.scheme === 'file' &&
-      shouldSaveTaskDocument(uri.fsPath, folder?.uri.fsPath, {
+      shouldSaveTaskDocument(targetFilePath, scopeRoot, {
         filePath: document.uri.fsPath,
         languageId: document.languageId,
         isDirty: document.isDirty,
@@ -240,7 +241,7 @@ async function runPaletteTask(action: VTaskAction): Promise<void> {
     return;
   }
   const uri = activeFileUri();
-  if (!(await saveTaskDocuments(uri))) {
+  if (!(await saveTaskDocuments(workspaceTarget, uri?.fsPath))) {
     vscode.window.showErrorMessage(
       `V: ${taskActionTitle(action)} was cancelled because one or more V files were not saved.`
     );
@@ -285,14 +286,14 @@ export async function runCodeLensCommand(command: string, args: unknown[]): Prom
     vscode.window.showErrorMessage('V: This command requires a local V source file.');
     return;
   }
-  if (!(await saveTaskDocuments(uri))) {
+  const target = targetForUri(uri);
+  if (!(await saveTaskDocuments(target, uri.fsPath))) {
     vscode.window.showErrorMessage(
       'V: The command was cancelled because one or more V files were not saved.'
     );
     return;
   }
 
-  const target = targetForUri(uri);
   const testName = typeof args[1] === 'string' ? args[1].trim() : '';
   const spec = codeLensTaskSpec(command, uri.fsPath, testName);
   const task = createVTask(spec.action, target, spec.args, spec.name);

--- a/vscode-extension/src/vTasks.ts
+++ b/vscode-extension/src/vTasks.ts
@@ -5,6 +5,7 @@ import * as path from 'path';
 import {
   codeLensTaskSpec,
   shouldSaveTaskDocument,
+  standaloneTaskScope,
   taskActionTitle,
   VTaskAction,
   workspaceTaskSpec,
@@ -194,7 +195,7 @@ async function saveTaskDocuments(
   targetFilePath = target.cwd
 ): Promise<boolean> {
   const folder = workspaceFolderForScope(target.scope);
-  const scopeRoot = folder?.uri.fsPath || target.cwd;
+  const scopeRoot = folder?.uri.fsPath || standaloneTaskScope(targetFilePath);
   const documents = vscode.workspace.textDocuments.filter((document) => {
     return (
       document.uri.scheme === 'file' &&

--- a/vscode-extension/src/vTasks.ts
+++ b/vscode-extension/src/vTasks.ts
@@ -4,6 +4,7 @@ import * as os from 'os';
 import * as path from 'path';
 import {
   codeLensTaskSpec,
+  shouldSaveTaskDocument,
   taskActionTitle,
   VTaskAction,
   workspaceTaskSpec,
@@ -188,17 +189,27 @@ function activeWorkspaceTarget(): VTaskTarget | undefined {
   return folder ? folderTarget(folder) : undefined;
 }
 
-async function saveDocument(uri?: vscode.Uri): Promise<boolean> {
+async function saveTaskDocuments(uri?: vscode.Uri): Promise<boolean> {
   if (!uri) {
     return true;
   }
-  const document = vscode.workspace.textDocuments.find((candidate) => {
-    return candidate.uri.toString() === uri.toString();
+  const folder = vscode.workspace.getWorkspaceFolder(uri);
+  const documents = vscode.workspace.textDocuments.filter((document) => {
+    return (
+      document.uri.scheme === 'file' &&
+      shouldSaveTaskDocument(uri.fsPath, folder?.uri.fsPath, {
+        filePath: document.uri.fsPath,
+        languageId: document.languageId,
+        isDirty: document.isDirty,
+      })
+    );
   });
-  if (!document || !document.isDirty) {
-    return true;
+  for (const document of documents) {
+    if (!(await document.save())) {
+      return false;
+    }
   }
-  return document.save();
+  return true;
 }
 
 async function executeVTask(
@@ -229,9 +240,9 @@ async function runPaletteTask(action: VTaskAction): Promise<void> {
     return;
   }
   const uri = activeFileUri();
-  if (!(await saveDocument(uri))) {
+  if (!(await saveTaskDocuments(uri))) {
     vscode.window.showErrorMessage(
-      `V: ${taskActionTitle(action)} was cancelled because the file was not saved.`
+      `V: ${taskActionTitle(action)} was cancelled because one or more V files were not saved.`
     );
     return;
   }
@@ -274,8 +285,10 @@ export async function runCodeLensCommand(command: string, args: unknown[]): Prom
     vscode.window.showErrorMessage('V: This command requires a local V source file.');
     return;
   }
-  if (!(await saveDocument(uri))) {
-    vscode.window.showErrorMessage('V: The command was cancelled because the file was not saved.');
+  if (!(await saveTaskDocuments(uri))) {
+    vscode.window.showErrorMessage(
+      'V: The command was cancelled because one or more V files were not saved.'
+    );
     return;
   }
 


### PR DESCRIPTION
## Summary

- Save dirty V documents in the active workspace before CodeLens and Command Palette task runs.
- Include sibling and imported V buffers while excluding clean, non-V, and unrelated workspace
  files.
- Scope standalone files to their module tree and cancel task launch when any save fails.
- Publish the review correction as VS Code extension 0.0.4.

Fixes the unresolved review feedback from #509:
https://github.com/vlang/vls/pull/509#discussion_r3973389196

## Verification

- `npm test` (5 passing)
- `npm audit --omit=dev` (0 vulnerabilities)
- `npm run build -- --out /tmp/vls-0.0.4.vsix`
- `unzip -t /tmp/vls-0.0.4.vsix`
