### PR TITLE
fix: address remaining VS Code task reviews

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1,12 +1,8 @@
 import * as vscode from 'vscode';
 import { LanguageClient, LanguageClientOptions, ServerOptions } from 'vscode-languageclient/node';
 import * as fs from 'fs';
-import {
-  findInPath,
-  registerVTasks,
-  runCodeLensCommand,
-  vCommandForServer,
-} from './vTasks';
+import { findInPath } from './vCommand';
+import { registerVTasks, runCodeLensCommand, vCommandForServer } from './vTasks';
 
 let client: LanguageClient | undefined;
 
@@ -24,7 +20,7 @@ function isExecutable(filePath: string): boolean {
 }
 
 export async function activate(context: vscode.ExtensionContext) {
-  registerVTasks(context);
+  const taskManager = registerVTasks(context);
 
   // Get the configuration for our server.
   const config = vscode.workspace.getConfiguration('vls');
@@ -58,7 +54,10 @@ export async function activate(context: vscode.ExtensionContext) {
   }
 
   const serverEnvironment = { ...process.env };
-  const vCommand = vCommandForServer();
+  const activeFolder = vscode.window.activeTextEditor
+    ? vscode.workspace.getWorkspaceFolder(vscode.window.activeTextEditor.document.uri)
+    : undefined;
+  const vCommand = vCommandForServer(activeFolder || vscode.workspace.workspaceFolders?.[0]);
   if (vCommand) {
     serverEnvironment.VLS_V_COMMAND = vCommand;
   }
@@ -82,7 +81,7 @@ export async function activate(context: vscode.ExtensionContext) {
       },
       executeCommand: async (command, args, next) => {
         if (command === 'vls.runFile' || command === 'vls.runTests') {
-          await runCodeLensCommand(command, args);
+          await runCodeLensCommand(command, args, taskManager);
           return;
         }
         return next(command, args);

--- a/vscode-extension/src/taskSpec.ts
+++ b/vscode-extension/src/taskSpec.ts
@@ -1,3 +1,5 @@
+import * as path from 'path';
+
 export type VTaskAction = 'build' | 'run' | 'test';
 
 export interface VTaskSpec {
@@ -24,15 +26,45 @@ export function workspaceTaskSpec(action: VTaskAction): VTaskSpec {
   return { action, args, name: taskActionTitle(action) };
 }
 
+export function taskWorkingDirectory(filePath: string, workspaceFolder?: string): string {
+  return workspaceFolder || path.dirname(filePath);
+}
+
+function taskPath(targetPath: string, workingDirectory: string): string {
+  const relativePath = path.relative(workingDirectory, targetPath);
+  if (relativePath === '') {
+    return '.';
+  }
+  if (
+    relativePath === '..' ||
+    relativePath.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relativePath)
+  ) {
+    return targetPath;
+  }
+  return relativePath;
+}
+
+export function activeRunTaskSpec(filePath: string, workingDirectory: string): VTaskSpec {
+  const isScript = filePath.endsWith('.vsh');
+  const targetPath = isScript ? filePath : path.dirname(filePath);
+  return {
+    action: 'run',
+    args: ['-nocolor', 'run', taskPath(targetPath, workingDirectory)],
+    name: isScript ? 'Run Active Script' : 'Run Active Module',
+  };
+}
+
 export function codeLensTaskSpec(
   command: string,
   filePath: string,
-  testName: string
+  testName: string,
+  workingDirectory = path.dirname(filePath)
 ): VTaskSpec {
   if (command === 'vls.runFile') {
     return {
       action: 'run',
-      args: ['-nocolor', 'run', '.'],
+      args: ['-nocolor', 'run', taskPath(path.dirname(filePath), workingDirectory)],
       name: 'Run Main',
     };
   }

--- a/vscode-extension/src/test/extension.test.ts
+++ b/vscode-extension/src/test/extension.test.ts
@@ -1,7 +1,13 @@
 import * as assert from 'assert';
 import * as fs from 'fs';
 import * as path from 'path';
-import { codeLensTaskSpec, workspaceTaskSpec } from '../taskSpec';
+import {
+  activeRunTaskSpec,
+  codeLensTaskSpec,
+  taskWorkingDirectory,
+  workspaceTaskSpec,
+} from '../taskSpec';
+import { serverCommand } from '../vCommand';
 
 describe('VLS VS Code extension', () => {
   it('contributes build, run, and test commands and tasks', () => {
@@ -52,5 +58,39 @@ describe('VLS VS Code extension', () => {
       args: ['-nocolor', 'test', '/tmp/main_test.v', '-run-only', 'test_one'],
       name: 'Run Test: test_one',
     });
+  });
+
+  it('runs active V scripts directly', () => {
+    assert.deepStrictEqual(activeRunTaskSpec('/workspace/tools/deploy.vsh', '/workspace'), {
+      action: 'run',
+      args: ['-nocolor', 'run', path.join('tools', 'deploy.vsh')],
+      name: 'Run Active Script',
+    });
+    assert.deepStrictEqual(activeRunTaskSpec('/workspace/app/main.v', '/workspace'), {
+      action: 'run',
+      args: ['-nocolor', 'run', 'app'],
+      name: 'Run Active Module',
+    });
+  });
+
+  it('runs nested modules from the problem matcher base', () => {
+    const filePath = path.join('/workspace', 'cmd', 'app', 'main.v');
+    const workingDirectory = taskWorkingDirectory(filePath, '/workspace');
+    assert.strictEqual(workingDirectory, '/workspace');
+    assert.deepStrictEqual(codeLensTaskSpec('vls.runFile', filePath, '', workingDirectory), {
+      action: 'run',
+      args: ['-nocolor', 'run', path.join('cmd', 'app')],
+      name: 'Run Main',
+    });
+  });
+
+  it('scopes and preserves the configured server compiler', () => {
+    const configured = path.join('${workspaceFolder}', 'bin', 'v');
+    assert.strictEqual(
+      serverCommand(configured, '/workspace'),
+      path.join('/workspace', 'bin', 'v')
+    );
+    const missing = path.join('/missing', 'custom-v');
+    assert.strictEqual(serverCommand(missing, '/workspace'), missing);
   });
 });

--- a/vscode-extension/src/vCommand.ts
+++ b/vscode-extension/src/vCommand.ts
@@ -1,0 +1,94 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+function isExecutable(filePath: string): boolean {
+  try {
+    if (!fs.statSync(filePath).isFile()) {
+      return false;
+    }
+    if (process.platform !== 'win32') {
+      fs.accessSync(filePath, fs.constants.X_OK);
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function executableNames(bin: string): string[] {
+  if (process.platform !== 'win32' || path.extname(bin) !== '') {
+    return [bin];
+  }
+  const extensions = (process.env.PATHEXT || '.EXE;.CMD;.BAT;.COM')
+    .split(';')
+    .filter(Boolean);
+  return [bin, ...extensions.map((extension) => `${bin}${extension.toLowerCase()}`)];
+}
+
+export function findInPath(bin: string): string | undefined {
+  const envPath = process.env.PATH || '';
+  for (const rawDirectory of envPath.split(path.delimiter)) {
+    const directory = rawDirectory.replace(/^"|"$/g, '');
+    if (!directory) {
+      continue;
+    }
+    for (const name of executableNames(bin)) {
+      const fullPath = path.join(directory, name);
+      if (isExecutable(fullPath)) {
+        return fullPath;
+      }
+    }
+  }
+  return undefined;
+}
+
+export function expandConfiguredPath(value: string, workspaceFolder?: string): string {
+  let expanded = value.replace(/^~(?=$|[\\/])/, os.homedir());
+  expanded = expanded.replace(/\$\{env:([^}]+)\}/g, (_match, name: string) => {
+    return process.env[name] || '';
+  });
+  if (workspaceFolder) {
+    expanded = expanded.replace(/\$\{workspaceFolder\}/g, workspaceFolder);
+  }
+  return expanded;
+}
+
+function pathCommand(command: string, workspaceFolder?: string): string | undefined {
+  const isPath = path.isAbsolute(command) || command.includes('/') || command.includes('\\');
+  if (!isPath) {
+    return undefined;
+  }
+  return path.isAbsolute(command)
+    ? command
+    : path.resolve(workspaceFolder || process.cwd(), command);
+}
+
+export function configuredCommand(configured: string, workspaceFolder?: string): string {
+  const value = configured.trim();
+  if (!value) {
+    return findInPath('v') || 'v';
+  }
+  return expandConfiguredPath(value, workspaceFolder);
+}
+
+export function resolvedCommand(
+  configured: string,
+  workspaceFolder?: string
+): string | undefined {
+  const command = configuredCommand(configured, workspaceFolder);
+  const fullPath = pathCommand(command, workspaceFolder);
+  if (fullPath) {
+    return isExecutable(fullPath) ? fullPath : undefined;
+  }
+  return findInPath(command);
+}
+
+export function serverCommand(configured: string, workspaceFolder?: string): string | undefined {
+  const value = configured.trim();
+  if (!value) {
+    return findInPath('v');
+  }
+  const command = expandConfiguredPath(value, workspaceFolder);
+  return pathCommand(command, workspaceFolder) || findInPath(command) || command;
+}

--- a/vscode-extension/src/vTasks.ts
+++ b/vscode-extension/src/vTasks.ts
@@ -1,13 +1,13 @@
 import * as vscode from 'vscode';
-import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
 import {
+  activeRunTaskSpec,
   codeLensTaskSpec,
+  taskWorkingDirectory,
   taskActionTitle,
   VTaskAction,
   workspaceTaskSpec,
 } from './taskSpec';
+import { configuredCommand, resolvedCommand, serverCommand } from './vCommand';
 
 interface VTaskDefinition extends vscode.TaskDefinition {
   type: 'v';
@@ -19,83 +19,22 @@ interface VTaskTarget {
   scope: vscode.WorkspaceFolder | vscode.TaskScope;
 }
 
-const activeExecutions = new Map<string, vscode.TaskExecution>();
-
-function isExecutable(filePath: string): boolean {
-  try {
-    if (!fs.statSync(filePath).isFile()) {
-      return false;
-    }
-    if (process.platform !== 'win32') {
-      fs.accessSync(filePath, fs.constants.X_OK);
-    }
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function executableNames(bin: string): string[] {
-  if (process.platform !== 'win32' || path.extname(bin) !== '') {
-    return [bin];
-  }
-  const extensions = (process.env.PATHEXT || '.EXE;.CMD;.BAT;.COM')
-    .split(';')
-    .filter(Boolean);
-  return [bin, ...extensions.map((extension) => `${bin}${extension.toLowerCase()}`)];
-}
-
-export function findInPath(bin: string): string | undefined {
-  const envPath = process.env.PATH || '';
-  for (const rawDirectory of envPath.split(path.delimiter)) {
-    const directory = rawDirectory.replace(/^"|"$/g, '');
-    if (!directory) {
-      continue;
-    }
-    for (const name of executableNames(bin)) {
-      const fullPath = path.join(directory, name);
-      if (isExecutable(fullPath)) {
-        return fullPath;
-      }
-    }
-  }
-  return undefined;
-}
-
-function expandConfiguredPath(value: string, folder?: vscode.WorkspaceFolder): string {
-  let expanded = value.replace(/^~(?=$|[\\/])/, os.homedir());
-  expanded = expanded.replace(/\$\{env:([^}]+)\}/g, (_match, name: string) => {
-    return process.env[name] || '';
-  });
-  if (folder) {
-    expanded = expanded.replace(/\$\{workspaceFolder\}/g, folder.uri.fsPath);
-  }
-  return expanded;
+function vCommandSetting(folder?: vscode.WorkspaceFolder): string {
+  return vscode.workspace
+    .getConfiguration('vls', folder?.uri)
+    .get<string>('vCommand', '');
 }
 
 function configuredVCommand(folder?: vscode.WorkspaceFolder): string {
-  const config = vscode.workspace.getConfiguration('vls', folder?.uri);
-  const configured = config.get<string>('vCommand', '').trim();
-  if (!configured) {
-    return findInPath('v') || 'v';
-  }
-  return expandConfiguredPath(configured, folder);
+  return configuredCommand(vCommandSetting(folder), folder?.uri.fsPath);
 }
 
 function resolvedVCommand(folder?: vscode.WorkspaceFolder): string | undefined {
-  const command = configuredVCommand(folder);
-  const isPath = path.isAbsolute(command) || command.includes('/') || command.includes('\\');
-  if (isPath) {
-    const fullPath = path.isAbsolute(command)
-      ? command
-      : path.resolve(folder?.uri.fsPath || process.cwd(), command);
-    return isExecutable(fullPath) ? fullPath : undefined;
-  }
-  return findInPath(command);
+  return resolvedCommand(vCommandSetting(folder), folder?.uri.fsPath);
 }
 
-export function vCommandForServer(): string | undefined {
-  return resolvedVCommand();
+export function vCommandForServer(folder?: vscode.WorkspaceFolder): string | undefined {
+  return serverCommand(vCommandSetting(folder), folder?.uri.fsPath);
 }
 
 async function showMissingVCompiler(folder?: vscode.WorkspaceFolder): Promise<void> {
@@ -170,7 +109,7 @@ function activeFileUri(): vscode.Uri | undefined {
 function targetForUri(uri: vscode.Uri): VTaskTarget {
   const folder = vscode.workspace.getWorkspaceFolder(uri);
   return {
-    cwd: path.dirname(uri.fsPath),
+    cwd: taskWorkingDirectory(uri.fsPath, folder?.uri.fsPath),
     scope: folder || vscode.TaskScope.Global,
   };
 }
@@ -201,26 +140,25 @@ async function saveDocument(uri?: vscode.Uri): Promise<boolean> {
   return document.save();
 }
 
-async function executeVTask(
-  task: vscode.Task,
-  folder: vscode.WorkspaceFolder | undefined,
-  executionKey: string
-): Promise<vscode.TaskExecution | undefined> {
-  if (!resolvedVCommand(folder)) {
-    await showMissingVCompiler(folder);
-    return undefined;
-  }
-  activeExecutions.get(executionKey)?.terminate();
-  const execution = await vscode.tasks.executeTask(task);
-  activeExecutions.set(executionKey, execution);
-  return execution;
-}
-
 function taskFolder(task: vscode.Task): vscode.WorkspaceFolder | undefined {
   return workspaceFolderForScope(task.scope);
 }
 
-async function runPaletteTask(action: VTaskAction): Promise<void> {
+function codeLensUri(argument: unknown): vscode.Uri | undefined {
+  if (typeof argument !== 'string' || argument.trim() === '') {
+    return undefined;
+  }
+  try {
+    const uri = argument.includes('://') || argument.startsWith('file:')
+      ? vscode.Uri.parse(argument, true)
+      : vscode.Uri.file(argument);
+    return uri.scheme === 'file' ? uri : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function runPaletteTask(action: VTaskAction, manager: VTaskManager): Promise<void> {
   const workspaceTarget = activeWorkspaceTarget();
   if (!workspaceTarget) {
     vscode.window.showErrorMessage(
@@ -242,7 +180,9 @@ async function runPaletteTask(action: VTaskAction): Promise<void> {
   let name = workspaceSpec.name;
   if (action === 'run' && uri) {
     target = targetForUri(uri);
-    name = 'Run Active Module';
+    const runSpec = activeRunTaskSpec(uri.fsPath, target.cwd);
+    args = runSpec.args;
+    name = runSpec.name;
   } else if (action === 'test' && uri?.fsPath.endsWith('_test.v')) {
     target = targetForUri(uri);
     args = ['-nocolor', 'test', uri.fsPath];
@@ -251,24 +191,14 @@ async function runPaletteTask(action: VTaskAction): Promise<void> {
 
   const task = createVTask(action, target, args, name);
   const key = `${action}:${target.cwd}:${args.join('\0')}`;
-  await executeVTask(task, taskFolder(task), key);
+  await manager.executeVTask(task, taskFolder(task), key);
 }
 
-function codeLensUri(argument: unknown): vscode.Uri | undefined {
-  if (typeof argument !== 'string' || argument.trim() === '') {
-    return undefined;
-  }
-  try {
-    const uri = argument.includes('://') || argument.startsWith('file:')
-      ? vscode.Uri.parse(argument, true)
-      : vscode.Uri.file(argument);
-    return uri.scheme === 'file' ? uri : undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-export async function runCodeLensCommand(command: string, args: unknown[]): Promise<void> {
+export async function runCodeLensCommand(
+  command: string,
+  args: unknown[],
+  manager: VTaskManager
+): Promise<void> {
   const uri = codeLensUri(args[0]);
   if (!uri) {
     vscode.window.showErrorMessage('V: This command requires a local V source file.');
@@ -281,10 +211,10 @@ export async function runCodeLensCommand(command: string, args: unknown[]): Prom
 
   const target = targetForUri(uri);
   const testName = typeof args[1] === 'string' ? args[1].trim() : '';
-  const spec = codeLensTaskSpec(command, uri.fsPath, testName);
+  const spec = codeLensTaskSpec(command, uri.fsPath, testName, target.cwd);
   const task = createVTask(spec.action, target, spec.args, spec.name);
   const key = `${command}:${uri.fsPath}:${args[1] || ''}`;
-  await executeVTask(task, taskFolder(task), key);
+  await manager.executeVTask(task, taskFolder(task), key);
 }
 
 class VTaskProvider implements vscode.TaskProvider {
@@ -311,24 +241,51 @@ class VTaskProvider implements vscode.TaskProvider {
   }
 }
 
-export function registerVTasks(context: vscode.ExtensionContext): void {
+export class VTaskManager implements vscode.Disposable {
+  private readonly activeExecutions = new Map<string, vscode.TaskExecution>();
+
+  async executeVTask(
+    task: vscode.Task,
+    folder: vscode.WorkspaceFolder | undefined,
+    executionKey: string
+  ): Promise<vscode.TaskExecution | undefined> {
+    if (!resolvedVCommand(folder)) {
+      await showMissingVCompiler(folder);
+      return undefined;
+    }
+    this.activeExecutions.get(executionKey)?.terminate();
+    const execution = await vscode.tasks.executeTask(task);
+    this.activeExecutions.set(executionKey, execution);
+    return execution;
+  }
+
+  endExecution(execution: vscode.TaskExecution): void {
+    for (const [key, activeExecution] of this.activeExecutions) {
+      if (activeExecution === execution) {
+        this.activeExecutions.delete(key);
+      }
+    }
+  }
+
+  dispose(): void {
+    for (const execution of this.activeExecutions.values()) {
+      execution.terminate();
+    }
+    this.activeExecutions.clear();
+  }
+}
+
+export function registerVTasks(context: vscode.ExtensionContext): VTaskManager {
+  const manager = new VTaskManager();
   context.subscriptions.push(vscode.tasks.registerTaskProvider('v', new VTaskProvider()));
   context.subscriptions.push(
-    vscode.commands.registerCommand('vls.build', () => runPaletteTask('build')),
-    vscode.commands.registerCommand('vls.run', () => runPaletteTask('run')),
-    vscode.commands.registerCommand('vls.test', () => runPaletteTask('test')),
+    vscode.commands.registerCommand('vls.build', () => runPaletteTask('build', manager)),
+    vscode.commands.registerCommand('vls.run', () => runPaletteTask('run', manager)),
+    vscode.commands.registerCommand('vls.test', () => runPaletteTask('test', manager)),
     vscode.tasks.onDidEndTask((event) => {
-      for (const [key, execution] of activeExecutions) {
-        if (execution === event.execution) {
-          activeExecutions.delete(key);
-        }
-      }
+      manager.endExecution(event.execution);
     }),
-    new vscode.Disposable(() => {
-      for (const execution of activeExecutions.values()) {
-        execution.terminate();
-      }
-      activeExecutions.clear();
-    })
+    manager
   );
+  return manager;
 }


### PR DESCRIPTION
## Summary

- Resolve the language-server compiler from the active workspace folder and preserve explicit invalid configurations so VLS reports them instead of falling back to another compiler.
- Own active task executions on a disposable task manager rather than in mutable module state.
- Run active `.vsh` files directly and launch nested modules from the workspace root so task diagnostics resolve against the problem matcher base.
- Add regression coverage for compiler selection, scripts, and nested module targets.

Addresses the remaining unresolved review feedback from #509:

- https://github.com/vlang/vls/pull/509#discussion_r3973351320
- https://github.com/vlang/vls/pull/509#discussion_r3973351326
- https://github.com/vlang/vls/pull/509#discussion_r3973468585
- https://github.com/vlang/vls/pull/509#discussion_r3973468595
- https://github.com/vlang/vls/pull/509#discussion_r3973616866

PR #510 separately addresses the resolved dirty-buffer review thread.

## Verification

- `npm test` (6 passing)
- `npm audit --omit=dev` (0 production vulnerabilities)
- `npm run build -- --out /tmp/vls-pr509-review-followups.vsix`
- `unzip -t /tmp/vls-pr509-review-followups.vsix`
