### PR TITLE
fix: restore CI on pinned V3 compiler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,24 +49,24 @@ jobs:
         env:
           VLS_VLANG_V_REPO: ${{ github.workspace }}
           V_MACOS_V3_NO_FALLBACK: "1"
-        run: v -no-memory-limit test vls/
+        run: v -no-memory-limit -nocache test vls/
 
       - name: Run tests with production optimizations
         if: runner.os == 'Linux'
         env:
           VLS_VLANG_V_REPO: ${{ github.workspace }}
           V_MACOS_V3_NO_FALLBACK: "1"
-        run: v -no-memory-limit -prod test vls/
+        run: v -no-memory-limit -nocache -prod test vls/
 
       - name: Compile project with V3
         if: runner.os != 'Windows'
         env:
           V_MACOS_V3_NO_FALLBACK: "1"
-        run: v -no-memory-limit -new-compiler vls/
+        run: v -no-memory-limit -nocache -new-compiler vls/
 
       - name: Compile project
         if: runner.os == 'Windows'
-        run: v vls/
+        run: v -nocache vls/
 
   vscode-extension:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Run all tests, including the vlang/v workspace tests
         env:
           VLS_VLANG_V_REPO: ${{ github.workspace }}
-          V_MACOS_V3_NO_FALLBACK: "1"
+          V_MACOS_V3_NO_FALLBACK: ${{ runner.os == 'Windows' && '0' || '1' }}
         run: v -no-memory-limit -nocache test vls/
 
       - name: Run tests with production optimizations

--- a/call_hierarchy.v
+++ b/call_hierarchy.v
@@ -10,9 +10,11 @@ import os
 // a CallHierarchyItem that can be used for subsequent incoming/outgoing queries.
 fn (mut app App) handle_prepare_call_hierarchy(request Request) Response {
 	params := json2.decode[PrepareCallHierarchyParams](request.params) or {
-		$if debug { log('Failed to decode PrepareCallHierarchyParams: ${err}') }
+		$if debug {
+			log('Failed to decode PrepareCallHierarchyParams: ${err}')
+		}
 		return Response{
-			id:     request.id
+			id: request.id
 			result: 'null'
 		}
 	}
@@ -21,7 +23,7 @@ fn (mut app App) handle_prepare_call_hierarchy(request Request) Response {
 	lines := content.split_into_lines()
 	if params.position.line < 0 || params.position.line >= lines.len {
 		return Response{
-			id:     request.id
+			id: request.id
 			result: 'null'
 		}
 	}
@@ -29,14 +31,14 @@ fn (mut app App) handle_prepare_call_hierarchy(request Request) Response {
 	start, end := find_word_bounds_at_col(line_text, params.position.char, app.position_encoding)
 	if start < 0 || end <= start {
 		return Response{
-			id:     request.id
+			id: request.id
 			result: 'null'
 		}
 	}
 	word := substr_by_char_bounds(line_text, start, end, app.position_encoding)
 	if word == '' {
 		return Response{
-			id:     request.id
+			id: request.id
 			result: 'null'
 		}
 	}
@@ -49,12 +51,12 @@ fn (mut app App) handle_prepare_call_hierarchy(request Request) Response {
 	}
 	if item.name == '' {
 		return Response{
-			id:     request.id
+			id: request.id
 			result: 'null'
 		}
 	}
 	return Response{
-		id:     request.id
+		id: request.id
 		result: [item]
 	}
 }
@@ -64,16 +66,18 @@ fn (mut app App) handle_prepare_call_hierarchy(request Request) Response {
 // calls to the queried function and groups them by the enclosing caller.
 fn (mut app App) handle_call_hierarchy_incoming(request Request) Response {
 	params := json2.decode[CallHierarchyIncomingCallsParams](request.params) or {
-		$if debug { log('Failed to decode CallHierarchyIncomingCallsParams: ${err}') }
+		$if debug {
+			log('Failed to decode CallHierarchyIncomingCallsParams: ${err}')
+		}
 		return Response{
-			id:     request.id
+			id: request.id
 			result: []CallHierarchyIncomingCall{}
 		}
 	}
 	fn_name := extract_simple_fn_name(params.item.name)
 	if fn_name == '' {
 		return Response{
-			id:     request.id
+			id: request.id
 			result: []CallHierarchyIncomingCall{}
 		}
 	}
@@ -86,7 +90,7 @@ fn (mut app App) handle_call_hierarchy_incoming(request Request) Response {
 	for uri, fc in app.open_files {
 		if request.id in app.cancelled_requests {
 			return Response{
-				id:     request.id
+				id: request.id
 				result: results
 			}
 		}
@@ -104,7 +108,7 @@ fn (mut app App) handle_call_hierarchy_incoming(request Request) Response {
 		for f in os.walk_ext(dir, '.v') {
 			if request.id in app.cancelled_requests {
 				return Response{
-					id:     request.id
+					id: request.id
 					result: results
 				}
 			}
@@ -121,7 +125,7 @@ fn (mut app App) handle_call_hierarchy_incoming(request Request) Response {
 		}
 	}
 	return Response{
-		id:     request.id
+		id: request.id
 		result: results
 	}
 }
@@ -130,9 +134,11 @@ fn (mut app App) handle_call_hierarchy_incoming(request Request) Response {
 // It identifies every function called within the body of the queried function.
 fn (mut app App) handle_call_hierarchy_outgoing(request Request) Response {
 	params := json2.decode[CallHierarchyOutgoingCallsParams](request.params) or {
-		$if debug { log('Failed to decode CallHierarchyOutgoingCallsParams: ${err}') }
+		$if debug {
+			log('Failed to decode CallHierarchyOutgoingCallsParams: ${err}')
+		}
 		return Response{
-			id:     request.id
+			id: request.id
 			result: []CallHierarchyOutgoingCall{}
 		}
 	}
@@ -168,12 +174,12 @@ fn (mut app App) handle_call_hierarchy_outgoing(request Request) Response {
 			continue
 		}
 		results << CallHierarchyOutgoingCall{
-			to:          callee
+			to: callee
 			from_ranges: call_ranges
 		}
 	}
 	return Response{
-		id:     request.id
+		id: request.id
 		result: results
 	}
 }
@@ -202,10 +208,10 @@ fn find_fn_in_content(fn_name string, content string, uri string, enc PositionEn
 		}
 		if extract_simple_fn_name(sym.name) == fn_name {
 			return CallHierarchyItem{
-				name:            sym.name
-				kind:            sym.kind
-				uri:             uri
-				range:           sym.range
+				name: sym.name
+				kind: sym.kind
+				uri: uri
+				range: sym.range
 				selection_range: sym.selection_range
 			}
 		}
@@ -229,10 +235,10 @@ fn (mut app App) find_fn_declaration(fn_name string, search_dirs []string, inclu
 	for dirs in dir_passes {
 		if uri, sym := app.find_indexed_fn(fn_name, include_tests, dirs) {
 			return CallHierarchyItem{
-				name:            sym.name
-				kind:            sym.kind
-				uri:             uri
-				range:           sym.range
+				name: sym.name
+				kind: sym.kind
+				uri: uri
+				range: sym.range
 				selection_range: sym.selection_range
 			}
 		}
@@ -299,7 +305,7 @@ fn scan_for_callers(fn_name string, file_uri string, file_content string, enc Po
 						line: li
 						char: start_char
 					}
-					end:   Position{
+					end: Position{
 						line: li
 						char: end_char
 					}
@@ -309,11 +315,11 @@ fn scan_for_callers(fn_name string, file_uri string, file_content string, enc Po
 		}
 		if call_ranges.len > 0 {
 			results << CallHierarchyIncomingCall{
-				from:        CallHierarchyItem{
-					name:            sym.name
-					kind:            sym.kind
-					uri:             file_uri
-					range:           sym.range
+				from: CallHierarchyItem{
+					name: sym.name
+					kind: sym.kind
+					uri: file_uri
+					range: sym.range
 					selection_range: sym.selection_range
 				}
 				from_ranges: call_ranges
@@ -374,7 +380,7 @@ fn find_fn_calls_in_line(line string, line_idx int, enc PositionEncoding, mut ca
 							line: line_idx
 							char: start_char
 						}
-						end:   Position{
+						end: Position{
 							line: line_idx
 							char: end_char
 						}

--- a/compilation_test.v
+++ b/compilation_test.v
@@ -16,7 +16,7 @@ fn test_smoke_incremental_edit_is_lossless() {
 			line: 0
 			char: 1
 		}
-		end:   Position{
+		end: Position{
 			line: 0
 			char: 1
 		}
@@ -35,7 +35,7 @@ fn test_smoke_raw_id_extraction() {
 
 fn test_smoke_argv_is_shell_free() {
 	// A malicious path stays a single literal argv element (no shell involved).
-	malicious := '/tmp/$(touch /tmp/pwned)/x.v'
+	malicious := '/tmp/\$(touch /tmp/pwned)/x.v'
 	args := build_v_check_args_single(malicious)
 	assert malicious in args
 }

--- a/document_highlight.v
+++ b/document_highlight.v
@@ -165,9 +165,9 @@ fn collect_document_highlight_candidates(content string, lines []string, symbol 
 		}
 		line := lines[position.line]
 		candidates << DocumentHighlightCandidate{
-			line_idx:   position.line
+			line_idx: position.line
 			start_byte: encoded_col_to_byte(line, position.start_char, enc)
-			end_byte:   encoded_col_to_byte(line, position.end_char, enc)
+			end_byte: encoded_col_to_byte(line, position.end_char, enc)
 		}
 	}
 	return candidates
@@ -178,9 +178,11 @@ fn collect_document_highlight_candidates(content string, lines []string, symbol 
 // document and returns them as a DocumentHighlight list.
 fn (mut app App) handle_document_highlight(request Request) Response {
 	params := json2.decode[DocumentHighlightParams](request.params) or {
-		$if debug { log('Failed to decode DocumentHighlightParams: ${err}') }
+		$if debug {
+			log('Failed to decode DocumentHighlightParams: ${err}')
+		}
 		return Response{
-			id:     request.id
+			id: request.id
 			result: []DocumentHighlight{}
 		}
 	}
@@ -188,14 +190,14 @@ fn (mut app App) handle_document_highlight(request Request) Response {
 	content := app.open_files[uri] or { os.read_file(uri_to_path(uri)) or { '' } }
 	if content == '' {
 		return Response{
-			id:     request.id
+			id: request.id
 			result: []DocumentHighlight{}
 		}
 	}
 	lines := content.split_into_lines()
 	if params.position.line < 0 || params.position.line >= lines.len {
 		return Response{
-			id:     request.id
+			id: request.id
 			result: []DocumentHighlight{}
 		}
 	}
@@ -203,22 +205,21 @@ fn (mut app App) handle_document_highlight(request Request) Response {
 	start, end := find_word_bounds_at_col(line_text, params.position.char, app.position_encoding)
 	if start < 0 || end <= start {
 		return Response{
-			id:     request.id
+			id: request.id
 			result: []DocumentHighlight{}
 		}
 	}
 	symbol := substr_by_char_bounds(line_text, start, end, app.position_encoding)
 	if symbol == '' {
 		return Response{
-			id:     request.id
+			id: request.id
 			result: []DocumentHighlight{}
 		}
 	}
-	candidates := collect_document_highlight_candidates(content, lines, symbol,
-		app.position_encoding)
+	candidates := collect_document_highlight_candidates(content, lines, symbol, app.position_encoding)
 	if candidates.len > document_highlight_semantic_max_candidates {
 		return Response{
-			id:     request.id
+			id: request.id
 			result: []DocumentHighlight{}
 		}
 	}
@@ -234,9 +235,7 @@ fn (mut app App) handle_document_highlight(request Request) Response {
 		start_char := byte_to_encoded_col(line, candidate.start_byte, app.position_encoding)
 		end_char := byte_to_encoded_col(line, candidate.end_byte, app.position_encoding)
 		if a := anchor {
-			if resolved := app.resolve_symbol_anchor_cached(uri, candidate.line_idx, start_char, mut
-				anchor_cache)
-			{
+			if resolved := app.resolve_symbol_anchor_cached(uri, candidate.line_idx, start_char, mut anchor_cache) {
 				if !same_anchor_location(resolved, a) {
 					continue
 				}
@@ -247,7 +246,7 @@ fn (mut app App) handle_document_highlight(request Request) Response {
 		mut kind := classify_highlight_kind(line, candidate.start_byte, candidate.end_byte)
 		if a := anchor {
 			occurrence := Location{
-				uri:   uri
+				uri: uri
 				range: LSPRange{
 					start: Position{
 						line: candidate.line_idx
@@ -265,16 +264,16 @@ fn (mut app App) handle_document_highlight(request Request) Response {
 					line: candidate.line_idx
 					char: start_char
 				}
-				end:   Position{
+				end: Position{
 					line: candidate.line_idx
 					char: end_char
 				}
 			}
-			kind:  kind // Read/Write (P2-03)
+			kind: kind // Read/Write (P2-03)
 		}
 	}
 	return Response{
-		id:     request.id
+		id: request.id
 		result: highlights
 	}
 }

--- a/folding_range.v
+++ b/folding_range.v
@@ -9,9 +9,11 @@ import os
 // returning all collapsible regions for the document.
 fn (mut app App) handle_folding_range(request Request) Response {
 	params := json2.decode[FoldingRangeParams](request.params) or {
-		$if debug { log('Failed to decode FoldingRangeParams: ${err}') }
+		$if debug {
+			log('Failed to decode FoldingRangeParams: ${err}')
+		}
 		return Response{
-			id:     request.id
+			id: request.id
 			result: []FoldingRange{}
 		}
 	}
@@ -19,12 +21,12 @@ fn (mut app App) handle_folding_range(request Request) Response {
 	content := app.open_files[uri] or { os.read_file(uri_to_path(uri)) or { '' } }
 	if content == '' {
 		return Response{
-			id:     request.id
+			id: request.id
 			result: []FoldingRange{}
 		}
 	}
 	return Response{
-		id:     request.id
+		id: request.id
 		result: compute_folding_ranges(content)
 	}
 }
@@ -55,8 +57,8 @@ fn compute_folding_ranges(content string) []FoldingRange {
 				if i > block_comment_start {
 					ranges << FoldingRange{
 						start_line: block_comment_start
-						end_line:   i
-						kind:       'comment'
+						end_line: i
+						kind: 'comment'
 					}
 				}
 				block_comment_start = -1
@@ -81,8 +83,8 @@ fn compute_folding_ranges(content string) []FoldingRange {
 			if import_start >= 0 && import_end > import_start {
 				ranges << FoldingRange{
 					start_line: import_start
-					end_line:   import_end
-					kind:       'imports'
+					end_line: import_end
+					kind: 'imports'
 				}
 			}
 			import_start = -1
@@ -99,8 +101,8 @@ fn compute_folding_ranges(content string) []FoldingRange {
 			if comment_start >= 0 && comment_end > comment_start {
 				ranges << FoldingRange{
 					start_line: comment_start
-					end_line:   comment_end
-					kind:       'comment'
+					end_line: comment_end
+					kind: 'comment'
 				}
 			}
 			comment_start = -1
@@ -120,8 +122,8 @@ fn compute_folding_ranges(content string) []FoldingRange {
 					if i > start {
 						ranges << FoldingRange{
 							start_line: start
-							end_line:   i
-							kind:       'region'
+							end_line: i
+							kind: 'region'
 						}
 					}
 				}
@@ -133,15 +135,15 @@ fn compute_folding_ranges(content string) []FoldingRange {
 	if import_start >= 0 && import_end > import_start {
 		ranges << FoldingRange{
 			start_line: import_start
-			end_line:   import_end
-			kind:       'imports'
+			end_line: import_end
+			kind: 'imports'
 		}
 	}
 	if comment_start >= 0 && comment_end > comment_start {
 		ranges << FoldingRange{
 			start_line: comment_start
-			end_line:   comment_end
-			kind:       'comment'
+			end_line: comment_end
+			kind: 'comment'
 		}
 	}
 

--- a/handlers.v
+++ b/handlers.v
@@ -21,19 +21,22 @@ struct SourceCallTarget {
 	active_parameter int
 }
 
-// source_call_target finds the function identifier for the call containing the
-// cursor. It is used only when the compiler's signature-help query has no
-// payload, so keep the scan bounded to the current source line.
-fn source_call_target(line string, cursor_col int, enc PositionEncoding) ?SourceCallTarget {
-	mut cursor_byte := encoded_col_to_byte(line, cursor_col, enc)
-	if cursor_byte > line.len {
-		cursor_byte = line.len
+// source_call_target finds the function identifier for the call containing the cursor.
+// It is used only when the compiler's signature-help query has no payload, so the
+// backward scan is bounded to the preceding 32 source lines.
+fn source_call_target(content string, cursor Position, enc PositionEncoding) ?SourceCallTarget {
+	starts := line_start_offsets(content)
+	if cursor.line < 0 || cursor.line >= starts.len || cursor.char < 0 {
+		return none
 	}
-	mask := v_source_code_mask(line)
+	cursor_byte := position_to_byte_offset(content, starts, cursor.line, cursor.char, enc)
+	mask := v_source_code_mask(content)
+	first_line := if cursor.line > 32 { cursor.line - 32 } else { 0 }
+	scan_start := starts[first_line]
 	mut depth := 0
 	mut open_paren := -1
 	mut i := cursor_byte - 1
-	for i >= 0 {
+	for i >= scan_start {
 		if mask[i] == `)` {
 			depth++
 		} else if mask[i] == `(` {
@@ -49,11 +52,35 @@ fn source_call_target(line string, cursor_col int, enc PositionEncoding) ?Source
 		return none
 	}
 	mut name_end := open_paren
-	for name_end > 0 && line[name_end - 1].is_space() {
+	for name_end > scan_start && content[name_end - 1].is_space() {
 		name_end--
 	}
+	if name_end > scan_start && mask[name_end - 1] == `]` {
+		mut generic_depth := 0
+		mut generic_start := -1
+		mut generic_pos := name_end - 1
+		for generic_pos >= scan_start {
+			if mask[generic_pos] == `]` {
+				generic_depth++
+			} else if mask[generic_pos] == `[` {
+				generic_depth--
+				if generic_depth == 0 {
+					generic_start = generic_pos
+					break
+				}
+			}
+			generic_pos--
+		}
+		if generic_start < 0 {
+			return none
+		}
+		name_end = generic_start
+		for name_end > scan_start && content[name_end - 1].is_space() {
+			name_end--
+		}
+	}
 	mut name_start := name_end
-	for name_start > 0 && is_ident_char(line[name_start - 1]) {
+	for name_start > scan_start && is_ident_char(content[name_start - 1]) {
 		name_start--
 	}
 	if name_start == name_end {
@@ -70,10 +97,21 @@ fn source_call_target(line string, cursor_col int, enc PositionEncoding) ?Source
 			active_parameter++
 		}
 	}
-	probe_byte := if name_end - name_start > 2 { name_start + 2 } else { name_start }
+	mut target_line := cursor.line
+	for target_line > first_line && starts[target_line] > name_start {
+		target_line--
+	}
+	target_line_text := line_text_without_terminator(content, starts, target_line)
+	name_start_in_line := name_start - starts[target_line]
+	probe_byte := if name_end - name_start > 2 {
+		name_start_in_line + 2
+	} else {
+		name_start_in_line
+	}
 	return SourceCallTarget{
 		position: Position{
-			char: byte_to_encoded_col(line, probe_byte, enc)
+			line: target_line
+			char: byte_to_encoded_col(target_line_text, probe_byte, enc)
 		}
 		active_parameter: active_parameter
 	}
@@ -89,6 +127,14 @@ fn (app &App) source_declaration_at(location Location) string {
 	if start_line < 0 || start_line >= lines.len {
 		return ''
 	}
+	first_part := lines[start_line].trim_space()
+	if first_part == '' {
+		return ''
+	}
+	first_mask := v_source_code_mask(first_part)
+	if !source_declaration_opens_body(first_mask) {
+		return first_part
+	}
 	mut parts := []string{}
 	end_line := if start_line + 16 < lines.len { start_line + 16 } else { lines.len }
 	for i in start_line .. end_line {
@@ -96,7 +142,8 @@ fn (app &App) source_declaration_at(location Location) string {
 		if part == '' {
 			continue
 		}
-		if brace := part.index('{') {
+		part_mask := v_source_code_mask(part).bytestr()
+		if brace := part_mask.index('{') {
 			part = part[..brace].trim_space()
 			if part != '' {
 				parts << part
@@ -108,32 +155,144 @@ fn (app &App) source_declaration_at(location Location) string {
 	return parts.join(' ').trim_space()
 }
 
+fn source_declaration_opens_body(mask []u8) bool {
+	mut pos := 0
+	for pos < mask.len {
+		for pos < mask.len && mask[pos].is_space() {
+			pos++
+		}
+		if pos + 1 < mask.len && mask[pos] == `@` && mask[pos + 1] == `[` {
+			mut depth := 1
+			pos += 2
+			for pos < mask.len && depth > 0 {
+				if mask[pos] == `[` {
+					depth++
+				} else if mask[pos] == `]` {
+					depth--
+				}
+				pos++
+			}
+			continue
+		}
+		if pos >= mask.len || !is_ident_start(mask[pos]) {
+			return false
+		}
+		start := pos
+		for pos < mask.len && is_ident_char(mask[pos]) {
+			pos++
+		}
+		keyword := mask[start..pos].bytestr()
+		if keyword in ['pub', 'unsafe'] {
+			continue
+		}
+		return keyword in ['fn', 'struct', 'enum', 'interface', 'union']
+	}
+	return false
+}
+
 fn declaration_signature_label(declaration string, name string) string {
-	start := declaration.index('${name}(') or { return '' }
-	mut depth := 0
-	for i in start + name.len .. declaration.len {
-		if declaration[i] == `(` {
-			depth++
-		} else if declaration[i] == `)` {
-			depth--
-			if depth == 0 {
-				return declaration[start..i + 1]
+	if name == '' {
+		return ''
+	}
+	mask := v_source_code_mask(declaration)
+	mut search_start := 0
+	for search_start + name.len <= declaration.len {
+		relative_start := declaration[search_start..].index(name) or { return '' }
+		start := search_start + relative_start
+		name_end := start + name.len
+		if (start == 0 || !is_ident_char(mask[start - 1]))
+			&& (name_end == declaration.len || !is_ident_char(mask[name_end])) {
+			mut open_paren := name_end
+			for open_paren < declaration.len && mask[open_paren].is_space() {
+				open_paren++
+			}
+			if open_paren < declaration.len && mask[open_paren] == `[` {
+				mut generic_depth := 0
+				for open_paren < declaration.len {
+					if mask[open_paren] == `[` {
+						generic_depth++
+					} else if mask[open_paren] == `]` {
+						generic_depth--
+						if generic_depth == 0 {
+							open_paren++
+							break
+						}
+					}
+					open_paren++
+				}
+				for open_paren < declaration.len && mask[open_paren].is_space() {
+					open_paren++
+				}
+			}
+			if open_paren < declaration.len && mask[open_paren] == `(` {
+				mut paren_depth := 0
+				mut close_paren := -1
+				for i in open_paren .. declaration.len {
+					if mask[i] == `(` {
+						paren_depth++
+					} else if mask[i] == `)` {
+						paren_depth--
+						if paren_depth == 0 {
+							close_paren = i
+							break
+						}
+					}
+				}
+				if close_paren < 0 {
+					return ''
+				}
+				mut end := declaration.len
+				for i in close_paren + 1 .. declaration.len {
+					if mask[i] == `{` {
+						end = i
+						break
+					}
+				}
+				return declaration[start..end].trim_space()
 			}
 		}
+		search_start = name_end
 	}
 	return ''
 }
 
 fn signature_parameters(label string) []ParameterInformation {
-	open_paren := label.index('(') or { return [] }
-	close_paren := label.last_index(')') or { return [] }
+	mask := v_source_code_mask(label)
+	open_paren := mask.bytestr().index('(') or { return [] }
+	mut close_paren := -1
+	mut paren_depth := 0
+	for i in open_paren .. label.len {
+		if mask[i] == `(` {
+			paren_depth++
+		} else if mask[i] == `)` {
+			paren_depth--
+			if paren_depth == 0 {
+				close_paren = i
+				break
+			}
+		}
+	}
 	if close_paren <= open_paren + 1 {
 		return []
 	}
 	mut parameters := []ParameterInformation{}
-	for parameter in label[open_paren + 1..close_paren].split(',') {
+	mut parameter_start := open_paren + 1
+	mut depth := 0
+	for i in open_paren + 1 .. close_paren {
+		if mask[i] in [`(`, `[`, `{`] {
+			depth++
+		} else if mask[i] in [`)`, `]`, `}`] && depth > 0 {
+			depth--
+		} else if mask[i] == `,` && depth == 0 {
+			parameters << ParameterInformation{
+				label: label[parameter_start..i].trim_space()
+			}
+			parameter_start = i + 1
+		}
+	}
+	if parameter_start < close_paren {
 		parameters << ParameterInformation{
-			label: parameter.trim_space()
+			label: label[parameter_start..close_paren].trim_space()
 		}
 	}
 	return parameters
@@ -157,17 +316,10 @@ fn (mut app App) source_hover_fallback(uri string, position Position) ?Hover {
 
 fn (mut app App) source_signature_fallback(uri string, position Position) ?SignatureHelp {
 	content := app.index_source_for(uri) or { return none }
-	lines := content.split_into_lines()
-	if position.line < 0 || position.line >= lines.len {
+	target := source_call_target(content, position, app.position_encoding) or {
 		return none
 	}
-	target := source_call_target(lines[position.line], position.char, app.position_encoding) or {
-		return none
-	}
-	target_position := Position{
-		line: position.line
-		char: target.position.char
-	}
+	target_position := target.position
 	name := app.get_word_at_position(uri, target_position.line, target_position.char)
 	if name == '' {
 		return none

--- a/handlers.v
+++ b/handlers.v
@@ -29,13 +29,14 @@ fn source_call_target(line string, cursor_col int, enc PositionEncoding) ?Source
 	if cursor_byte > line.len {
 		cursor_byte = line.len
 	}
+	mask := v_source_code_mask(line)
 	mut depth := 0
 	mut open_paren := -1
 	mut i := cursor_byte - 1
 	for i >= 0 {
-		if line[i] == `)` {
+		if mask[i] == `)` {
 			depth++
-		} else if line[i] == `(` {
+		} else if mask[i] == `(` {
 			if depth == 0 {
 				open_paren = i
 				break
@@ -61,11 +62,11 @@ fn source_call_target(line string, cursor_col int, enc PositionEncoding) ?Source
 	mut active_parameter := 0
 	depth = 0
 	for j in open_paren + 1 .. cursor_byte {
-		if line[j] in [`(`, `[`, `{`] {
+		if mask[j] in [`(`, `[`, `{`] {
 			depth++
-		} else if line[j] in [`)`, `]`, `}`] && depth > 0 {
+		} else if mask[j] in [`)`, `]`, `}`] && depth > 0 {
 			depth--
-		} else if line[j] == `,` && depth == 0 {
+		} else if mask[j] == `,` && depth == 0 {
 			active_parameter++
 		}
 	}

--- a/handlers.v
+++ b/handlers.v
@@ -306,6 +306,17 @@ fn signature_parameters(label string) []ParameterInformation {
 	return parameters
 }
 
+fn signature_active_parameter(parameters []ParameterInformation, requested int) int {
+	if parameters.len > 0 && requested >= parameters.len {
+		last_parameter := parameters[parameters.len - 1]
+		last_mask := v_source_code_mask(last_parameter.label).bytestr()
+		if last_mask.contains('...') {
+			return parameters.len - 1
+		}
+	}
+	return requested
+}
+
 fn (mut app App) source_hover_fallback(uri string, position Position) ?Hover {
 	location := app.resolve_indexed_definition(uri, position) or {
 		app.resolve_symbol_anchor(uri, position.line, position.char) or { return none }
@@ -340,14 +351,15 @@ fn (mut app App) source_signature_fallback(uri string, position Position) ?Signa
 	if label == '' {
 		return none
 	}
+	parameters := signature_parameters(label)
 	return SignatureHelp{
 		signatures: [
 			SignatureInformation{
 				label: label
-				parameters: signature_parameters(label)
+				parameters: parameters
 			},
 		]
-		active_parameter: target.active_parameter
+		active_parameter: signature_active_parameter(parameters, target.active_parameter)
 	}
 }
 

--- a/handlers.v
+++ b/handlers.v
@@ -8,27 +8,205 @@ import time
 import v.pref
 
 const v_keywords = ['asm', 'as', 'assert', 'atomic', 'break', 'const', 'continue', 'defer', 'dump',
-	'else', 'enum', 'false', 'fn', 'for', 'go', 'goto', 'if', 'ilike', 'implements', 'import',
-	'in', 'interface', 'is', 'isreftype', 'like', 'lock', 'match', 'module', 'mut', 'nil', 'none',
-	'or', 'pub', 'return', 'rlock', 'select', 'shared', 'sizeof', 'spawn', 'static', 'struct',
-	'true', 'type', 'typeof', 'union', 'unsafe', 'volatile']!
+	'else', 'enum', 'false', 'fn', 'for', 'go', 'goto', 'if', 'ilike', 'implements', 'import', 'in',
+	'interface', 'is', 'isreftype', 'like', 'lock', 'match', 'module', 'mut', 'nil', 'none', 'or',
+	'pub', 'return', 'rlock', 'select', 'shared', 'sizeof', 'spawn', 'static', 'struct', 'true',
+	'type', 'typeof', 'union', 'unsafe', 'volatile']!
 
 const v_builtins = ['close', 'copy', 'eprintln', 'eprint', 'error', 'error_with_code', 'exit',
 	'flush_stderr', 'flush_stdout', 'free', 'isnil', 'panic', 'print', 'println']!
 
+struct SourceCallTarget {
+	position         Position
+	active_parameter int
+}
+
+// source_call_target finds the function identifier for the call containing the
+// cursor. It is used only when the compiler's signature-help query has no
+// payload, so keep the scan bounded to the current source line.
+fn source_call_target(line string, cursor_col int, enc PositionEncoding) ?SourceCallTarget {
+	mut cursor_byte := encoded_col_to_byte(line, cursor_col, enc)
+	if cursor_byte > line.len {
+		cursor_byte = line.len
+	}
+	mut depth := 0
+	mut open_paren := -1
+	mut i := cursor_byte - 1
+	for i >= 0 {
+		if line[i] == `)` {
+			depth++
+		} else if line[i] == `(` {
+			if depth == 0 {
+				open_paren = i
+				break
+			}
+			depth--
+		}
+		i--
+	}
+	if open_paren < 0 {
+		return none
+	}
+	mut name_end := open_paren
+	for name_end > 0 && line[name_end - 1].is_space() {
+		name_end--
+	}
+	mut name_start := name_end
+	for name_start > 0 && is_ident_char(line[name_start - 1]) {
+		name_start--
+	}
+	if name_start == name_end {
+		return none
+	}
+	mut active_parameter := 0
+	depth = 0
+	for j in open_paren + 1 .. cursor_byte {
+		if line[j] in [`(`, `[`, `{`] {
+			depth++
+		} else if line[j] in [`)`, `]`, `}`] && depth > 0 {
+			depth--
+		} else if line[j] == `,` && depth == 0 {
+			active_parameter++
+		}
+	}
+	probe_byte := if name_end - name_start > 2 { name_start + 2 } else { name_start }
+	return SourceCallTarget{
+		position: Position{
+			char: byte_to_encoded_col(line, probe_byte, enc)
+		}
+		active_parameter: active_parameter
+	}
+}
+
+// source_declaration_at returns a compact declaration header for a compiler
+// definition location. A small line cap prevents malformed source from causing
+// an unbounded scan.
+fn (app &App) source_declaration_at(location Location) string {
+	content := app.index_source_for(location.uri) or { return '' }
+	lines := content.split_into_lines()
+	start_line := location.range.start.line
+	if start_line < 0 || start_line >= lines.len {
+		return ''
+	}
+	mut parts := []string{}
+	end_line := if start_line + 16 < lines.len { start_line + 16 } else { lines.len }
+	for i in start_line .. end_line {
+		mut part := lines[i].trim_space()
+		if part == '' {
+			continue
+		}
+		if brace := part.index('{') {
+			part = part[..brace].trim_space()
+			if part != '' {
+				parts << part
+			}
+			break
+		}
+		parts << part
+	}
+	return parts.join(' ').trim_space()
+}
+
+fn declaration_signature_label(declaration string, name string) string {
+	start := declaration.index('${name}(') or { return '' }
+	mut depth := 0
+	for i in start + name.len .. declaration.len {
+		if declaration[i] == `(` {
+			depth++
+		} else if declaration[i] == `)` {
+			depth--
+			if depth == 0 {
+				return declaration[start..i + 1]
+			}
+		}
+	}
+	return ''
+}
+
+fn signature_parameters(label string) []ParameterInformation {
+	open_paren := label.index('(') or { return [] }
+	close_paren := label.last_index(')') or { return [] }
+	if close_paren <= open_paren + 1 {
+		return []
+	}
+	mut parameters := []ParameterInformation{}
+	for parameter in label[open_paren + 1..close_paren].split(',') {
+		parameters << ParameterInformation{
+			label: parameter.trim_space()
+		}
+	}
+	return parameters
+}
+
+fn (mut app App) source_hover_fallback(uri string, position Position) ?Hover {
+	location := app.resolve_indexed_definition(uri, position) or {
+		app.resolve_symbol_anchor(uri, position.line, position.char) or { return none }
+	}
+	declaration := app.source_declaration_at(location)
+	if declaration == '' {
+		return none
+	}
+	return Hover{
+		contents: MarkupContent{
+			kind: 'markdown'
+			value: '```v\n${declaration}\n```'
+		}
+	}
+}
+
+fn (mut app App) source_signature_fallback(uri string, position Position) ?SignatureHelp {
+	content := app.index_source_for(uri) or { return none }
+	lines := content.split_into_lines()
+	if position.line < 0 || position.line >= lines.len {
+		return none
+	}
+	target := source_call_target(lines[position.line], position.char, app.position_encoding) or {
+		return none
+	}
+	target_position := Position{
+		line: position.line
+		char: target.position.char
+	}
+	name := app.get_word_at_position(uri, target_position.line, target_position.char)
+	if name == '' {
+		return none
+	}
+	location := app.resolve_indexed_definition(uri, target_position) or {
+		app.resolve_symbol_anchor(uri, target_position.line, target_position.char) or { return none }
+	}
+	declaration := app.source_declaration_at(location)
+	label := declaration_signature_label(declaration, name)
+	if label == '' {
+		return none
+	}
+	return SignatureHelp{
+		signatures: [
+			SignatureInformation{
+				label: label
+				parameters: signature_parameters(label)
+			},
+		]
+		active_parameter: target.active_parameter
+	}
+}
+
 // operation_at_pos handles LSP requests at a given position (completion, hover, signature, definition).
 fn (mut app App) operation_at_pos(method Method, request Request) Response {
 	params := json2.decode[TextDocumentPositionParams](request.params) or {
-		$if debug { log('Failed to decode TextDocumentPositionParams: ${err}') }
+		$if debug {
+			log('Failed to decode TextDocumentPositionParams: ${err}')
+		}
 		return Response{
-			id:     request.id
+			id: request.id
 			result: 'null'
 		}
 	}
 	if params.text_document.uri == '' {
-		$if debug { log('operation_at_pos: missing textDocument.uri') }
+		$if debug {
+			log('operation_at_pos: missing textDocument.uri')
+		}
 		return Response{
-			id:     request.id
+			id: request.id
 			result: 'null'
 		}
 	}
@@ -36,7 +214,7 @@ fn (mut app App) operation_at_pos(method Method, request Request) Response {
 	// than indexing arrays with negative values (P1-09).
 	if params.position.line < 0 || params.position.char < 0 {
 		return Response{
-			id:     request.id
+			id: request.id
 			result: 'null'
 		}
 	}
@@ -59,10 +237,10 @@ fn (mut app App) operation_at_pos(method Method, request Request) Response {
 					completions := get_import_completions(current_line, work_dir)
 					if completions.len > 0 {
 						return Response{
-							id:     request.id
+							id: request.id
 							result: CompletionList{
 								is_incomplete: false
-								items:         completions
+								items: completions
 							}
 						}
 					}
@@ -78,7 +256,7 @@ fn (mut app App) operation_at_pos(method Method, request Request) Response {
 	if method in [.definition, .declaration, .type_definition, .implementation] {
 		if location := app.resolve_indexed_definition(path, params.position) {
 			return Response{
-				id:     request.id
+				id: request.id
 				result: location
 			}
 		}
@@ -103,6 +281,17 @@ fn (mut app App) operation_at_pos(method Method, request Request) Response {
 	}
 
 	mut result := app.run_v_line_info(method, path, line_info)
+	if result is string && result == 'null' {
+		if method == .hover {
+			if fallback := app.source_hover_fallback(path, params.position) {
+				result = fallback
+			}
+		} else if method == .signature_help {
+			if fallback := app.source_signature_fallback(path, params.position) {
+				result = fallback
+			}
+		}
+	}
 	if method == .completion {
 		// Check the character immediately before the cursor.
 		// If it is not '.', the user is not doing member access, so augment
@@ -154,10 +343,10 @@ fn (mut app App) operation_at_pos(method Method, request Request) Response {
 				}
 			}
 			return Response{
-				id:     request.id
+				id: request.id
 				result: CompletionList{
 					is_incomplete: false
-					items:         details
+					items: details
 				}
 			}
 		}
@@ -188,10 +377,10 @@ fn (mut app App) operation_at_pos(method Method, request Request) Response {
 			}
 		}
 		return Response{
-			id:     request.id
+			id: request.id
 			result: CompletionList{
 				is_incomplete: false
-				items:         dot_items
+				items: dot_items
 			}
 		}
 	}
@@ -199,7 +388,7 @@ fn (mut app App) operation_at_pos(method Method, request Request) Response {
 		log(result.str())
 	}
 	return Response{
-		id:     request.id
+		id: request.id
 		result: result
 	}
 }
@@ -371,7 +560,7 @@ fn parse_import_binding(text string) ?ImportedModuleBinding {
 		return none
 	}
 	return ImportedModuleBinding{
-		alias:       alias
+		alias: alias
 		module_path: module_path
 	}
 }
@@ -506,8 +695,8 @@ fn parse_public_module_member_completions(content string) []Detail {
 			name := extract_const_name(trimmed)
 			if name != '' {
 				items << Detail{
-					kind:   21 // CompletionItemKind.Constant
-					label:  name
+					kind: 21 // CompletionItemKind.Constant
+					label: name
 					detail: 'pub const'
 				}
 			}
@@ -526,11 +715,11 @@ fn parse_public_module_member_completions(content string) []Detail {
 			detail_str := trimmed.all_before('{').trim_space()
 			insert := build_fn_snippet(fn_name, after_fn[paren_idx..])
 			items << Detail{
-				kind:               3 // CompletionItemKind.Function
-				label:              fn_name
-				detail:             detail_str
-				insert_text:        insert
-				insert_text_format: if insert.contains('$') { 2 } else { 1 }
+				kind: 3 // CompletionItemKind.Function
+				label: fn_name
+				detail: detail_str
+				insert_text: insert
+				insert_text_format: if insert.contains('\$') { 2 } else { 1 }
 			}
 			continue
 		}
@@ -538,8 +727,8 @@ fn parse_public_module_member_completions(content string) []Detail {
 			name := extract_const_name(trimmed[10..])
 			if name != '' {
 				items << Detail{
-					kind:   21
-					label:  name
+					kind: 21
+					label: name
 					detail: 'pub const'
 				}
 			}
@@ -552,7 +741,9 @@ fn parse_public_module_member_completions(content string) []Detail {
 // the server state. It returns true when diagnostics were scheduled.
 fn (mut app App) on_did_open(request Request) bool {
 	params := json2.decode[DidOpenTextDocumentParams](request.params) or {
-		$if debug { log('Failed to decode DidOpenTextDocumentParams: ${err}') }
+		$if debug {
+			log('Failed to decode DidOpenTextDocumentParams: ${err}')
+		}
 		return false
 	}
 	uri := params.text_document.uri
@@ -564,7 +755,9 @@ fn (mut app App) on_did_open(request Request) bool {
 	} else {
 		real_path := uri_to_path(uri)
 		content = os.read_file(real_path) or {
-			$if debug { log('Failed to read file ${real_path}: ${err}') }
+			$if debug {
+				log('Failed to read file ${real_path}: ${err}')
+			}
 			return false
 		}
 	}
@@ -576,7 +769,9 @@ fn (mut app App) on_did_open(request Request) bool {
 	app.bump_generation(uri)
 	app.invalidate_index_uri(uri) // re-parse from the buffer on next query
 	app.text = content
-	$if debug { log('STORED CONTENT for uri=${uri}, FILE COUNT: ${app.open_files.len}') }
+	$if debug {
+		log('STORED CONTENT for uri=${uri}, FILE COUNT: ${app.open_files.len}')
+	}
 	return app.finish_diagnostics_project_schedule(diagnostics_mutation, uri, content)
 }
 
@@ -586,7 +781,9 @@ fn (mut app App) on_did_open(request Request) bool {
 // diagnostic set to clear editor markers.
 fn (mut app App) on_did_close(request Request) {
 	params := json2.decode[DidCloseTextDocumentParams](request.params) or {
-		$if debug { log('Failed to decode DidCloseTextDocumentParams: ${err}') }
+		$if debug {
+			log('Failed to decode DidCloseTextDocumentParams: ${err}')
+		}
 		return
 	}
 	uri := params.text_document.uri
@@ -625,8 +822,8 @@ fn (mut app App) build_diagnostics_notification(uri string, content string) Noti
 		return Notification{
 			method: 'textDocument/publishDiagnostics'
 			params: PublishDiagnosticsParams{
-				uri:         uri
-				version:     if uri in app.open_files_versions {
+				uri: uri
+				version: if uri in app.open_files_versions {
 					?i64(app.open_files_versions[uri])
 				} else {
 					none
@@ -654,8 +851,8 @@ fn (mut app App) build_diagnostics_notification(uri string, content string) Noti
 		diagnostics << app.encode_diagnostic_range(v_error_to_lsp_diagnostic(v_err), lines)
 	}
 	pd_params := PublishDiagnosticsParams{
-		uri:         uri
-		version:     if uri in app.open_files_versions {
+		uri: uri
+		version: if uri in app.open_files_versions {
 			?i64(app.open_files_versions[uri])
 		} else {
 			none
@@ -671,7 +868,9 @@ fn (mut app App) build_diagnostics_notification(uri string, content string) Noti
 // Returns instant red wavy errors
 fn (mut app App) on_did_change(request Request) ?Notification {
 	params := json2.decode[DidChangeTextDocumentParams](request.params) or {
-		$if debug { log('Failed to decode DidChangeTextDocumentParams: ${err}') }
+		$if debug {
+			log('Failed to decode DidChangeTextDocumentParams: ${err}')
+		}
 		return none
 	}
 	log('on did change(len=${params.content_changes.len})')
@@ -702,7 +901,9 @@ fn (mut app App) on_did_change(request Request) ?Notification {
 				return none
 			}
 			rng := change.range or {
-				$if debug { log('Skipping malformed incremental change with missing range') }
+				$if debug {
+					log('Skipping malformed incremental change with missing range')
+				}
 				continue
 			}
 
@@ -733,7 +934,9 @@ fn (mut app App) on_did_change(request Request) ?Notification {
 		return none
 	}
 	notification := app.build_diagnostics_notification(uri, content)
-	$if debug { log('returning notification: ${notification}') }
+	$if debug {
+		log('returning notification: ${notification}')
+	}
 	return notification
 }
 
@@ -760,7 +963,7 @@ fn (app &App) encode_diagnostic_range(diag LSPDiagnostic, lines []string) LSPDia
 				line: start_line
 				char: start_char
 			}
-			end:   Position{
+			end: Position{
 				line: end_line
 				char: end_char
 			}
@@ -771,7 +974,9 @@ fn (app &App) encode_diagnostic_range(diag LSPDiagnostic, lines []string) LSPDia
 // on_did_save handles didSave by re-running diagnostics for the saved document.
 fn (mut app App) on_did_save(request Request) ?Notification {
 	params := json2.decode[DidSaveTextDocumentParams](request.params) or {
-		$if debug { log('Failed to decode DidSaveTextDocumentParams: ${err}') }
+		$if debug {
+			log('Failed to decode DidSaveTextDocumentParams: ${err}')
+		}
 		return none
 	}
 	uri := params.text_document.uri
@@ -801,7 +1006,9 @@ fn (mut app App) on_did_save(request Request) ?Notification {
 		} else {
 			real_path := uri_to_path(uri)
 			content = os.read_file(real_path) or {
-				$if debug { log('on_did_save: failed to read file ${real_path}: ${err}') }
+				$if debug {
+					log('on_did_save: failed to read file ${real_path}: ${err}')
+				}
 				return none
 			}
 		}
@@ -821,16 +1028,18 @@ fn (mut app App) on_did_save(request Request) ?Notification {
 // before it is saved, returning the edits to apply atomically with the save.
 fn (mut app App) on_will_save_wait_until(request Request) Response {
 	params := json2.decode[WillSaveTextDocumentParams](request.params) or {
-		$if debug { log('Failed to decode WillSaveTextDocumentParams: ${err}') }
+		$if debug {
+			log('Failed to decode WillSaveTextDocumentParams: ${err}')
+		}
 		return Response{
-			id:     request.id
+			id: request.id
 			result: []TextEdit{}
 		}
 	}
 	uri := params.text_document.uri
 	content := app.open_files[uri] or {
 		return Response{
-			id:     request.id
+			id: request.id
 			result: []TextEdit{}
 		}
 	}
@@ -840,7 +1049,7 @@ fn (mut app App) on_will_save_wait_until(request Request) Response {
 	// would desynchronize the server from the editor (P0-07 item 7).
 	edits, _ := app.format_content(uri, content)
 	return Response{
-		id:     request.id
+		id: request.id
 		result: edits
 	}
 }
@@ -850,9 +1059,11 @@ fn (mut app App) on_will_save_wait_until(request Request) Response {
 // when the cursor is not on a renameable symbol.
 fn (mut app App) handle_prepare_rename(request Request) Response {
 	params := json2.decode[TextDocumentPositionParams](request.params) or {
-		$if debug { log('Failed to decode TextDocumentPositionParams for prepareRename: ${err}') }
+		$if debug {
+			log('Failed to decode TextDocumentPositionParams for prepareRename: ${err}')
+		}
 		return Response{
-			id:     request.id
+			id: request.id
 			result: 'null'
 		}
 	}
@@ -861,7 +1072,7 @@ fn (mut app App) handle_prepare_rename(request Request) Response {
 	lines := content.split_into_lines()
 	if params.position.line < 0 || params.position.line >= lines.len {
 		return Response{
-			id:     request.id
+			id: request.id
 			result: 'null'
 		}
 	}
@@ -869,14 +1080,14 @@ fn (mut app App) handle_prepare_rename(request Request) Response {
 	start, end := find_word_bounds_at_col(line_text, params.position.char, app.position_encoding)
 	if start < 0 || end <= start {
 		return Response{
-			id:     request.id
+			id: request.id
 			result: 'null'
 		}
 	}
 	symbol := substr_by_char_bounds(line_text, start, end, app.position_encoding)
 	if symbol == '' {
 		return Response{
-			id:     request.id
+			id: request.id
 			result: 'null'
 		}
 	}
@@ -884,26 +1095,26 @@ fn (mut app App) handle_prepare_rename(request Request) Response {
 	first := symbol[0]
 	if !is_ident_start(first) {
 		return Response{
-			id:     request.id
+			id: request.id
 			result: 'null'
 		}
 	}
 	// Reject V keywords and built-in function names — they cannot be renamed.
 	if symbol in v_keywords || symbol in v_builtins {
 		return Response{
-			id:     request.id
+			id: request.id
 			result: 'null'
 		}
 	}
 	return Response{
-		id:     request.id
+		id: request.id
 		result: PrepareRenameResult{
-			range:       LSPRange{
+			range: LSPRange{
 				start: Position{
 					line: params.position.line
 					char: start
 				}
-				end:   Position{
+				end: Position{
 					line: params.position.line
 					char: end
 				}
@@ -921,10 +1132,10 @@ fn add_workspace_symbol(mut results []WorkspaceSymbol, mut seen_symbols map[stri
 	}
 	seen_symbols[key] = true
 	results << WorkspaceSymbol{
-		name:     name
-		kind:     kind
+		name: name
+		kind: kind
 		location: Location{
-			uri:   uri
+			uri: uri
 			range: rng
 		}
 	}
@@ -982,9 +1193,11 @@ fn find_word_bounds_at_col(line string, col int, enc PositionEncoding) (int, int
 // and returns them as WorkspaceSymbol items.
 fn (mut app App) handle_workspace_symbol(request Request) Response {
 	params := json2.decode[WorkspaceSymbolParams](request.params) or {
-		$if debug { log('Failed to decode WorkspaceSymbolParams: ${err}') }
+		$if debug {
+			log('Failed to decode WorkspaceSymbolParams: ${err}')
+		}
 		return Response{
-			id:     request.id
+			id: request.id
 			result: []WorkspaceSymbol{}
 		}
 	}
@@ -998,7 +1211,7 @@ fn (mut app App) handle_workspace_symbol(request Request) Response {
 	results := app.query_workspace_symbols(query)
 	app.end_progress(token, '')
 	return Response{
-		id:     request.id
+		id: request.id
 		result: results
 	}
 }
@@ -1126,9 +1339,11 @@ fn incremental_change_is_valid(content string, range LSPRange, enc PositionEncod
 // find_references handles the LSP references request, returning all locations of a symbol.
 fn (mut app App) find_references(request Request) Response {
 	params := json2.decode[ReferenceParams](request.params) or {
-		$if debug { log('Failed to decode ReferenceParams: ${err}') }
+		$if debug {
+			log('Failed to decode ReferenceParams: ${err}')
+		}
 		return Response{
-			id:     request.id
+			id: request.id
 			result: 'null'
 		}
 	}
@@ -1140,7 +1355,7 @@ fn (mut app App) find_references(request Request) Response {
 	symbol := app.get_word_at_position(path, line, col)
 	if symbol == '' {
 		return Response{
-			id:     request.id
+			id: request.id
 			result: 'null'
 		}
 	}
@@ -1170,13 +1385,13 @@ fn (mut app App) find_references(request Request) Response {
 	}
 	if locations.len == 0 {
 		return Response{
-			id:     request.id
+			id: request.id
 			result: 'null'
 		}
 	}
 
 	return Response{
-		id:     request.id
+		id: request.id
 		result: locations
 	}
 }
@@ -1184,9 +1399,11 @@ fn (mut app App) find_references(request Request) Response {
 // handle_rename handles the LSP rename request, returning edits to rename a symbol.
 fn (mut app App) handle_rename(request Request) Response {
 	params := json2.decode[RenameParams](request.params) or {
-		$if debug { log('Failed to decode RenameParams: ${err}') }
+		$if debug {
+			log('Failed to decode RenameParams: ${err}')
+		}
 		return Response{
-			id:     request.id
+			id: request.id
 			result: 'null'
 		}
 	}
@@ -1199,7 +1416,7 @@ fn (mut app App) handle_rename(request Request) Response {
 	symbol := app.get_word_at_position(path, line, col)
 	if symbol == '' {
 		return Response{
-			id:     request.id
+			id: request.id
 			result: 'null'
 		}
 	}
@@ -1212,7 +1429,7 @@ fn (mut app App) handle_rename(request Request) Response {
 	if !app.index_is_complete_for_scope(scope) {
 		log('rename: source index is incomplete; refusing a partial workspace edit')
 		return Response{
-			id:     request.id
+			id: request.id
 			result: 'null'
 		}
 	}
@@ -1225,7 +1442,7 @@ fn (mut app App) handle_rename(request Request) Response {
 	anchor := app.resolve_symbol_anchor(path, line, col) or {
 		log('rename: could not resolve a semantic anchor for "${symbol}"; refusing lexical rename (P1-04)')
 		return Response{
-			id:     request.id
+			id: request.id
 			result: 'null'
 		}
 	}
@@ -1236,7 +1453,7 @@ fn (mut app App) handle_rename(request Request) Response {
 	if locations.len == 0 {
 		log('rename: no scope-safe occurrences for "${symbol}" (unresolved or above candidate cap); refusing')
 		return Response{
-			id:     request.id
+			id: request.id
 			result: 'null'
 		}
 	}
@@ -1251,9 +1468,9 @@ fn (mut app App) handle_rename(request Request) Response {
 			loc.range.start.char + byte_to_encoded_col(symbol, symbol.len, app.position_encoding)
 		}
 		edit := TextEdit{
-			range:    LSPRange{
+			range: LSPRange{
 				start: loc.range.start
-				end:   Position{
+				end: Position{
 					line: loc.range.start.line
 					char: end_char
 				}
@@ -1274,17 +1491,17 @@ fn (mut app App) handle_rename(request Request) Response {
 		}
 		doc_changes << TextDocumentEdit{
 			text_document: VersionedTextDocumentIdentifier{
-				uri:     uri
+				uri: uri
 				version: version
 			}
-			edits:         edits
+			edits: edits
 		}
 	}
 
 	return Response{
-		id:     request.id
+		id: request.id
 		result: WorkspaceEdit{
-			changes:          changes
+			changes: changes
 			document_changes: doc_changes
 		}
 	}
@@ -1633,9 +1850,9 @@ fn source_declaration_is_compile_time_conditional(content string, declaration_li
 		mut col := 0
 		for col < line.len {
 			if line[col] == `$` {
-				directive_len := if line[col..].starts_with('$if') {
+				directive_len := if line[col..].starts_with('\$if') {
 					3
-				} else if line[col..].starts_with('$else') {
+				} else if line[col..].starts_with('\$else') {
 					5
 				} else {
 					0
@@ -2092,8 +2309,7 @@ fn source_occurrence_is_enum_member_declaration(content string, symbol string, t
 			continue
 		}
 		if declaration.children.any(it.kind == sym_kind_enum_member && it.name == symbol
-			&& it.selection_range.start.line == target_line)
-		{
+			&& it.selection_range.start.line == target_line) {
 			return true
 		}
 	}
@@ -2341,9 +2557,9 @@ fn (app &App) active_indexed_source_file_names(dir string, active_test_file_name
 		}
 	}
 	build_prefs := pref.Preferences{
-		os:      pref.get_host_os()
+		os: pref.get_host_os()
 		backend: .c
-		arch:    pref.get_host_arch()
+		arch: pref.get_host_arch()
 	}
 	mut active := map[string]bool{}
 	for path in build_prefs.should_compile_filtered_files(dir, source_names) {
@@ -2407,7 +2623,7 @@ fn (mut app App) find_indexed_source_definition(dir string, symbol string, activ
 				continue
 			}
 			matches << Location{
-				uri:   uri
+				uri: uri
 				range: sym.selection_range
 			}
 		}
@@ -2489,15 +2705,12 @@ fn (mut app App) resolve_indexed_definition(uri string, position Position) ?Loca
 		dot_col := byte_to_encoded_col(line, start_byte - 1, app.position_encoding)
 		alias := get_word_before_dot(line, dot_col, app.position_encoding)
 		alias_occurrences := file_occurrences[alias] or { return none }
-		if source_occurrences_have_potential_local_binding(lines, alias_occurrences,
-			app.position_encoding)
-		{
+		if source_occurrences_have_potential_local_binding(lines, alias_occurrences, app.position_encoding) {
 			return none
 		}
 		module_path := parse_import_aliases(content)[alias] or { return none }
 		module_dir := app.resolve_indexed_import_module_dir(module_path, os.dir(uri_to_path(uri)))
-		return app.find_indexed_source_definition(module_dir, symbol, '', true,
-			module_path.all_after_last('.'))
+		return app.find_indexed_source_definition(module_dir, symbol, '', true, module_path.all_after_last('.'))
 	}
 	if source_occurrences_have_potential_local_binding(lines, occurrences, app.position_encoding) {
 		return none
@@ -2508,8 +2721,7 @@ fn (mut app App) resolve_indexed_definition(uri string, position Position) ?Loca
 	} else {
 		''
 	}
-	return app.find_indexed_source_definition(os.dir(requesting_path), symbol,
-		active_test_file_name, false, get_module_name(content))
+	return app.find_indexed_source_definition(os.dir(requesting_path), symbol, active_test_file_name, false, get_module_name(content))
 }
 
 // find_declaration_line searches `lines` for a top-level declaration whose name
@@ -2662,9 +2874,9 @@ fn get_import_completions(line string, work_dir string) []Detail {
 				continue
 			}
 			results << Detail{
-				kind:        9 // CompletionItemKind.Module
-				label:       entry
-				detail:      'V stdlib module'
+				kind: 9 // CompletionItemKind.Module
+				label: entry
+				detail: 'V stdlib module'
 				insert_text: entry
 			}
 		}
@@ -2687,9 +2899,9 @@ fn get_import_completions(line string, work_dir string) []Detail {
 				continue
 			}
 			results << Detail{
-				kind:        9
-				label:       entry
-				detail:      'Local module'
+				kind: 9
+				label: entry
+				detail: 'Local module'
 				insert_text: entry
 			}
 		}
@@ -2831,11 +3043,15 @@ fn (mut app App) format_content(uri string, content string) ([]TextEdit, string)
 	mut formatted := os.read_file(temp_file) or { result.output }
 
 	os.rm(temp_file) or {
-		$if debug { log('Failed to remove temp file: ${err}') }
+		$if debug {
+			log('Failed to remove temp file: ${err}')
+		}
 	}
 
 	if result.exit_code != 0 {
-		$if debug { log('v fmt failed with code ${result.exit_code}: ${result.output}') }
+		$if debug {
+			log('v fmt failed with code ${result.exit_code}: ${result.output}')
+		}
 		return []TextEdit{}, ''
 	}
 
@@ -2855,12 +3071,12 @@ fn (mut app App) format_content(uri string, content string) ([]TextEdit, string)
 	end_char := byte_to_encoded_col(final_segment, final_segment.len, app.position_encoding)
 
 	edit := TextEdit{
-		range:    LSPRange{
+		range: LSPRange{
 			start: Position{
 				line: 0
 				char: 0
 			}
-			end:   Position{
+			end: Position{
 				line: end_line
 				char: end_char
 			}
@@ -2875,7 +3091,7 @@ fn (mut app App) handle_formatting(request Request) Response {
 	params := json2.decode[DocumentFormattingParams](request.params) or {
 		log('Failed to decode DocumentFormattingParams: ${err}')
 		return Response{
-			id:     request.id
+			id: request.id
 			result: []TextEdit{}
 		}
 	}
@@ -2886,7 +3102,7 @@ fn (mut app App) handle_formatting(request Request) Response {
 		os.read_file(real_path) or {
 			log('Failed to read file for formatting: ${err}')
 			return Response{
-				id:     request.id
+				id: request.id
 				result: []TextEdit{}
 			}
 		}
@@ -2894,7 +3110,7 @@ fn (mut app App) handle_formatting(request Request) Response {
 
 	edits, _ := app.format_content(path, content)
 	return Response{
-		id:     request.id
+		id: request.id
 		result: edits
 	}
 }
@@ -2904,7 +3120,7 @@ fn (mut app App) handle_document_symbols(request Request) Response {
 	params := json2.decode[DocumentSymbolParams](request.params) or {
 		log('Failed to decode DocumentSymbolParams: ${err}')
 		return Response{
-			id:     request.id
+			id: request.id
 			result: []DocumentSymbol{}
 		}
 	}
@@ -2914,15 +3130,14 @@ fn (mut app App) handle_document_symbols(request Request) Response {
 	app.reindex_uri(uri)
 	if entry := app.symbol_index[uri] {
 		return Response{
-			id:     request.id
+			id: request.id
 			result: entry.doc_symbols
 		}
 	}
 	content := app.open_files[uri] or { '' }
 	return Response{
-		id:     request.id
-		result: encode_document_symbols(parse_document_symbols(content),
-			content.split_into_lines(), app.position_encoding)
+		id: request.id
+		result: encode_document_symbols(parse_document_symbols(content), content.split_into_lines(), app.position_encoding)
 	}
 }
 
@@ -2930,14 +3145,14 @@ fn (mut app App) handle_document_symbols(request Request) Response {
 fn (mut app App) handle_inlay_hints(request Request) Response {
 	if !app.inlay_hints_enabled {
 		return Response{
-			id:     request.id
+			id: request.id
 			result: []InlayHint{}
 		}
 	}
 	params := json2.decode[InlayHintParams](request.params) or {
 		log('Failed to decode InlayHintParams: ${err}')
 		return Response{
-			id:     request.id
+			id: request.id
 			result: []InlayHint{}
 		}
 	}
@@ -3064,18 +3279,18 @@ fn (mut app App) handle_inlay_hints(request Request) Response {
 		// byte offset is re-encoded into the client's encoding (P0-01/P2-07).
 		name_col := raw.index(var_name) or { continue }
 		hints << InlayHint{
-			position:     Position{
+			position: Position{
 				line: line_idx
 				char: byte_to_encoded_col(raw, name_col + var_name.len, app.position_encoding)
 			}
-			label:        ': ${inferred}'
-			kind:         inlay_hint_kind_type
+			label: ': ${inferred}'
+			kind: inlay_hint_kind_type
 			padding_left: false
 		}
 	}
 
 	return Response{
-		id:     request.id
+		id: request.id
 		result: hints
 	}
 }
@@ -3391,7 +3606,7 @@ fn make_symbol(name string, kind int, line_idx int, raw_line string) DocumentSym
 			line: line_idx
 			char: 0
 		}
-		end:   Position{
+		end: Position{
 			line: line_idx
 			char: raw_line.len
 		}
@@ -3401,17 +3616,17 @@ fn make_symbol(name string, kind int, line_idx int, raw_line string) DocumentSym
 			line: line_idx
 			char: col_start
 		}
-		end:   Position{
+		end: Position{
 			line: line_idx
 			char: col_end
 		}
 	}
 	return DocumentSymbol{
-		name:            name
-		kind:            kind
-		range:           line_range
+		name: name
+		kind: kind
+		range: line_range
 		selection_range: sel_range
-		children:        []DocumentSymbol{}
+		children: []DocumentSymbol{}
 	}
 }
 
@@ -3499,13 +3714,13 @@ fn (mut app App) search_symbol_in_dirs(symbol string, request_id int) []Location
 		positions := occ[symbol] or { continue }
 		for p in positions {
 			locations << Location{
-				uri:   uri
+				uri: uri
 				range: LSPRange{
 					start: Position{
 						line: p.line
 						char: p.start_char
 					}
-					end:   Position{
+					end: Position{
 						line: p.line
 						char: p.end_char
 					}
@@ -3608,13 +3823,13 @@ fn (mut app App) collect_semantic_candidates(symbol string, scope IndexScope) []
 		positions := occ[symbol] or { continue }
 		for p in positions {
 			candidates << Location{
-				uri:   uri
+				uri: uri
 				range: LSPRange{
 					start: Position{
 						line: p.line
 						char: p.start_char
 					}
-					end:   Position{
+					end: Position{
 						line: p.line
 						char: p.end_char
 					}
@@ -3644,12 +3859,10 @@ fn (mut app App) search_symbol_in_dirs_semantic(symbol string, anchor Location, 
 	// unrelated same-named symbols in other scopes.
 	if candidates.len > reference_semantic_max_candidates {
 		if !allow_lexical_fallback {
-			app.send_log_message('semantic-scan symbol=${symbol} candidates=${candidates.len} exceeds cap ${reference_semantic_max_candidates}; refusing scope-unsafe resolution',
-				2)
+			app.send_log_message('semantic-scan symbol=${symbol} candidates=${candidates.len} exceeds cap ${reference_semantic_max_candidates}; refusing scope-unsafe resolution', 2)
 			return []Location{}
 		}
-		app.send_log_message('semantic-scan symbol=${symbol} candidates=${candidates.len} exceeds cap ${reference_semantic_max_candidates}; returning lexical occurrences',
-			3)
+		app.send_log_message('semantic-scan symbol=${symbol} candidates=${candidates.len} exceeds cap ${reference_semantic_max_candidates}; returning lexical occurrences', 3)
 		return candidates
 	}
 
@@ -3666,24 +3879,24 @@ fn (mut app App) search_symbol_in_dirs_semantic(symbol string, anchor Location, 
 			locations << cand
 			continue
 		}
-		resolved := app.resolve_symbol_anchor_cached(cand.uri, cand.range.start.line,
-			cand.range.start.char, mut anchor_cache) or { continue }
+		resolved := app.resolve_symbol_anchor_cached(cand.uri, cand.range.start.line, cand.range.start.char, mut anchor_cache) or { continue }
 		if same_anchor_location(resolved, anchor) {
 			locations << cand
 		}
 	}
 	elapsed_ms := time.now().unix_milli() - started_ms
-	app.send_log_message('semantic-scan symbol=${symbol} candidates=${candidates.len} matches=${locations.len} elapsed_ms=${elapsed_ms}',
-		4)
+	app.send_log_message('semantic-scan symbol=${symbol} candidates=${candidates.len} matches=${locations.len} elapsed_ms=${elapsed_ms}', 4)
 	return locations
 }
 
 // handle_code_action handles the LSP codeAction request, returning quick fixes and organize imports.
 fn (mut app App) handle_code_action(request Request) Response {
 	params := json2.decode[CodeActionParams](request.params) or {
-		$if debug { log('Failed to decode CodeActionParams: ${err}') }
+		$if debug {
+			log('Failed to decode CodeActionParams: ${err}')
+		}
 		return Response{
-			id:     request.id
+			id: request.id
 			result: []CodeAction{}
 		}
 	}
@@ -3718,20 +3931,19 @@ fn (mut app App) handle_code_action(request Request) Response {
 					} else {
 						Position{
 							line: line_nr
-							char: byte_to_encoded_col(lines[line_nr], lines[line_nr].len,
-								app.position_encoding)
+							char: byte_to_encoded_col(lines[line_nr], lines[line_nr].len, app.position_encoding)
 						}
 					}
 					edit := WorkspaceEdit{
 						changes: {
 							uri: [
 								TextEdit{
-									range:    LSPRange{
+									range: LSPRange{
 										start: Position{
 											line: line_nr
 											char: 0
 										}
-										end:   end_pos
+										end: end_pos
 									}
 									new_text: ''
 								},
@@ -3739,11 +3951,11 @@ fn (mut app App) handle_code_action(request Request) Response {
 						}
 					}
 					actions << CodeAction{
-						title:        'Remove unknown import'
-						kind:         code_action_kind_quickfix
+						title: 'Remove unknown import'
+						kind: code_action_kind_quickfix
 						is_preferred: true
-						edit:         edit
-						diagnostics:  [diag]
+						edit: edit
+						diagnostics: [diag]
 					}
 				}
 			}
@@ -3760,7 +3972,7 @@ fn (mut app App) handle_code_action(request Request) Response {
 	}
 
 	return Response{
-		id:     request.id
+		id: request.id
 		result: actions
 	}
 }
@@ -3831,12 +4043,12 @@ fn build_safe_organize_imports_action(uri string, content string, lines []string
 		changes: {
 			uri: [
 				TextEdit{
-					range:    LSPRange{
+					range: LSPRange{
 						start: Position{
 							line: first
 							char: 0
 						}
-						end:   Position{
+						end: Position{
 							line: last
 							char: byte_to_encoded_col(lines[last], lines[last].len, enc)
 						}
@@ -3848,8 +4060,8 @@ fn build_safe_organize_imports_action(uri string, content string, lines []string
 	}
 	return CodeAction{
 		title: 'Organize Imports'
-		kind:  code_action_kind_source_organize_imports
-		edit:  edit
+		kind: code_action_kind_source_organize_imports
+		edit: edit
 	}
 }
 
@@ -3919,11 +4131,11 @@ fn parse_module_fn_completions(content string) []Detail {
 		// Build snippet insertText: fn_name($1, $2, ...) or fn_name($1)$0
 		insert := build_fn_snippet(fn_name, after_fn[paren_idx..])
 		items << Detail{
-			kind:               3 // CompletionItemKind.Function
-			label:              fn_name
-			detail:             detail_str
-			insert_text:        insert
-			insert_text_format: if insert.contains('$') { 2 } else { 1 }
+			kind: 3 // CompletionItemKind.Function
+			label: fn_name
+			detail: detail_str
+			insert_text: insert
+			insert_text_format: if insert.contains('\$') { 2 } else { 1 }
 		}
 	}
 	return items
@@ -3966,22 +4178,22 @@ fn build_fn_snippet(fn_name string, params_str string) string {
 		}
 		placeholders << '\${${idx + 1}:${param_name}}'
 	}
-	return '${fn_name}(${placeholders.join(', ')})$0'
+	return '${fn_name}(${placeholders.join(', ')})\$0'
 }
 
 fn make_keyword_completions() []Detail {
 	mut items := []Detail{}
 	for kw in v_keywords {
 		items << Detail{
-			kind:   14 // Keyword
-			label:  kw
+			kind: 14 // Keyword
+			label: kw
 			detail: kw
 		}
 	}
 	for b in v_builtins {
 		items << Detail{
-			kind:   3 // Function
-			label:  b
+			kind: 3 // Function
+			label: b
 			detail: b
 		}
 	}
@@ -3994,7 +4206,7 @@ fn (mut app App) handle_range_formatting(request Request) Response {
 	params := json2.decode[DocumentRangeFormattingParams](request.params) or {
 		log('Failed to decode DocumentRangeFormattingParams: ${err}')
 		return Response{
-			id:     request.id
+			id: request.id
 			result: []TextEdit{}
 		}
 	}
@@ -4004,7 +4216,7 @@ fn (mut app App) handle_range_formatting(request Request) Response {
 		os.read_file(real_path) or {
 			log('Failed to read file for range formatting: ${err}')
 			return Response{
-				id:     request.id
+				id: request.id
 				result: []TextEdit{}
 			}
 		}
@@ -4017,7 +4229,7 @@ fn (mut app App) handle_range_formatting(request Request) Response {
 	os.write_file(temp_file, content) or {
 		log('Failed to write temp file for range formatting: ${err}')
 		return Response{
-			id:     request.id
+			id: request.id
 			result: []TextEdit{}
 		}
 	}
@@ -4026,16 +4238,18 @@ fn (mut app App) handle_range_formatting(request Request) Response {
 	formatted := os.read_file(temp_file) or {
 		os.rm(temp_file) or {}
 		return Response{
-			id:     request.id
+			id: request.id
 			result: []TextEdit{}
 		}
 	}
 	os.rm(temp_file) or {
-		$if debug { log('Failed to remove temp file for range formatting: ${err}') }
+		$if debug {
+			log('Failed to remove temp file for range formatting: ${err}')
+		}
 	}
 	if result.exit_code != 0 || formatted == '' || formatted == content {
 		return Response{
-			id:     request.id
+			id: request.id
 			result: []TextEdit{}
 		}
 	}
@@ -4048,7 +4262,7 @@ fn (mut app App) handle_range_formatting(request Request) Response {
 	}
 	if req_start >= original_lines.len || req_start > req_end {
 		return Response{
-			id:     request.id
+			id: request.id
 			result: []TextEdit{}
 		}
 	}
@@ -4070,19 +4284,19 @@ fn (mut app App) handle_range_formatting(request Request) Response {
 	if orig_hunk_start < req_start || orig_hunk_end - 1 > req_end {
 		log('range formatting: changed hunk [${orig_hunk_start}..${orig_hunk_end}) outside requested range [${req_start}..${req_end}]; returning no edits')
 		return Response{
-			id:     request.id
+			id: request.id
 			result: []TextEdit{}
 		}
 	}
 	fmt_hunk_end := formatted_lines.len - suf // exclusive
 	new_text := formatted_lines[orig_hunk_start..fmt_hunk_end].join('\n') + '\n'
 	edit := TextEdit{
-		range:    LSPRange{
+		range: LSPRange{
 			start: Position{
 				line: orig_hunk_start
 				char: 0
 			}
-			end:   Position{
+			end: Position{
 				line: orig_hunk_end
 				char: 0
 			}
@@ -4090,7 +4304,7 @@ fn (mut app App) handle_range_formatting(request Request) Response {
 		new_text: new_text
 	}
 	return Response{
-		id:     request.id
+		id: request.id
 		result: [edit]
 	}
 }
@@ -4101,9 +4315,11 @@ fn (mut app App) handle_range_formatting(request Request) Response {
 // as the outer (parent) range.  Clients expand the selection incrementally.
 fn (mut app App) handle_selection_range(request Request) Response {
 	params := json2.decode[SelectionRangeParams](request.params) or {
-		$if debug { log('Failed to decode SelectionRangeParams: ${err}') }
+		$if debug {
+			log('Failed to decode SelectionRangeParams: ${err}')
+		}
 		return Response{
-			id:     request.id
+			id: request.id
 			result: []SelectionRange{}
 		}
 	}
@@ -4116,7 +4332,7 @@ fn (mut app App) handle_selection_range(request Request) Response {
 			results << SelectionRange{
 				range: LSPRange{
 					start: pos
-					end:   pos
+					end: pos
 				}
 			}
 			continue
@@ -4129,7 +4345,7 @@ fn (mut app App) handle_selection_range(request Request) Response {
 				line: pos.line
 				char: 0
 			}
-			end:   Position{
+			end: Position{
 				line: pos.line
 				char: byte_to_encoded_col(line_text, line_text.len, app.position_encoding)
 			}
@@ -4147,7 +4363,7 @@ fn (mut app App) handle_selection_range(request Request) Response {
 				line: pos.line
 				char: start
 			}
-			end:   Position{
+			end: Position{
 				line: pos.line
 				char: end
 			}
@@ -4156,12 +4372,12 @@ fn (mut app App) handle_selection_range(request Request) Response {
 			range: line_range
 		}
 		results << SelectionRange{
-			range:  word_range
+			range: word_range
 			parent: line_parent
 		}
 	}
 	return Response{
-		id:     request.id
+		id: request.id
 		result: results
 	}
 }
@@ -4203,52 +4419,42 @@ fn resolve_workspace_settings(params_json string) ResolvedWorkspaceSettings {
 	sectioned_flat := json2.decode[DidChangeConfigurationParams](params_json) or {
 		DidChangeConfigurationParams{}
 	}
-	merge_workspace_settings(mut resolved, sectioned_flat.settings.vls.inlay_hints,
-		sectioned_flat.settings.vls.diagnostics)
+	merge_workspace_settings(mut resolved, sectioned_flat.settings.vls.inlay_hints, sectioned_flat.settings.vls.diagnostics)
 
 	sectioned_inlay_nested := json2.decode[DidChangeConfigurationParamsCompat](params_json) or {
 		DidChangeConfigurationParamsCompat{}
 	}
-	merge_workspace_settings(mut resolved,
-		sectioned_inlay_nested.settings.vls.inlay_hints.enabled,
-		sectioned_inlay_nested.settings.vls.diagnostics)
+	merge_workspace_settings(mut resolved, sectioned_inlay_nested.settings.vls.inlay_hints.enabled, sectioned_inlay_nested.settings.vls.diagnostics)
 
 	sectioned_diagnostics_nested := json2.decode[DidChangeConfigurationParamsNestedDiagnosticsCompat](params_json) or {
 		DidChangeConfigurationParamsNestedDiagnosticsCompat{}
 	}
-	merge_workspace_settings(mut resolved,
-		sectioned_diagnostics_nested.settings.vls.inlay_hints,
-		sectioned_diagnostics_nested.settings.vls.diagnostics.enabled)
+	merge_workspace_settings(mut resolved, sectioned_diagnostics_nested.settings.vls.inlay_hints, sectioned_diagnostics_nested.settings.vls.diagnostics.enabled)
 
 	sectioned_nested := json2.decode[DidChangeConfigurationParamsNestedFeaturesCompat](params_json) or {
 		DidChangeConfigurationParamsNestedFeaturesCompat{}
 	}
-	merge_workspace_settings(mut resolved, sectioned_nested.settings.vls.inlay_hints.enabled,
-		sectioned_nested.settings.vls.diagnostics.enabled)
+	merge_workspace_settings(mut resolved, sectioned_nested.settings.vls.inlay_hints.enabled, sectioned_nested.settings.vls.diagnostics.enabled)
 
 	direct_flat := json2.decode[DidChangeConfigurationDirectParams](params_json) or {
 		DidChangeConfigurationDirectParams{}
 	}
-	merge_workspace_settings(mut resolved, direct_flat.settings.inlay_hints,
-		direct_flat.settings.diagnostics)
+	merge_workspace_settings(mut resolved, direct_flat.settings.inlay_hints, direct_flat.settings.diagnostics)
 
 	direct_inlay_nested := json2.decode[DidChangeConfigurationDirectParamsCompat](params_json) or {
 		DidChangeConfigurationDirectParamsCompat{}
 	}
-	merge_workspace_settings(mut resolved, direct_inlay_nested.settings.inlay_hints.enabled,
-		direct_inlay_nested.settings.diagnostics)
+	merge_workspace_settings(mut resolved, direct_inlay_nested.settings.inlay_hints.enabled, direct_inlay_nested.settings.diagnostics)
 
 	direct_diagnostics_nested := json2.decode[DidChangeConfigurationDirectParamsNestedDiagnosticsCompat](params_json) or {
 		DidChangeConfigurationDirectParamsNestedDiagnosticsCompat{}
 	}
-	merge_workspace_settings(mut resolved, direct_diagnostics_nested.settings.inlay_hints,
-		direct_diagnostics_nested.settings.diagnostics.enabled)
+	merge_workspace_settings(mut resolved, direct_diagnostics_nested.settings.inlay_hints, direct_diagnostics_nested.settings.diagnostics.enabled)
 
 	direct_nested := json2.decode[DidChangeConfigurationDirectParamsNestedFeaturesCompat](params_json) or {
 		DidChangeConfigurationDirectParamsNestedFeaturesCompat{}
 	}
-	merge_workspace_settings(mut resolved, direct_nested.settings.inlay_hints.enabled,
-		direct_nested.settings.diagnostics.enabled)
+	merge_workspace_settings(mut resolved, direct_nested.settings.inlay_hints.enabled, direct_nested.settings.diagnostics.enabled)
 	return resolved
 }
 
@@ -4271,7 +4477,9 @@ fn merge_workspace_settings(mut resolved ResolvedWorkspaceSettings, inlay_hints 
 fn (mut app App) on_initialize(request Request) ?string {
 	params := json2.decode[InitializeParams](request.params) or {
 		msg := 'Invalid initialize params: ${err.msg()}'
-		$if debug { log(msg) }
+		$if debug {
+			log(msg)
+		}
 		return msg
 	}
 	roots := resolve_initialize_workspace_roots(params)
@@ -4308,9 +4516,15 @@ fn negotiate_position_encoding(params InitializeParams) PositionEncoding {
 				mut has_utf32 := false
 				for e in encodings {
 					match e {
-						'utf-8' { return PositionEncoding.utf8 }
-						'utf-16' { has_utf16 = true }
-						'utf-32' { has_utf32 = true }
+						'utf-8' {
+							return PositionEncoding.utf8
+						}
+						'utf-16' {
+							has_utf16 = true
+						}
+						'utf-32' {
+							has_utf32 = true
+						}
 						else {}
 					}
 				}
@@ -4408,7 +4622,9 @@ fn (mut app App) on_cancel_request(request Request) {
 		app.cancelled_requests[params.id] = true
 		log('VLS: request ${params.id} marked as cancelled')
 	} else {
-		$if debug { log('Failed to decode CancelRequestParams') }
+		$if debug {
+			log('Failed to decode CancelRequestParams')
+		}
 	}
 }
 
@@ -4416,7 +4632,9 @@ fn (mut app App) on_cancel_request(request Request) {
 // updating the server's list of workspace roots when the client adds or removes folders.
 fn (mut app App) on_did_change_workspace_folders(request Request) {
 	params := json2.decode[DidChangeWorkspaceFoldersParams](request.params) or {
-		$if debug { log('Failed to decode DidChangeWorkspaceFoldersParams: ${err}') }
+		$if debug {
+			log('Failed to decode DidChangeWorkspaceFoldersParams: ${err}')
+		}
 		return
 	}
 	// Remove folders that were closed.
@@ -4501,7 +4719,7 @@ fn code_lens_range(line int, raw_line string, encoding PositionEncoding) LSPRang
 			line: line
 			char: 0
 		}
-		end:   Position{
+		end: Position{
 			line: line
 			char: byte_to_encoded_col(raw_line, raw_line.len, encoding)
 		}
@@ -4512,9 +4730,11 @@ fn code_lens_range(line int, raw_line string, encoding PositionEncoding) LSPRang
 // It returns Run Main for main and Run File plus Run Test for test functions.
 fn (mut app App) handle_code_lens(request Request) Response {
 	params := json2.decode[CodeLensParams](request.params) or {
-		$if debug { log('Failed to decode CodeLensParams: ${err}') }
+		$if debug {
+			log('Failed to decode CodeLensParams: ${err}')
+		}
 		return Response{
-			id:     request.id
+			id: request.id
 			result: []CodeLens{}
 		}
 	}
@@ -4529,35 +4749,35 @@ fn (mut app App) handle_code_lens(request Request) Response {
 		fn_name := code_lens_fn_name(code)
 		if fn_name == 'main' {
 			lenses << CodeLens{
-				range:   code_lens_range(i, raw_line, app.position_encoding)
+				range: code_lens_range(i, raw_line, app.position_encoding)
 				command: Command{
-					title:     'Run Main'
-					command:   'vls.runFile'
+					title: 'Run Main'
+					command: 'vls.runFile'
 					arguments: [uri]
 				}
 			}
 		}
 		if is_test_file && fn_name.starts_with('test_') {
 			lenses << CodeLens{
-				range:   code_lens_range(i, raw_line, app.position_encoding)
+				range: code_lens_range(i, raw_line, app.position_encoding)
 				command: Command{
-					title:     'Run File'
-					command:   'vls.runTests'
+					title: 'Run File'
+					command: 'vls.runTests'
 					arguments: [uri]
 				}
 			}
 			lenses << CodeLens{
-				range:   code_lens_range(i, raw_line, app.position_encoding)
+				range: code_lens_range(i, raw_line, app.position_encoding)
 				command: Command{
-					title:     'Run Test'
-					command:   'vls.runTests'
+					title: 'Run Test'
+					command: 'vls.runTests'
 					arguments: [uri, fn_name]
 				}
 			}
 		}
 	}
 	return Response{
-		id:     request.id
+		id: request.id
 		result: lenses
 	}
 }
@@ -4566,14 +4786,16 @@ fn (mut app App) handle_code_lens(request Request) Response {
 // The lens is already fully resolved at creation time so this is a pass-through.
 fn (mut app App) handle_code_lens_resolve(request Request) Response {
 	lens := json2.decode[CodeLens](request.params) or {
-		$if debug { log('Failed to decode CodeLens for resolve: ${err}') }
+		$if debug {
+			log('Failed to decode CodeLens for resolve: ${err}')
+		}
 		return Response{
-			id:     request.id
+			id: request.id
 			result: 'null'
 		}
 	}
 	return Response{
-		id:     request.id
+		id: request.id
 		result: lens
 	}
 }
@@ -4611,9 +4833,11 @@ fn (app &App) code_lens_command_target(arguments []string) (string, string, stri
 // handle_execute_command handles workspace/executeCommand by invoking the V compiler.
 fn (mut app App) handle_execute_command(request Request) Response {
 	params := json2.decode[ExecuteCommandParams](request.params) or {
-		$if debug { log('Failed to decode ExecuteCommandParams: ${err}') }
+		$if debug {
+			log('Failed to decode ExecuteCommandParams: ${err}')
+		}
 		return Response{
-			id:     request.id
+			id: request.id
 			result: 'null'
 		}
 	}
@@ -4627,13 +4851,13 @@ fn (mut app App) handle_execute_command(request Request) Response {
 				app.send_show_message('vls: the V compiler (`v`) was not found on PATH.', 1)
 			} else {
 				app.start_code_lens_run(CodeLensRunJob{
-					kind:           .main
-					title:          'Run Main'
-					uri:            uri
-					path:           path
-					open_files:     app.open_files.clone()
-					write_mutex:    app.write_mutex
-					tcp_conn:       app.tcp_conn
+					kind: .main
+					title: 'Run Main'
+					uri: uri
+					path: path
+					open_files: app.open_files.clone()
+					write_mutex: app.write_mutex
+					tcp_conn: app.tcp_conn
 					capture_output: app.capture_output
 				})
 			}
@@ -4658,18 +4882,17 @@ fn (mut app App) handle_execute_command(request Request) Response {
 						CodeLensRunKind.test_function
 					}
 					if !compiler_is_available() {
-						app.send_show_message('vls: the V compiler (`v`) was not found on PATH.',
-							1)
+						app.send_show_message('vls: the V compiler (`v`) was not found on PATH.', 1)
 					} else {
 						app.start_code_lens_run(CodeLensRunJob{
-							kind:           kind
-							title:          title
-							uri:            uri
-							path:           path
-							fn_name:        fn_name
-							open_files:     app.open_files.clone()
-							write_mutex:    app.write_mutex
-							tcp_conn:       app.tcp_conn
+							kind: kind
+							title: title
+							uri: uri
+							path: path
+							fn_name: fn_name
+							open_files: app.open_files.clone()
+							write_mutex: app.write_mutex
+							tcp_conn: app.tcp_conn
 							capture_output: app.capture_output
 						})
 					}
@@ -4682,7 +4905,7 @@ fn (mut app App) handle_execute_command(request Request) Response {
 	}
 
 	return Response{
-		id:     request.id
+		id: request.id
 		result: 'null'
 	}
 }
@@ -4691,9 +4914,11 @@ fn (mut app App) handle_execute_command(request Request) Response {
 // Returns inline text values for simple variable := literal assignments in the range.
 fn (mut app App) handle_inline_value(request Request) Response {
 	params := json2.decode[InlineValueParams](request.params) or {
-		$if debug { log('Failed to decode InlineValueParams: ${err}') }
+		$if debug {
+			log('Failed to decode InlineValueParams: ${err}')
+		}
 		return Response{
-			id:     request.id
+			id: request.id
 			result: []InlineValueText{}
 		}
 	}
@@ -4727,16 +4952,16 @@ fn (mut app App) handle_inline_value(request Request) Response {
 					line: i
 					char: col_start
 				}
-				end:   Position{
+				end: Position{
 					line: i
 					char: col_start + var_name.len
 				}
 			}
-			text:  ': ${inferred}'
+			text: ': ${inferred}'
 		}
 	}
 	return Response{
-		id:     request.id
+		id: request.id
 		result: values
 	}
 }
@@ -4750,7 +4975,7 @@ fn (mut app App) handle_linked_editing_range(request Request) Response {
 			log('Failed to decode TextDocumentPositionParams for linkedEditingRange: ${err}')
 		}
 		return Response{
-			id:     request.id
+			id: request.id
 			result: 'null'
 		}
 	}
@@ -4759,7 +4984,7 @@ fn (mut app App) handle_linked_editing_range(request Request) Response {
 	lines := content.split_into_lines()
 	if params.position.line < 0 || params.position.line >= lines.len {
 		return Response{
-			id:     request.id
+			id: request.id
 			result: 'null'
 		}
 	}
@@ -4767,7 +4992,7 @@ fn (mut app App) handle_linked_editing_range(request Request) Response {
 	start, end := find_word_bounds_at_col(line_text, params.position.char, app.position_encoding)
 	if start < 0 || end <= start {
 		return Response{
-			id:     request.id
+			id: request.id
 			result: 'null'
 		}
 	}
@@ -4788,7 +5013,7 @@ fn (mut app App) handle_linked_editing_range(request Request) Response {
 					line: params.position.line
 					char: sc
 				}
-				end:   Position{
+				end: Position{
 					line: params.position.line
 					char: ec
 				}
@@ -4798,12 +5023,12 @@ fn (mut app App) handle_linked_editing_range(request Request) Response {
 	}
 	if ranges.len == 0 {
 		return Response{
-			id:     request.id
+			id: request.id
 			result: 'null'
 		}
 	}
 	return Response{
-		id:     request.id
+		id: request.id
 		result: LinkedEditingRanges{
 			ranges: ranges
 		}
@@ -4814,7 +5039,7 @@ fn (mut app App) handle_linked_editing_range(request Request) Response {
 // For now it returns empty edits — triggering v fmt on every keystroke would be too expensive.
 fn (mut app App) handle_on_type_formatting(request Request) Response {
 	return Response{
-		id:     request.id
+		id: request.id
 		result: []TextEdit{}
 	}
 }

--- a/handlers.v
+++ b/handlers.v
@@ -152,7 +152,7 @@ fn (app &App) source_declaration_at(location Location) string {
 		}
 		parts << part
 	}
-	return parts.join(' ').trim_space()
+	return parts.join('\n').trim_space()
 }
 
 fn source_declaration_opens_body(mask []u8) bool {
@@ -284,15 +284,21 @@ fn signature_parameters(label string) []ParameterInformation {
 		} else if mask[i] in [`)`, `]`, `}`] && depth > 0 {
 			depth--
 		} else if mask[i] == `,` && depth == 0 {
-			parameters << ParameterInformation{
-				label: label[parameter_start..i].trim_space()
+			parameter := label[parameter_start..i].trim_space()
+			if parameter != '' {
+				parameters << ParameterInformation{
+					label: parameter
+				}
 			}
 			parameter_start = i + 1
 		}
 	}
 	if parameter_start < close_paren {
-		parameters << ParameterInformation{
-			label: label[parameter_start..close_paren].trim_space()
+		parameter := label[parameter_start..close_paren].trim_space()
+		if parameter != '' {
+			parameters << ParameterInformation{
+				label: parameter
+			}
 		}
 	}
 	return parameters

--- a/handlers.v
+++ b/handlers.v
@@ -135,22 +135,24 @@ fn (app &App) source_declaration_at(location Location) string {
 	if !source_declaration_opens_body(first_mask) {
 		return first_part
 	}
-	mut parts := []string{}
+	starts := line_start_offsets(content)
+	source_mask := v_source_code_mask(content)
 	end_line := if start_line + 16 < lines.len { start_line + 16 } else { lines.len }
-	for i in start_line .. end_line {
-		mut part := lines[i].trim_space()
-		if part == '' {
-			continue
-		}
-		part_mask := v_source_code_mask(part).bytestr()
-		if brace := part_mask.index('{') {
-			part = part[..brace].trim_space()
-			if part != '' {
-				parts << part
-			}
+	start_byte := starts[start_line]
+	end_byte := if end_line < starts.len { starts[end_line] } else { content.len }
+	mut header_end := end_byte
+	for pos in start_byte .. end_byte {
+		if source_mask[pos] == `{` {
+			header_end = pos
 			break
 		}
-		parts << part
+	}
+	mut parts := []string{}
+	for raw_part in content[start_byte..header_end].split_into_lines() {
+		part := raw_part.trim_space()
+		if part != '' {
+			parts << part
+		}
 	}
 	return parts.join('\n').trim_space()
 }

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -2662,6 +2662,15 @@ fn test_signature_parameters_split_only_top_level_commas() {
 	assert parameters[1].label == 'value int'
 }
 
+fn test_signature_active_parameter_clamps_variadic_arguments() {
+	variadic := signature_parameters('collect(prefix string, values ...int)')
+	assert signature_active_parameter(variadic, 1) == 1
+	assert signature_active_parameter(variadic, 2) == 1
+
+	fixed := signature_parameters('collect(prefix string, value int)')
+	assert signature_active_parameter(fixed, 2) == 2
+}
+
 fn test_source_declaration_at_stops_non_braced_declarations() {
 	mut app := create_test_app()
 	defer {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -2668,7 +2668,7 @@ fn test_source_declaration_at_stops_non_braced_declarations() {
 		cleanup_test_app(app)
 	}
 	uri := 'file:///tmp/source_declaration_fallback.v'
-	content := 'module main\n\nconst (\n\tanswer = 42\n\tother = 7\n)\n\ntype Alias = int\ntype Handler = fn (int) bool\n\nfn next() {}\n\nfn parse(\n\tvalue string, // explanation\n\tradix int,\n) !int {\n}\n'
+	content := 'module main\n\nconst (\n\tanswer = 42\n\tother = 7\n)\n\ntype Alias = int\ntype Handler = fn (int) bool\n\nfn next() {}\n\nfn parse(\n\tvalue string, // explanation\n\t/* { inside comment\n\tcontinued } */\n\tradix int,\n) !int {\n}\n'
 	app.open_files[uri] = content
 
 	constant := app.source_declaration_at(Location{
@@ -2709,9 +2709,9 @@ fn test_source_declaration_at_stops_non_braced_declarations() {
 			}
 		}
 	})
-	assert function == 'fn parse(\nvalue string, // explanation\nradix int,\n) !int'
+	assert function == 'fn parse(\nvalue string, // explanation\n/* { inside comment\ncontinued } */\nradix int,\n) !int'
 	label := declaration_signature_label(function, 'parse')
-	assert label == 'parse(\nvalue string, // explanation\nradix int,\n) !int'
+	assert label == 'parse(\nvalue string, // explanation\n/* { inside comment\ncontinued } */\nradix int,\n) !int'
 	assert signature_parameters(label).len == 2
 }
 

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -25,15 +25,15 @@ fn create_test_app() &App {
 	os.mkdir_all(temp_dir) or {
 		assert false, 'Failed to create test temp dir: ${err}'
 		return &App{
-			text:       ''
+			text: ''
 			open_files: map[string]string{}
-			temp_dir:   temp_dir
+			temp_dir: temp_dir
 		}
 	}
 	return &App{
-		text:       ''
+		text: ''
 		open_files: map[string]string{}
-		temp_dir:   temp_dir
+		temp_dir: temp_dir
 	}
 }
 
@@ -56,10 +56,10 @@ fn test_on_did_open_tracks_file() {
 
 	uri := path_to_uri(test_file)
 	request := Request{
-		id:      1
-		method:  'textDocument/didOpen'
+		id: 1
+		method: 'textDocument/didOpen'
 		jsonrpc: '2.0'
-		params:  json2.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
@@ -201,7 +201,7 @@ fn test_on_did_open_uses_text_document_payload() {
 	app.on_did_open(Request{
 		params: json2.encode(DidOpenTextDocumentParams{
 			text_document: DidOpenTextDocumentItem{
-				uri:  uri
+				uri: uri
 				text: content
 			}
 		},
@@ -224,7 +224,7 @@ fn test_on_did_open_uses_empty_text_payload_without_disk_fallback() {
 	app.on_did_open(Request{
 		params: json2.encode(DidOpenTextDocumentParams{
 			text_document: DidOpenTextDocumentItem{
-				uri:  uri
+				uri: uri
 				text: ''
 			}
 		},
@@ -335,11 +335,11 @@ fn test_on_did_change_updates_content() {
 	// Then change it
 	new_content := 'module main\n\nfn main() {\n\tprintln("changed")\n}'
 	request := Request{
-		id:      2
-		method:  'textDocument/didChange'
+		id: 2
+		method: 'textDocument/didChange'
 		jsonrpc: '2.0'
-		params:  json2.encode(Params{
-			text_document:   TextDocumentIdentifier{
+		params: json2.encode(Params{
+			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
 			content_changes: [ContentChange{
@@ -427,7 +427,7 @@ fn test_on_did_change_returns_notification() {
 
 	request := Request{
 		params: json2.encode(Params{
-			text_document:   TextDocumentIdentifier{
+			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
 			content_changes: [ContentChange{
@@ -461,8 +461,8 @@ fn test_on_did_change_schedules_diagnostics_without_blocking() {
 
 	result := app.on_did_change(Request{
 		params: json2.encode(DidChangeTextDocumentParams{
-			text_document:   VersionedTextDocumentIdentifier{
-				uri:     uri
+			text_document: VersionedTextDocumentIdentifier{
+				uri: uri
 				version: 2
 			}
 			content_changes: [ContentChange{
@@ -501,7 +501,7 @@ fn test_diagnostics_scheduler_coalesces_pending_jobs() {
 	mut scheduler := new_diagnostics_scheduler()
 	uri := 'file:///pending.v'
 	global_first, generation_first := scheduler.next_generation(uri)
-	assert scheduler.enqueue(DiagnosticsJob{
+	should_start := scheduler.enqueue(DiagnosticsJob{
 		uri: uri
 		content: 'first'
 		global_generation: global_first
@@ -509,8 +509,9 @@ fn test_diagnostics_scheduler_coalesces_pending_jobs() {
 		ready_at: 100
 		write_mutex: app.write_mutex
 	})
+	assert should_start
 	global_latest, generation_latest := scheduler.next_generation(uri)
-	assert !scheduler.enqueue(DiagnosticsJob{
+	should_restart := scheduler.enqueue(DiagnosticsJob{
 		uri: uri
 		content: 'latest'
 		global_generation: global_latest
@@ -518,6 +519,7 @@ fn test_diagnostics_scheduler_coalesces_pending_jobs() {
 		ready_at: 100
 		write_mutex: app.write_mutex
 	})
+	assert !should_restart
 
 	jobs, should_stop := scheduler.take_ready_jobs(100)
 	assert !should_stop
@@ -856,7 +858,7 @@ fn test_on_did_change_multiple_changes() {
 	for change in changes {
 		request := Request{
 			params: json2.encode(Params{
-				text_document:   TextDocumentIdentifier{
+				text_document: TextDocumentIdentifier{
 					uri: uri
 				}
 				content_changes: [ContentChange{
@@ -903,7 +905,7 @@ fn test_on_did_change_updates_tracked_file() {
 	new_content := 'modified content'
 	app.on_did_change(Request{
 		params: json2.encode(Params{
-			text_document:   TextDocumentIdentifier{
+			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
 			content_changes: [ContentChange{
@@ -926,7 +928,7 @@ fn test_apply_incremental_change_handles_utf8_columns() {
 			line: 0
 			char: 1
 		}
-		end:   Position{
+		end: Position{
 			line: 0
 			char: 2
 		}
@@ -945,7 +947,7 @@ fn test_apply_incremental_change_preserves_crlf() {
 			line: 1
 			char: 0
 		}
-		end:   Position{
+		end: Position{
 			line: 1
 			char: 3
 		}
@@ -961,7 +963,7 @@ fn test_apply_incremental_change_rejects_reversed_range() {
 			line: 0
 			char: 4
 		}
-		end:   Position{
+		end: Position{
 			line: 0
 			char: 2
 		}
@@ -980,7 +982,7 @@ fn test_incremental_change_is_valid_rejects_lines_past_eof() {
 			line: 5
 			char: 0
 		}
-		end:   Position{
+		end: Position{
 			line: 6
 			char: 0
 		}
@@ -992,7 +994,7 @@ fn test_incremental_change_is_valid_rejects_lines_past_eof() {
 			line: 1
 			char: 0
 		}
-		end:   Position{
+		end: Position{
 			line: 9
 			char: 0
 		}
@@ -1004,7 +1006,7 @@ fn test_incremental_change_is_valid_rejects_lines_past_eof() {
 			line: 0
 			char: 1
 		}
-		end:   Position{
+		end: Position{
 			line: 1
 			char: 2
 		}
@@ -1055,7 +1057,7 @@ fn test_semantic_candidate_cap_ignores_unrelated_workspace_root() {
 	app.ensure_dirs_indexed(app.index_query_dirs())
 
 	current_scope := IndexScope{
-		dir:       '/root_a'
+		dir: '/root_a'
 		recursive: true
 	}
 	candidates := app.collect_semantic_candidates('unique', current_scope)
@@ -1074,7 +1076,7 @@ fn test_incremental_change_is_valid_rejects_char_past_line() {
 			line: 0
 			char: 9
 		}
-		end:   Position{
+		end: Position{
 			line: 1
 			char: 1
 		}
@@ -1085,7 +1087,7 @@ fn test_incremental_change_is_valid_rejects_char_past_line() {
 			line: 0
 			char: 1
 		}
-		end:   Position{
+		end: Position{
 			line: 1
 			char: 9
 		}
@@ -1098,7 +1100,7 @@ fn test_incremental_change_is_valid_rejects_char_past_line() {
 			line: 0
 			char: 3
 		}
-		end:   Position{
+		end: Position{
 			line: 0
 			char: 3
 		}
@@ -1113,7 +1115,7 @@ fn test_apply_incremental_change_handles_multiline_ranges() {
 			line: 0
 			char: 1
 		}
-		end:   Position{
+		end: Position{
 			line: 1
 			char: 2
 		}
@@ -1139,13 +1141,13 @@ fn test_operation_at_pos_completion_line_info() {
 	app.open_files[uri] = content
 
 	request := Request{
-		id:     1
+		id: 1
 		method: 'textDocument/completion'
 		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-			position:      Position{
+			position: Position{
 				line: 3
 				char: 4
 			}
@@ -1175,13 +1177,13 @@ fn test_operation_at_pos_definition_line_info() {
 	app.open_files[uri] = content
 
 	request := Request{
-		id:     2
+		id: 2
 		method: 'textDocument/definition'
 		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-			position:      Position{
+			position: Position{
 				line: 5
 				char: 2
 			}
@@ -2110,7 +2112,7 @@ fn test_resolve_indexed_definition_defers_compile_time_condition() {
 	test_dir := os.join_path(app.temp_dir, 'indexed_definition_compile_time_condition')
 	must_mkdir_all(test_dir)
 	test_file := os.join_path(test_dir, 'main.v')
-	content := 'module main\n\nfn windows() {}\n\n$if windows {\n\tfn active() {}\n}\n'
+	content := 'module main\n\nfn windows() {}\n\n\$if windows {\n\tfn active() {}\n}\n'
 	must_write_file(test_file, content)
 	uri := path_to_uri(test_file)
 	app.open_files[uri] = content
@@ -2134,7 +2136,7 @@ fn test_resolve_indexed_definition_defers_multiline_compile_time_condition() {
 	test_dir := os.join_path(app.temp_dir, 'indexed_definition_multiline_compile_time_condition')
 	must_mkdir_all(test_dir)
 	test_file := os.join_path(test_dir, 'main.v')
-	content := 'module main\n\nfn windows() {}\n\n$if (\n\twindows\n) {\n\tfn active() {}\n}\n'
+	content := 'module main\n\nfn windows() {}\n\n\$if (\n\twindows\n) {\n\tfn active() {}\n}\n'
 	must_write_file(test_file, content)
 	uri := path_to_uri(test_file)
 	app.open_files[uri] = content
@@ -2650,13 +2652,13 @@ fn test_operation_at_pos_signature_help_line_info() {
 	app.open_files[uri] = content
 
 	request := Request{
-		id:     3
+		id: 3
 		method: 'textDocument/signatureHelp'
 		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-			position:      Position{
+			position: Position{
 				line: 5
 				char: 7
 			}
@@ -2689,12 +2691,12 @@ fn test_operation_at_pos_preserves_request_id() {
 	test_ids := [0, 1, 42, 999, 12345]
 	for id in test_ids {
 		request := Request{
-			id:     id
+			id: id
 			params: json2.encode(Params{
 				text_document: TextDocumentIdentifier{
 					uri: uri
 				}
-				position:      Position{
+				position: Position{
 					line: 2
 					char: 0
 				}
@@ -2709,7 +2711,7 @@ fn test_operation_at_pos_preserves_request_id() {
 
 fn test_json_encode_response() {
 	response := Response{
-		id:     1
+		id: 1
 		result: 'null'
 	}
 	encoded := json2.encode(response, escape_unicode: true)
@@ -2719,20 +2721,20 @@ fn test_json_encode_response() {
 
 fn test_json_encode_capabilities_response() {
 	response := Response{
-		id:     0
+		id: 0
 		result: Capabilities{
 			capabilities: Capability{
-				text_document_sync:      TextDocumentSyncOptions{
+				text_document_sync: TextDocumentSyncOptions{
 					open_close: true
-					change:     1
+					change: 1
 				}
-				completion_provider:     CompletionProvider{
+				completion_provider: CompletionProvider{
 					trigger_characters: ['.']
 				}
 				signature_help_provider: SignatureHelpOptions{
 					trigger_characters: ['(', ',']
 				}
-				definition_provider:     true
+				definition_provider: true
 			}
 		}
 	}
@@ -2745,20 +2747,20 @@ fn test_json_encode_capabilities_response() {
 fn test_json_encode_completion_response() {
 	details := [
 		Detail{
-			kind:          6
-			label:         'println'
-			detail:        'fn println(s string)'
+			kind: 6
+			label: 'println'
+			detail: 'fn println(s string)'
 			documentation: 'Prints to stdout'
 		},
 		Detail{
-			kind:          6
-			label:         'print'
-			detail:        'fn print(s string)'
+			kind: 6
+			label: 'print'
+			detail: 'fn print(s string)'
 			documentation: 'Prints without newline'
 		},
 	]
 	response := Response{
-		id:     2
+		id: 2
 		result: details
 	}
 	encoded := json2.encode(response, escape_unicode: true)
@@ -2768,15 +2770,15 @@ fn test_json_encode_completion_response() {
 
 fn test_json_encode_location_response() {
 	response := Response{
-		id:     3
+		id: 3
 		result: Location{
-			uri:   'file:///test/main.v'
+			uri: 'file:///test/main.v'
 			range: LSPRange{
 				start: Position{
 					line: 10
 					char: 5
 				}
-				end:   Position{
+				end: Position{
 					line: 10
 					char: 15
 				}
@@ -2790,11 +2792,11 @@ fn test_json_encode_location_response() {
 
 fn test_json_encode_signature_help_response() {
 	response := Response{
-		id:     4
+		id: 4
 		result: SignatureHelp{
-			signatures:       [
+			signatures: [
 				SignatureInformation{
-					label:      'fn test(a int, b string)'
+					label: 'fn test(a int, b string)'
 					parameters: [
 						ParameterInformation{
 							label: 'a int'
@@ -2819,20 +2821,20 @@ fn test_json_encode_notification() {
 	notification := Notification{
 		method: 'textDocument/publishDiagnostics'
 		params: PublishDiagnosticsParams{
-			uri:         'file:///test.v'
+			uri: 'file:///test.v'
 			diagnostics: [
 				LSPDiagnostic{
-					range:    LSPRange{
+					range: LSPRange{
 						start: Position{
 							line: 5
 							char: 0
 						}
-						end:   Position{
+						end: Position{
 							line: 5
 							char: 10
 						}
 					}
-					message:  'undefined identifier'
+					message: 'undefined identifier'
 					severity: 1
 				},
 			]
@@ -2918,17 +2920,17 @@ fn test_diagnostics_deduplication() {
 	errors := [
 		JsonError{
 			line_nr: 5
-			col:     10
+			col: 10
 			message: 'error 1'
 		},
 		JsonError{
 			line_nr: 5
-			col:     10
+			col: 10
 			message: 'error 2'
 		}, // duplicate position
 		JsonError{
 			line_nr: 6
-			col:     5
+			col: 5
 			message: 'error 3'
 		},
 	]
@@ -2952,17 +2954,17 @@ fn test_diagnostics_deduplication_same_line_different_col() {
 	errors := [
 		JsonError{
 			line_nr: 5
-			col:     1
+			col: 1
 			message: 'error 1'
 		},
 		JsonError{
 			line_nr: 5
-			col:     10
+			col: 10
 			message: 'error 2'
 		},
 		JsonError{
 			line_nr: 5
-			col:     20
+			col: 20
 			message: 'error 3'
 		},
 	]
@@ -3009,7 +3011,7 @@ fn test_response_result_string() {
 fn test_response_result_details() {
 	details := [
 		Detail{
-			kind:  6
+			kind: 6
 			label: 'test'
 		},
 	]
@@ -3084,11 +3086,11 @@ fn test_app_exit_flag_default() {
 
 fn test_v_error_to_lsp_diagnostic_basic() {
 	v_err := JsonError{
-		path:    '/test/file.v'
+		path: '/test/file.v'
 		message: 'undefined identifier `foo`'
 		line_nr: 10
-		col:     5
-		len:     3
+		col: 5
+		len: 3
 	}
 	diag := v_error_to_lsp_diagnostic(v_err)
 
@@ -3103,11 +3105,11 @@ fn test_v_error_to_lsp_diagnostic_basic() {
 
 fn test_v_error_to_lsp_diagnostic_first_line() {
 	v_err := JsonError{
-		path:    '/test/file.v'
+		path: '/test/file.v'
 		message: 'syntax error'
 		line_nr: 1
-		col:     1
-		len:     1
+		col: 1
+		len: 1
 	}
 	diag := v_error_to_lsp_diagnostic(v_err)
 
@@ -3118,11 +3120,11 @@ fn test_v_error_to_lsp_diagnostic_first_line() {
 
 fn test_v_error_to_lsp_diagnostic_long_error() {
 	v_err := JsonError{
-		path:    '/test/file.v'
+		path: '/test/file.v'
 		message: 'unexpected token'
 		line_nr: 100
-		col:     50
-		len:     20
+		col: 50
+		len: 20
 	}
 	diag := v_error_to_lsp_diagnostic(v_err)
 
@@ -3133,11 +3135,11 @@ fn test_v_error_to_lsp_diagnostic_long_error() {
 
 fn test_v_error_to_lsp_diagnostic_zero_length() {
 	v_err := JsonError{
-		path:    '/test/file.v'
+		path: '/test/file.v'
 		message: 'error at position'
 		line_nr: 5
-		col:     10
-		len:     0
+		col: 10
+		len: 0
 	}
 	diag := v_error_to_lsp_diagnostic(v_err)
 
@@ -3158,8 +3160,8 @@ fn test_v_error_to_lsp_diagnostic_preserves_message() {
 		v_err := JsonError{
 			message: msg
 			line_nr: 1
-			col:     1
-			len:     1
+			col: 1
+			len: 1
 		}
 		diag := v_error_to_lsp_diagnostic(v_err)
 		assert diag.message == msg
@@ -3168,11 +3170,11 @@ fn test_v_error_to_lsp_diagnostic_preserves_message() {
 
 fn test_v_error_to_lsp_diagnostic_always_error_severity() {
 	v_err := JsonError{
-		path:    '/test.v'
+		path: '/test.v'
 		message: 'any error'
 		line_nr: 1
-		col:     1
-		len:     1
+		col: 1
+		len: 1
 	}
 	diag := v_error_to_lsp_diagnostic(v_err)
 	assert diag.severity == 1 // Always Error severity
@@ -3249,7 +3251,7 @@ fn test_multifile_change_single_file() {
 	new_content := 'module main\n\nfn main() { changed }'
 	app.on_did_change(Request{
 		params: json2.encode(Params{
-			text_document:   TextDocumentIdentifier{
+			text_document: TextDocumentIdentifier{
 				uri: main_uri
 			}
 			content_changes: [ContentChange{
@@ -3283,10 +3285,10 @@ fn test_handle_formatting_formats_code() {
 	app.open_files[uri] = unformatted
 
 	request := Request{
-		id:      1
-		method:  'textDocument/formatting'
+		id: 1
+		method: 'textDocument/formatting'
 		jsonrpc: '2.0'
-		params:  json2.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
@@ -3330,10 +3332,10 @@ fn test_handle_formatting_already_formatted() {
 	app.open_files[uri] = formatted
 
 	request := Request{
-		id:      2
-		method:  'textDocument/formatting'
+		id: 2
+		method: 'textDocument/formatting'
 		jsonrpc: '2.0'
-		params:  json2.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
@@ -3363,10 +3365,10 @@ fn test_handle_formatting_nonexistent_file() {
 	uri := path_to_uri(nonexistent)
 
 	request := Request{
-		id:      3
-		method:  'textDocument/formatting'
+		id: 3
+		method: 'textDocument/formatting'
 		jsonrpc: '2.0'
-		params:  json2.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
@@ -3403,10 +3405,10 @@ fn test_handle_formatting_uses_open_file_content() {
 	app.open_files[uri] = 'module main\n\nfn   new(   )   {}'
 
 	request := Request{
-		id:      4
-		method:  'textDocument/formatting'
+		id: 4
+		method: 'textDocument/formatting'
 		jsonrpc: '2.0'
-		params:  json2.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
@@ -3444,17 +3446,17 @@ fn test_find_references_returns_null_when_no_symbol_at_position() {
 	app.open_files[uri] = content
 
 	resp := app.find_references(Request{
-		id:     901
+		id: 901
 		method: 'textDocument/references'
 		params: json2.encode(ReferenceParams{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-			position:      Position{
+			position: Position{
 				line: 1
 				char: 0
 			}
-			context:       ReferenceContext{
+			context: ReferenceContext{
 				include_declaration: true
 			}
 		},
@@ -3483,17 +3485,17 @@ fn test_handle_rename_returns_null_when_no_symbol_at_position() {
 	app.open_files[uri] = content
 
 	resp := app.handle_rename(Request{
-		id:     902
+		id: 902
 		method: 'textDocument/rename'
 		params: json2.encode(RenameParams{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-			position:      Position{
+			position: Position{
 				line: 1
 				char: 0
 			}
-			new_name:      'renamed'
+			new_name: 'renamed'
 		},
 			escape_unicode: true
 		)
@@ -3551,7 +3553,7 @@ fn test_did_close_reindexes_noncanonical_uri_under_disk_uri() {
 	app.on_did_change_watched_files(Request{
 		params: json2.encode(DidChangeWatchedFilesParams{
 			changes: [FileEvent{
-				uri:        disk_uri
+				uri: disk_uri
 				event_type: 2
 			}]
 		})
@@ -3581,17 +3583,17 @@ fn test_handle_rename_refuses_incomplete_oversized_sibling_index() {
 	app.open_files[uri] = content
 
 	resp := app.handle_rename(Request{
-		id:     903
+		id: 903
 		method: 'textDocument/rename'
 		params: json2.encode(RenameParams{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-			position:      Position{
+			position: Position{
 				line: 2
 				char: 4
 			}
-			new_name:      'renamed'
+			new_name: 'renamed'
 		},
 			escape_unicode: true
 		)
@@ -3854,7 +3856,7 @@ fn test_handle_document_symbols_empty_file() {
 	app.open_files[uri] = ''
 
 	request := Request{
-		id:     10
+		id: 10
 		method: 'textDocument/documentSymbol'
 		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
@@ -3882,7 +3884,7 @@ fn test_handle_document_symbols_no_tracked_file() {
 
 	// URI not in open_files — should still return an empty symbol list, not crash
 	request := Request{
-		id:     11
+		id: 11
 		method: 'textDocument/documentSymbol'
 		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
@@ -3912,7 +3914,7 @@ fn test_handle_document_symbols_returns_correct_symbols() {
 	app.open_files[uri] = 'module main\n\nfn hello() {}\n\nstruct Config {}\n\nenum Mode { on off }\n\nconst version = 1\n'
 
 	request := Request{
-		id:     12
+		id: 12
 		method: 'textDocument/documentSymbol'
 		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
@@ -3949,7 +3951,7 @@ fn test_handle_document_symbols_preserves_request_id() {
 
 	for id in [1, 99, 1000, 0] {
 		request := Request{
-			id:     id
+			id: id
 			method: 'textDocument/documentSymbol'
 			params: json2.encode(Params{
 				text_document: TextDocumentIdentifier{
@@ -3987,7 +3989,7 @@ const my_const = 42
 '
 
 	request := Request{
-		id:     20
+		id: 20
 		method: 'textDocument/documentSymbol'
 		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
@@ -4433,18 +4435,18 @@ obj := MyStruct{}
 	app.open_files[uri] = content
 
 	request := Request{
-		id:     30
+		id: 30
 		method: 'textDocument/inlayHint'
 		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-			range:         LSPRange{
+			range: LSPRange{
 				start: Position{
 					line: 0
 					char: 0
 				}
-				end:   Position{
+				end: Position{
 					line: 9
 					char: 0
 				}
@@ -4484,18 +4486,18 @@ x := 99
 	app.open_files[uri] = content
 
 	request := Request{
-		id:     31
+		id: 31
 		method: 'textDocument/inlayHint'
 		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-			range:         LSPRange{
+			range: LSPRange{
 				start: Position{
 					line: 0
 					char: 0
 				}
-				end:   Position{
+				end: Position{
 					line: 4
 					char: 0
 				}
@@ -4531,18 +4533,18 @@ fn test_handle_inlay_hints_empty_file() {
 	app.open_files[uri] = ''
 
 	request := Request{
-		id:     32
+		id: 32
 		method: 'textDocument/inlayHint'
 		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-			range:         LSPRange{
+			range: LSPRange{
 				start: Position{
 					line: 0
 					char: 0
 				}
-				end:   Position{
+				end: Position{
 					line: 0
 					char: 0
 				}
@@ -4574,18 +4576,18 @@ mut count := 0
 	app.open_files[uri] = content
 
 	request := Request{
-		id:     33
+		id: 33
 		method: 'textDocument/inlayHint'
 		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-			range:         LSPRange{
+			range: LSPRange{
 				start: Position{
 					line: 0
 					char: 0
 				}
-				end:   Position{
+				end: Position{
 					line: 2
 					char: 0
 				}
@@ -4623,18 +4625,18 @@ const is_debug = false
 	app.open_files[uri] = content
 
 	request := Request{
-		id:     34
+		id: 34
 		method: 'textDocument/inlayHint'
 		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-			range:         LSPRange{
+			range: LSPRange{
 				start: Position{
 					line: 0
 					char: 0
 				}
-				end:   Position{
+				end: Position{
 					line: 7
 					char: 0
 				}
@@ -4678,18 +4680,18 @@ enabled   = true
 	app.open_files[uri] = content
 
 	request := Request{
-		id:     35
+		id: 35
 		method: 'textDocument/inlayHint'
 		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-			range:         LSPRange{
+			range: LSPRange{
 				start: Position{
 					line: 0
 					char: 0
 				}
-				end:   Position{
+				end: Position{
 					line: 9
 					char: 0
 				}
@@ -4729,18 +4731,18 @@ fn test_handle_inlay_hints_local_fn_call() {
 	app.open_files[uri] = 'module main\n\nfn main() {\n\tmsg := get_greeting()\n}\n'
 
 	request := Request{
-		id:     40
+		id: 40
 		method: 'textDocument/inlayHint'
 		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-			range:         LSPRange{
+			range: LSPRange{
 				start: Position{
 					line: 0
 					char: 0
 				}
-				end:   Position{
+				end: Position{
 					line: 5
 					char: 0
 				}
@@ -4774,18 +4776,18 @@ fn test_handle_inlay_hints_error_result_fn() {
 	app.open_files[uri] = 'module main\n\nfn main() {\n\tdata := read_data() or { return }\n}\n'
 
 	request := Request{
-		id:     41
+		id: 41
 		method: 'textDocument/inlayHint'
 		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-			range:         LSPRange{
+			range: LSPRange{
 				start: Position{
 					line: 0
 					char: 0
 				}
-				end:   Position{
+				end: Position{
 					line: 5
 					char: 0
 				}
@@ -4824,18 +4826,18 @@ greeting := get_greeting()
 	app.open_files[uri] = content
 
 	request := Request{
-		id:     50
+		id: 50
 		method: 'textDocument/inlayHint'
 		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-			range:         LSPRange{
+			range: LSPRange{
 				start: Position{
 					line: 0
 					char: 0
 				}
-				end:   Position{
+				end: Position{
 					line: 9
 					char: 0
 				}
@@ -5296,13 +5298,13 @@ fn test_operation_at_pos_completion_includes_current_file_fns() {
 	app.text = content
 
 	request := Request{
-		id:     1
+		id: 1
 		method: 'textDocument/completion'
 		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-			position:      Position{
+			position: Position{
 				line: 3
 				char: 4
 			}
@@ -5331,8 +5333,7 @@ fn test_operation_at_pos_dot_completion_includes_imported_module_members() {
 	mod_dir := os.join_path(test_dir, 'my_mod')
 	must_mkdir_all(mod_dir)
 
-	must_write_file(os.join_path(mod_dir, 'my_mod.v'),
-		'module my_mod\n\npub fn greet(name string) string {\n\treturn name\n}\n\nfn hidden() {}\n')
+	must_write_file(os.join_path(mod_dir, 'my_mod.v'), 'module my_mod\n\npub fn greet(name string) string {\n\treturn name\n}\n\nfn hidden() {}\n')
 
 	main_file := os.join_path(test_dir, 'main.v')
 	content := 'module main\n\nimport my_mod\n\nfn main() {\n\tmy_mod.\n}\n'
@@ -5343,13 +5344,13 @@ fn test_operation_at_pos_dot_completion_includes_imported_module_members() {
 	app.text = content
 
 	response := app.operation_at_pos(.completion, Request{
-		id:     9001
+		id: 9001
 		method: 'textDocument/completion'
 		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-			position:      Position{
+			position: Position{
 				line: 5
 				char: 8
 			}
@@ -5386,13 +5387,13 @@ fn test_operation_at_pos_dot_completion_includes_aliased_import_module_members()
 	app.text = content
 
 	response := app.operation_at_pos(.completion, Request{
-		id:     9002
+		id: 9002
 		method: 'textDocument/completion'
 		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-			position:      Position{
+			position: Position{
 				line: 5
 				char: 4
 			}
@@ -5417,7 +5418,7 @@ fn test_semantic_tokens_returns_data_for_known_content() {
 	app.open_files[uri] = content
 
 	resp := app.handle_semantic_tokens(Request{
-		id:     800
+		id: 800
 		method: 'textDocument/semanticTokens/full'
 		params: json2.encode(SemanticTokensParams{
 			text_document: TextDocumentIdentifier{
@@ -5444,7 +5445,7 @@ fn test_semantic_tokens_returns_empty_object_for_empty_file() {
 	app.open_files[uri] = ''
 
 	resp := app.handle_semantic_tokens(Request{
-		id:     801
+		id: 801
 		method: 'textDocument/semanticTokens/full'
 		params: json2.encode(SemanticTokensParams{
 			text_document: TextDocumentIdentifier{
@@ -5469,7 +5470,7 @@ fn test_semantic_tokens_range_returns_empty_for_missing_document() {
 	}
 
 	resp := app.handle_semantic_tokens_range(Request{
-		id:     802
+		id: 802
 		method: 'textDocument/semanticTokens/range'
 		params: '{}'
 	})
@@ -5495,12 +5496,12 @@ fn test_semantic_tokens_range_filters_by_character() {
 		text_document: TextDocumentIdentifier{
 			uri: uri
 		}
-		range:         LSPRange{
+		range: LSPRange{
 			start: Position{
 				line: 0
 				char: 0
 			}
-			end:   Position{
+			end: Position{
 				line: 0
 				char: 50
 			}
@@ -5509,7 +5510,7 @@ fn test_semantic_tokens_range_filters_by_character() {
 		escape_unicode: true
 	)
 	full := app.handle_semantic_tokens_range(Request{
-		id:     1
+		id: 1
 		params: full_params
 	})
 	ftok := full.result as SemanticTokens
@@ -5525,12 +5526,12 @@ fn test_semantic_tokens_range_filters_by_character() {
 		text_document: TextDocumentIdentifier{
 			uri: uri
 		}
-		range:         LSPRange{
+		range: LSPRange{
 			start: Position{
 				line: 0
 				char: 8
 			}
-			end:   Position{
+			end: Position{
 				line: 0
 				char: 50
 			}
@@ -5539,7 +5540,7 @@ fn test_semantic_tokens_range_filters_by_character() {
 		escape_unicode: true
 	)
 	narrow := app.handle_semantic_tokens_range(Request{
-		id:     2
+		id: 2
 		params: narrow_params
 	})
 	ntok := narrow.result as SemanticTokens
@@ -5561,7 +5562,7 @@ fn test_code_lens_returns_run_lens_for_main() {
 	app.open_files[uri] = content
 
 	resp := app.handle_code_lens(Request{
-		id:     810
+		id: 810
 		method: 'textDocument/codeLens'
 		params: json2.encode(CodeLensParams{
 			text_document: TextDocumentIdentifier{
@@ -5594,7 +5595,7 @@ fn test_code_lens_range_uses_negotiated_position_encoding() {
 	uri := 'file:///tmp/codelens_unicode.v'
 	app.open_files[uri] = 'module main\n\nfn main() {} // 🚀\n'
 	request := Request{
-		id:     814
+		id: 814
 		method: 'textDocument/codeLens'
 		params: json2.encode(CodeLensParams{
 			text_document: TextDocumentIdentifier{
@@ -5637,7 +5638,7 @@ fn test_code_lens_returns_test_lens_for_test_fn() {
 	app.open_files[uri] = content
 
 	resp := app.handle_code_lens(Request{
-		id:     811
+		id: 811
 		method: 'textDocument/codeLens'
 		params: json2.encode(CodeLensParams{
 			text_document: TextDocumentIdentifier{
@@ -5679,7 +5680,7 @@ fn test_code_lens_ignores_declarations_in_comments_and_non_test_files() {
 	app.open_files[uri] = 'module main\n\n/*\nfn main() {}\nfn test_hidden() {}\n*/\nfn helper() {}\n'
 
 	resp := app.handle_code_lens(Request{
-		id:     813
+		id: 813
 		method: 'textDocument/codeLens'
 		params: json2.encode(CodeLensParams{
 			text_document: TextDocumentIdentifier{
@@ -5700,25 +5701,25 @@ fn test_code_lens_resolve_returns_same_lens() {
 		cleanup_test_app(app)
 	}
 	lens := CodeLens{
-		range:   LSPRange{
+		range: LSPRange{
 			start: Position{
 				line: 2
 				char: 0
 			}
-			end:   Position{
+			end: Position{
 				line: 2
 				char: 10
 			}
 		}
 		command: Command{
-			title:     '▶ Run'
-			command:   'vls.runFile'
+			title: '▶ Run'
+			command: 'vls.runFile'
 			arguments: ['file:///tmp/a.v']
 		}
 	}
 
 	resp := app.handle_code_lens_resolve(Request{
-		id:     812
+		id: 812
 		method: 'codeLens/resolve'
 		params: json2.encode(lens, escape_unicode: true)
 	})
@@ -5739,7 +5740,7 @@ fn test_execute_command_returns_null_result() {
 
 	app.capture_output = true
 	resp := app.handle_execute_command(Request{
-		id:     820
+		id: 820
 		method: 'workspace/executeCommand'
 		params: json2.encode(ExecuteCommandParams{
 			command: 'vls.runFile'
@@ -5779,10 +5780,10 @@ fn test_execute_run_file_invokes_compiler() {
 	app.execute_commands_synchronously = true
 
 	resp := app.handle_execute_command(Request{
-		id:     822
+		id: 822
 		method: 'workspace/executeCommand'
 		params: json2.encode(ExecuteCommandParams{
-			command:   'vls.runFile'
+			command: 'vls.runFile'
 			arguments: [uri]
 		},
 			escape_unicode: true
@@ -5820,10 +5821,10 @@ fn test_execute_run_file_materializes_new_unsaved_buffer() {
 	app.execute_commands_synchronously = true
 
 	resp := app.handle_execute_command(Request{
-		id:     824
+		id: 824
 		method: 'workspace/executeCommand'
 		params: json2.encode(ExecuteCommandParams{
-			command:   'vls.runFile'
+			command: 'vls.runFile'
 			arguments: [uri]
 		},
 			escape_unicode: true
@@ -5849,10 +5850,10 @@ fn test_execute_run_file_returns_before_long_running_program_finishes() {
 
 	started_at := time.now().unix_milli()
 	resp := app.handle_execute_command(Request{
-		id:     825
+		id: 825
 		method: 'workspace/executeCommand'
 		params: json2.encode(ExecuteCommandParams{
-			command:   'vls.runFile'
+			command: 'vls.runFile'
 			arguments: [path_to_uri(path)]
 		},
 			escape_unicode: true
@@ -5889,10 +5890,10 @@ fn test_execute_run_file_replaces_active_target() {
 	app.capture_output = true
 
 	first_resp := app.handle_execute_command(Request{
-		id:     826
+		id: 826
 		method: 'workspace/executeCommand'
 		params: json2.encode(ExecuteCommandParams{
-			command:   'vls.runFile'
+			command: 'vls.runFile'
 			arguments: [uri]
 		},
 			escape_unicode: true
@@ -5911,10 +5912,10 @@ fn test_execute_run_file_replaces_active_target() {
 
 	app.open_files[uri] = 'module main\n\nimport os\nimport time\n\nfn main() {\n\tos.write_file(${marker_literal}, "second") or { return }\n\ttime.sleep(5 * time.second)\n}\n'
 	second_resp := app.handle_execute_command(Request{
-		id:     827
+		id: 827
 		method: 'workspace/executeCommand'
 		params: json2.encode(ExecuteCommandParams{
-			command:   'vls.runFile'
+			command: 'vls.runFile'
 			arguments: [uri]
 		},
 			escape_unicode: true
@@ -6003,10 +6004,10 @@ fn test_execute_run_test_selects_one_function() {
 	app.execute_commands_synchronously = true
 
 	resp := app.handle_execute_command(Request{
-		id:     823
+		id: 823
 		method: 'workspace/executeCommand'
 		params: json2.encode(ExecuteCommandParams{
-			command:   'vls.runTests'
+			command: 'vls.runTests'
 			arguments: [uri, 'test_selected']
 		},
 			escape_unicode: true
@@ -6026,7 +6027,7 @@ fn test_execute_command_unknown_still_returns_null() {
 	}
 
 	resp := app.handle_execute_command(Request{
-		id:     821
+		id: 821
 		method: 'workspace/executeCommand'
 		params: json2.encode(ExecuteCommandParams{
 			command: 'unknownCommand'
@@ -6052,18 +6053,18 @@ fn test_inline_value_returns_values_for_simple_assignment() {
 	app.open_files[uri] = content
 
 	resp := app.handle_inline_value(Request{
-		id:     830
+		id: 830
 		method: 'textDocument/inlineValue'
 		params: json2.encode(InlineValueParams{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-			range:         LSPRange{
+			range: LSPRange{
 				start: Position{
 					line: 0
 					char: 0
 				}
-				end:   Position{
+				end: Position{
 					line: 5
 					char: 0
 				}
@@ -6089,18 +6090,18 @@ fn test_inline_value_returns_empty_for_no_assignments() {
 	app.open_files[uri] = 'module main\n\nfn main() {}\n'
 
 	resp := app.handle_inline_value(Request{
-		id:     831
+		id: 831
 		method: 'textDocument/inlineValue'
 		params: json2.encode(InlineValueParams{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-			range:         LSPRange{
+			range: LSPRange{
 				start: Position{
 					line: 0
 					char: 0
 				}
-				end:   Position{
+				end: Position{
 					line: 2
 					char: 0
 				}
@@ -6129,13 +6130,13 @@ fn test_linked_editing_range_returns_ranges_for_identifier() {
 	app.open_files[uri] = content
 
 	resp := app.handle_linked_editing_range(Request{
-		id:     840
+		id: 840
 		method: 'textDocument/linkedEditingRange'
 		params: json2.encode(TextDocumentPositionParams{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-			position:      Position{
+			position: Position{
 				line: 3
 				char: 2
 			}
@@ -6161,13 +6162,13 @@ fn test_linked_editing_range_returns_null_when_not_on_identifier() {
 
 	// Position on an empty line
 	resp := app.handle_linked_editing_range(Request{
-		id:     841
+		id: 841
 		method: 'textDocument/linkedEditingRange'
 		params: json2.encode(TextDocumentPositionParams{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-			position:      Position{
+			position: Position{
 				line: 1
 				char: 0
 			}
@@ -6193,13 +6194,13 @@ fn test_selection_range_returns_one_entry_per_position() {
 	app.open_files[uri] = content
 
 	resp := app.handle_selection_range(Request{
-		id:     850
+		id: 850
 		method: 'textDocument/selectionRange'
 		params: json2.encode(SelectionRangeParams{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-			positions:     [Position{
+			positions: [Position{
 				line: 3
 				char: 2
 			}, Position{
@@ -6227,13 +6228,13 @@ fn test_selection_range_word_range_has_parent_line_range() {
 	app.open_files[uri] = content
 
 	resp := app.handle_selection_range(Request{
-		id:     851
+		id: 851
 		method: 'textDocument/selectionRange'
 		params: json2.encode(SelectionRangeParams{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-			positions:     [Position{
+			positions: [Position{
 				line: 3
 				char: 2
 			}]
@@ -6261,17 +6262,17 @@ fn test_on_type_formatting_returns_empty_edits() {
 	}
 
 	resp := app.handle_on_type_formatting(Request{
-		id:     860
+		id: 860
 		method: 'textDocument/onTypeFormatting'
 		params: json2.encode(OnTypeFormattingParams{
 			text_document: TextDocumentIdentifier{
 				uri: 'file:///tmp/fmt.v'
 			}
-			position:      Position{
+			position: Position{
 				line: 3
 				char: 0
 			}
-			ch:            '}'
+			ch: '}'
 		},
 			escape_unicode: true
 		)
@@ -6301,19 +6302,19 @@ fn test_call_hierarchy_outgoing_returns_callees() {
 	app.workspace_roots = [root]
 
 	resp := app.handle_call_hierarchy_outgoing(Request{
-		id:     870
+		id: 870
 		method: 'callHierarchy/outgoingCalls'
 		params: json2.encode(CallHierarchyOutgoingCallsParams{
 			item: CallHierarchyItem{
-				name:            'main'
-				kind:            sym_kind_function
-				uri:             uri
-				range:           LSPRange{
+				name: 'main'
+				kind: sym_kind_function
+				uri: uri
+				range: LSPRange{
 					start: Position{
 						line: 4
 						char: 0
 					}
-					end:   Position{
+					end: Position{
 						line: 6
 						char: 1
 					}
@@ -6323,7 +6324,7 @@ fn test_call_hierarchy_outgoing_returns_callees() {
 						line: 4
 						char: 3
 					}
-					end:   Position{
+					end: Position{
 						line: 4
 						char: 7
 					}
@@ -6356,19 +6357,19 @@ fn test_call_hierarchy_incoming_returns_callers() {
 	app.workspace_roots = [root]
 
 	resp := app.handle_call_hierarchy_incoming(Request{
-		id:     871
+		id: 871
 		method: 'callHierarchy/incomingCalls'
 		params: json2.encode(CallHierarchyIncomingCallsParams{
 			item: CallHierarchyItem{
-				name:            'helper'
-				kind:            sym_kind_function
-				uri:             uri
-				range:           LSPRange{
+				name: 'helper'
+				kind: sym_kind_function
+				uri: uri
+				range: LSPRange{
 					start: Position{
 						line: 2
 						char: 0
 					}
-					end:   Position{
+					end: Position{
 						line: 2
 						char: 15
 					}
@@ -6378,7 +6379,7 @@ fn test_call_hierarchy_incoming_returns_callers() {
 						line: 2
 						char: 3
 					}
-					end:   Position{
+					end: Position{
 						line: 2
 						char: 9
 					}
@@ -6409,11 +6410,11 @@ fn test_organize_imports_refuses_non_contiguous_block() {
 		text_document: TextDocumentIdentifier{
 			uri: uri
 		}
-		range:         LSPRange{}
-		context:       CodeActionContext{}
+		range: LSPRange{}
+		context: CodeActionContext{}
 	}
 	resp := app.handle_code_action(Request{
-		id:     1
+		id: 1
 		params: json2.encode(params, escape_unicode: true)
 	})
 	assert resp.result is []CodeAction
@@ -6434,11 +6435,11 @@ fn test_organize_imports_sorts_contiguous_block() {
 		text_document: TextDocumentIdentifier{
 			uri: uri
 		}
-		range:         LSPRange{}
-		context:       CodeActionContext{}
+		range: LSPRange{}
+		context: CodeActionContext{}
 	}
 	resp := app.handle_code_action(Request{
-		id:     2
+		id: 2
 		params: json2.encode(params, escape_unicode: true)
 	})
 	assert resp.result is []CodeAction
@@ -6465,13 +6466,13 @@ fn test_organize_imports_preserves_crlf_line_endings() {
 	uri := 'file:///tmp/oi_crlf.v'
 	app.open_files[uri] = 'module main\r\n\r\nimport time\r\nimport os\r\n\r\nfn main() {}\r\n'
 	resp := app.handle_code_action(Request{
-		id:     3
+		id: 3
 		params: json2.encode(CodeActionParams{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-			range:         LSPRange{}
-			context:       CodeActionContext{}
+			range: LSPRange{}
+			context: CodeActionContext{}
 		},
 			escape_unicode: true
 		)
@@ -6507,12 +6508,12 @@ fn test_remove_unknown_import_range_at_eof_without_newline() {
 	app.open_files[uri] = 'module main\nimport foo'
 	diag := LSPDiagnostic{
 		message: 'cannot import module "foo" (not found)'
-		range:   LSPRange{
+		range: LSPRange{
 			start: Position{
 				line: 1
 				char: 0
 			}
-			end:   Position{
+			end: Position{
 				line: 1
 				char: 10
 			}
@@ -6522,13 +6523,13 @@ fn test_remove_unknown_import_range_at_eof_without_newline() {
 		text_document: TextDocumentIdentifier{
 			uri: uri
 		}
-		range:         LSPRange{}
-		context:       CodeActionContext{
+		range: LSPRange{}
+		context: CodeActionContext{
 			diagnostics: [diag]
 		}
 	}
 	resp := app.handle_code_action(Request{
-		id:     1
+		id: 1
 		params: json2.encode(params, escape_unicode: true)
 	})
 	actions := resp.result as []CodeAction
@@ -6559,12 +6560,12 @@ fn test_remove_unknown_import_range_with_trailing_newline() {
 	app.open_files[uri] = 'import foo\nmodule main\n'
 	diag := LSPDiagnostic{
 		message: 'unknown module `foo`'
-		range:   LSPRange{
+		range: LSPRange{
 			start: Position{
 				line: 0
 				char: 0
 			}
-			end:   Position{
+			end: Position{
 				line: 0
 				char: 10
 			}
@@ -6574,13 +6575,13 @@ fn test_remove_unknown_import_range_with_trailing_newline() {
 		text_document: TextDocumentIdentifier{
 			uri: uri
 		}
-		range:         LSPRange{}
-		context:       CodeActionContext{
+		range: LSPRange{}
+		context: CodeActionContext{
 			diagnostics: [diag]
 		}
 	}
 	resp := app.handle_code_action(Request{
-		id:     1
+		id: 1
 		params: json2.encode(params, escape_unicode: true)
 	})
 	actions := resp.result as []CodeAction
@@ -6688,7 +6689,7 @@ fn test_apply_incremental_change_non_bmp_utf16() {
 			line: 0
 			char: 3 // after 🚀 in UTF-16 units (a=1, 🚀=2)
 		}
-		end:   Position{
+		end: Position{
 			line: 0
 			char: 4
 		}
@@ -6784,13 +6785,13 @@ fn test_document_highlight_returns_empty_over_semantic_cap() {
 	app.open_files[uri] = content
 
 	response := app.handle_document_highlight(Request{
-		id:     900
+		id: 900
 		method: 'textDocument/documentHighlight'
 		params: json2.encode(DocumentHighlightParams{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-			position:      Position{
+			position: Position{
 				line: 3
 				char: 5
 			}
@@ -6816,19 +6817,19 @@ fn test_on_did_change_invalid_range_does_not_advance_version() {
 	// must NOT advance (P0-07).
 	app.on_did_change(Request{
 		params: json2.encode(DidChangeTextDocumentParams{
-			text_document:   VersionedTextDocumentIdentifier{
-				uri:     uri
+			text_document: VersionedTextDocumentIdentifier{
+				uri: uri
 				version: 2
 			}
 			content_changes: [
 				ContentChange{
-					text:  'X'
+					text: 'X'
 					range: LSPRange{
 						start: Position{
 							line: 0
 							char: 5
 						}
-						end:   Position{
+						end: Position{
 							line: 0
 							char: 2
 						}
@@ -6876,13 +6877,13 @@ fn test_operation_at_pos_hover_returns_symbol_information() {
 	app.text = content
 
 	response := app.operation_at_pos(.hover, Request{
-		id:     901
+		id: 901
 		method: 'textDocument/hover'
 		params: json2.encode(TextDocumentPositionParams{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-			position:      Position{
+			position: Position{
 				line: 8
 				char: 13
 			}
@@ -6914,17 +6915,17 @@ fn test_find_references_returns_declaration_and_calls() {
 	app.workspace_roots = [test_dir]
 
 	response := app.find_references(Request{
-		id:     902
+		id: 902
 		method: 'textDocument/references'
 		params: json2.encode(ReferenceParams{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-			position:      Position{
+			position: Position{
 				line: 7
 				char: 10
 			}
-			context:       ReferenceContext{
+			context: ReferenceContext{
 				include_declaration: true
 			}
 		},
@@ -6958,17 +6959,17 @@ fn test_handle_rename_returns_complete_workspace_edit() {
 	app.workspace_roots = [test_dir]
 
 	response := app.handle_rename(Request{
-		id:     903
+		id: 903
 		method: 'textDocument/rename'
 		params: json2.encode(RenameParams{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-			position:      Position{
+			position: Position{
 				line: 7
 				char: 11
 			}
-			new_name:      'renamed_value'
+			new_name: 'renamed_value'
 		},
 			escape_unicode: true
 		)
@@ -6998,7 +6999,7 @@ fn test_folding_range_covers_imports_comments_and_code_blocks() {
 	app.open_files[uri] = 'module main\n\nimport os\nimport time\n\n// first line\n// second line\n\nfn main() {\n\tprintln(os.args)\n}\n'
 
 	response := app.handle_folding_range(Request{
-		id:     904
+		id: 904
 		method: 'textDocument/foldingRange'
 		params: json2.encode(FoldingRangeParams{
 			text_document: TextDocumentIdentifier{
@@ -7031,13 +7032,13 @@ fn test_document_highlight_returns_reads_and_writes() {
 	app.open_files[uri] = content
 
 	response := app.handle_document_highlight(Request{
-		id:     905
+		id: 905
 		method: 'textDocument/documentHighlight'
 		params: json2.encode(DocumentHighlightParams{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-			position:      Position{
+			position: Position{
 				line: 3
 				char: 2
 			}
@@ -7071,15 +7072,15 @@ fn test_workspace_configuration_toggles_feature_behavior() {
 	assert !app.diagnostics_enabled
 
 	hint_response := app.handle_inlay_hints(Request{
-		id:     906
+		id: 906
 		method: 'textDocument/inlayHint'
 		params: json2.encode(InlayHintParams{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-			range:         LSPRange{
+			range: LSPRange{
 				start: Position{}
-				end:   Position{
+				end: Position{
 					line: 5
 				}
 			}
@@ -7162,13 +7163,13 @@ fn test_will_save_wait_until_formats_without_mutating_open_document() {
 	app.open_files[uri] = content
 
 	response := app.on_will_save_wait_until(Request{
-		id:     907
+		id: 907
 		method: 'textDocument/willSaveWaitUntil'
 		params: json2.encode(WillSaveTextDocumentParams{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-			reason:        1
+			reason: 1
 		},
 			escape_unicode: true
 		)
@@ -7196,22 +7197,22 @@ fn test_range_formatting_returns_only_contained_changed_hunk() {
 	app.open_files[uri] = content
 
 	response := app.handle_range_formatting(Request{
-		id:     908
+		id: 908
 		method: 'textDocument/rangeFormatting'
 		params: json2.encode(DocumentRangeFormattingParams{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-			range:         LSPRange{
+			range: LSPRange{
 				start: Position{
 					line: 3
 				}
-				end:   Position{
+				end: Position{
 					line: 3
 					char: 4
 				}
 			}
-			options:       FormattingOptions{
+			options: FormattingOptions{
 				tab_size: 4
 			}
 		},
@@ -7237,13 +7238,13 @@ fn test_prepare_call_hierarchy_returns_function_item() {
 	app.open_files[uri] = 'module main\n\nfn helper() {}\n\nfn main() {\n\thelper()\n}\n'
 
 	response := app.handle_prepare_call_hierarchy(Request{
-		id:     909
+		id: 909
 		method: 'textDocument/prepareCallHierarchy'
 		params: json2.encode(PrepareCallHierarchyParams{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-			position:      Position{
+			position: Position{
 				line: 5
 				char: 2
 			}

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -5864,7 +5864,11 @@ fn test_execute_run_file_returns_before_long_running_program_finishes() {
 	assert resp.result is string
 	assert (resp.result as string) == 'null'
 	assert elapsed_ms < 1000
-	deadline := time.now().unix_milli() + 10_000
+	mut startup_timeout_ms := 10_000
+	$if windows {
+		startup_timeout_ms = 30_000
+	}
+	deadline := time.now().unix_milli() + startup_timeout_ms
 	for !os.exists(marker_path) && time.now().unix_milli() < deadline {
 		time.sleep(10 * time.millisecond)
 	}
@@ -5976,14 +5980,16 @@ fn test_code_lens_source_paths_are_rewritten_only_in_code() {
 	source_path := os.join_path(project_dir, 'main.v')
 	temp_source_path := os.join_path(app.temp_dir, 'overlay', 'main.v')
 	source := 'const source_file = @FILE\nconst source_dir = @DIR\nconst project = @VMODROOT\nconst manifest = @VMOD_FILE\nconst file_line = @FILE_LINE\nconst location = @LOCATION\nconst column = @FILE + @COLUMN\nconst literal = "@FILE @DIR @VMODROOT @VMOD_FILE @FILE_LINE @LOCATION @COLUMN"\n// @FILE @DIR @VMODROOT @VMOD_FILE @FILE_LINE @LOCATION @COLUMN\n#flag -I @VMODROOT/thirdparty\n'
-	rewritten := code_lens_source_with_original_pseudos(source, source_path, temp_source_path)
+	rewritten := code_lens_source_with_original_pseudos(source, source_path, temp_source_path, os.dir(temp_source_path))
 
 	assert rewritten.contains('const source_file = ${code_lens_v_string_literal(os.real_path(source_path))}')
 	assert rewritten.contains('const source_dir = ${code_lens_v_string_literal(os.real_path(project_dir))}')
 	assert rewritten.contains('const project = ${code_lens_v_string_literal(os.real_path(project_dir))}')
 	assert rewritten.contains('const manifest = ${code_lens_v_string_literal(vmod_source)}')
 	assert rewritten.contains("const file_line = 'main.v:5'")
-	assert rewritten.contains('const location = (@LOCATION.replace(${code_lens_v_string_literal(temp_source_path)}, ${code_lens_v_string_literal(os.real_path(source_path))}))')
+	assert rewritten.contains('const location = (@LOCATION.replace(')
+	assert rewritten.contains(code_lens_v_string_literal('.\\main.v'))
+	assert rewritten.contains(code_lens_v_string_literal('./main.v'))
 	assert rewritten.contains("const column = ${code_lens_v_string_literal(os.real_path(source_path))} + '24'")
 	assert rewritten.contains('const literal = "@FILE @DIR @VMODROOT @VMOD_FILE @FILE_LINE @LOCATION @COLUMN"')
 	assert rewritten.contains('// @FILE @DIR @VMODROOT @VMOD_FILE @FILE_LINE @LOCATION @COLUMN')

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -2668,7 +2668,7 @@ fn test_source_declaration_at_stops_non_braced_declarations() {
 		cleanup_test_app(app)
 	}
 	uri := 'file:///tmp/source_declaration_fallback.v'
-	content := 'module main\n\nconst (\n\tanswer = 42\n\tother = 7\n)\n\ntype Alias = int\ntype Handler = fn (int) bool\n\nfn next() {}\n\nfn parse(\n\tvalue string,\n) !int {\n}\n'
+	content := 'module main\n\nconst (\n\tanswer = 42\n\tother = 7\n)\n\ntype Alias = int\ntype Handler = fn (int) bool\n\nfn next() {}\n\nfn parse(\n\tvalue string, // explanation\n\tradix int,\n) !int {\n}\n'
 	app.open_files[uri] = content
 
 	constant := app.source_declaration_at(Location{
@@ -2709,7 +2709,10 @@ fn test_source_declaration_at_stops_non_braced_declarations() {
 			}
 		}
 	})
-	assert function == 'fn parse( value string, ) !int'
+	assert function == 'fn parse(\nvalue string, // explanation\nradix int,\n) !int'
+	label := declaration_signature_label(function, 'parse')
+	assert label == 'parse(\nvalue string, // explanation\nradix int,\n) !int'
+	assert signature_parameters(label).len == 2
 }
 
 fn test_resolve_indexed_definition_prefers_source_relative_module() {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -2578,6 +2578,40 @@ fn test_resolve_indexed_definition_prefers_workspace_vlib() {
 	assert location.range.start.line == 2
 }
 
+fn test_source_call_target_ignores_non_code_delimiters() {
+	literal_line := "foo(')')"
+	literal_target := source_call_target(literal_line, literal_line.len - 1, .utf8) or {
+		assert false, 'expected call target with a parenthesis in a string literal'
+		return
+	}
+	assert literal_target.position.char == 2
+	assert literal_target.active_parameter == 0
+
+	raw_line := "foo(r')')"
+	raw_target := source_call_target(raw_line, raw_line.len - 1, .utf8) or {
+		assert false, 'expected call target with a parenthesis in a raw string literal'
+		return
+	}
+	assert raw_target.position.char == 2
+	assert raw_target.active_parameter == 0
+
+	comment_line := 'foo(/* ) */ value)'
+	comment_target := source_call_target(comment_line, comment_line.len - 1, .utf8) or {
+		assert false, 'expected call target with a parenthesis in a comment'
+		return
+	}
+	assert comment_target.position.char == 2
+	assert comment_target.active_parameter == 0
+
+	comma_line := "foo('last, first', value)"
+	comma_target := source_call_target(comma_line, comma_line.len - 1, .utf8) or {
+		assert false, 'expected call target with a comma in a string literal'
+		return
+	}
+	assert comma_target.position.char == 2
+	assert comma_target.active_parameter == 1
+}
+
 fn test_resolve_indexed_definition_prefers_source_relative_module() {
 	mut app := create_test_app()
 	defer {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -5845,7 +5845,7 @@ fn test_execute_run_file_returns_before_long_running_program_finishes() {
 	}
 	path := os.join_path(app.temp_dir, 'code_lens_long_running.v')
 	marker_path := os.join_path(app.temp_dir, 'code_lens_long_running.started')
-	must_write_file(path, 'module main\n\nimport os\nimport time\n\nfn main() {\n\t_ := os.input("")\n\tos.write_file("${marker_path}", "started") or {}\n\ttime.sleep(5 * time.second)\n}\n')
+	must_write_file(path, 'module main\n\nimport os\nimport time\n\nfn main() {\n\tos.write_file("${marker_path}", "started") or {}\n\t_ := os.input("")\n\ttime.sleep(5 * time.second)\n}\n')
 	app.capture_output = true
 
 	started_at := time.now().unix_milli()

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -5845,7 +5845,8 @@ fn test_execute_run_file_returns_before_long_running_program_finishes() {
 	}
 	path := os.join_path(app.temp_dir, 'code_lens_long_running.v')
 	marker_path := os.join_path(app.temp_dir, 'code_lens_long_running.started')
-	must_write_file(path, 'module main\n\nimport os\nimport time\n\nfn main() {\n\tos.write_file("${marker_path}", "started") or {}\n\t_ := os.input("")\n\ttime.sleep(5 * time.second)\n}\n')
+	marker_literal := code_lens_v_string_literal(marker_path)
+	must_write_file(path, 'module main\n\nimport os\nimport time\n\nfn main() {\n\tos.write_file(${marker_literal}, "started") or {}\n\t_ := os.input("")\n\ttime.sleep(5 * time.second)\n}\n')
 	app.capture_output = true
 
 	started_at := time.now().unix_milli()

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -6002,10 +6002,8 @@ fn test_execute_run_file_returns_before_long_running_program_finishes() {
 	assert resp.result is string
 	assert (resp.result as string) == 'null'
 	assert elapsed_ms < 1000
-	mut startup_timeout_ms := 10_000
-	$if windows {
-		startup_timeout_ms = 30_000
-	}
+	// V3 compilation can take more than 10 seconds on loaded CI runners.
+	startup_timeout_ms := 30_000
 	deadline := time.now().unix_milli() + startup_timeout_ms
 	for !os.exists(marker_path) && time.now().unix_milli() < deadline {
 		time.sleep(10 * time.millisecond)

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -2580,7 +2580,9 @@ fn test_resolve_indexed_definition_prefers_workspace_vlib() {
 
 fn test_source_call_target_ignores_non_code_delimiters() {
 	literal_line := "foo(')')"
-	literal_target := source_call_target(literal_line, literal_line.len - 1, .utf8) or {
+	literal_target := source_call_target(literal_line, Position{
+		char: literal_line.len - 1
+	}, .utf8) or {
 		assert false, 'expected call target with a parenthesis in a string literal'
 		return
 	}
@@ -2588,7 +2590,9 @@ fn test_source_call_target_ignores_non_code_delimiters() {
 	assert literal_target.active_parameter == 0
 
 	raw_line := "foo(r')')"
-	raw_target := source_call_target(raw_line, raw_line.len - 1, .utf8) or {
+	raw_target := source_call_target(raw_line, Position{
+		char: raw_line.len - 1
+	}, .utf8) or {
 		assert false, 'expected call target with a parenthesis in a raw string literal'
 		return
 	}
@@ -2596,7 +2600,9 @@ fn test_source_call_target_ignores_non_code_delimiters() {
 	assert raw_target.active_parameter == 0
 
 	comment_line := 'foo(/* ) */ value)'
-	comment_target := source_call_target(comment_line, comment_line.len - 1, .utf8) or {
+	comment_target := source_call_target(comment_line, Position{
+		char: comment_line.len - 1
+	}, .utf8) or {
 		assert false, 'expected call target with a parenthesis in a comment'
 		return
 	}
@@ -2604,12 +2610,106 @@ fn test_source_call_target_ignores_non_code_delimiters() {
 	assert comment_target.active_parameter == 0
 
 	comma_line := "foo('last, first', value)"
-	comma_target := source_call_target(comma_line, comma_line.len - 1, .utf8) or {
+	comma_target := source_call_target(comma_line, Position{
+		char: comma_line.len - 1
+	}, .utf8) or {
 		assert false, 'expected call target with a comma in a string literal'
 		return
 	}
 	assert comma_target.position.char == 2
 	assert comma_target.active_parameter == 1
+}
+
+fn test_source_call_target_handles_multiline_and_generic_calls() {
+	generic_line := 'convert[int](value)'
+	generic_target := source_call_target(generic_line, Position{
+		char: generic_line.len - 1
+	}, .utf8) or {
+		assert false, 'expected call target before explicit generic arguments'
+		return
+	}
+	assert generic_target.position == Position{
+		line: 0
+		char: 2
+	}
+
+	multiline := "fn main() {\n\tfoo(\n\t\tfirst,\n\t\t'last, )'\n\t)\n}"
+	cursor_line := "\t\t'last, )'"
+	multiline_target := source_call_target(multiline, Position{
+		line: 3
+		char: cursor_line.len
+	}, .utf8) or {
+		assert false, 'expected call target on a preceding line'
+		return
+	}
+	assert multiline_target.position == Position{
+		line: 1
+		char: 3
+	}
+	assert multiline_target.active_parameter == 1
+}
+
+fn test_declaration_signature_label_keeps_generics_and_return_type() {
+	declaration := 'pub fn convert[T](value T) !T'
+	assert declaration_signature_label(declaration, 'convert') == 'convert[T](value T) !T'
+	assert declaration_signature_label('fn parse(value string) ?int', 'parse') == 'parse(value string) ?int'
+}
+
+fn test_signature_parameters_split_only_top_level_commas() {
+	parameters := signature_parameters('apply(cb fn (int, string), value int) !bool')
+	assert parameters.len == 2
+	assert parameters[0].label == 'cb fn (int, string)'
+	assert parameters[1].label == 'value int'
+}
+
+fn test_source_declaration_at_stops_non_braced_declarations() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	uri := 'file:///tmp/source_declaration_fallback.v'
+	content := 'module main\n\nconst (\n\tanswer = 42\n\tother = 7\n)\n\ntype Alias = int\ntype Handler = fn (int) bool\n\nfn next() {}\n\nfn parse(\n\tvalue string,\n) !int {\n}\n'
+	app.open_files[uri] = content
+
+	constant := app.source_declaration_at(Location{
+		uri: uri
+		range: LSPRange{
+			start: Position{
+				line: 3
+			}
+		}
+	})
+	assert constant == 'answer = 42'
+
+	alias := app.source_declaration_at(Location{
+		uri: uri
+		range: LSPRange{
+			start: Position{
+				line: 7
+			}
+		}
+	})
+	assert alias == 'type Alias = int'
+
+	function_alias := app.source_declaration_at(Location{
+		uri: uri
+		range: LSPRange{
+			start: Position{
+				line: 8
+			}
+		}
+	})
+	assert function_alias == 'type Handler = fn (int) bool'
+
+	function := app.source_declaration_at(Location{
+		uri: uri
+		range: LSPRange{
+			start: Position{
+				line: 12
+			}
+		}
+	})
+	assert function == 'fn parse( value string, ) !int'
 }
 
 fn test_resolve_indexed_definition_prefers_source_relative_module() {

--- a/index.v
+++ b/index.v
@@ -463,7 +463,7 @@ const index_excluded_dirs = ['.git', '.svn', '.hg', 'node_modules', '.vmodules',
 // root. This models the nearest V project root (audit P1-01).
 fn find_project_root(dir string) string {
 	mut d := dir
-	for d != '' && d != '/' {
+	for d != '' && d != '/' && d != '.' {
 		if os.exists(os.join_path(d, 'v.mod')) {
 			return d
 		}

--- a/index.v
+++ b/index.v
@@ -20,9 +20,9 @@ import time
 struct IndexEntry {
 	fingerprint    int // content.hash(); used to skip re-parsing unchanged files
 	module_name    string
-	doc_symbols    []DocumentSymbol  // hierarchical symbols (as parse_document_symbols returns)
+	doc_symbols    []DocumentSymbol // hierarchical symbols (as parse_document_symbols returns)
 	docs           map[string]string // simple symbol name -> leading vdoc comment
-	fn_completions []Detail          // free-function completion items for this file
+	fn_completions []Detail // free-function completion items for this file
 }
 
 // build_index_entry parses `content` into an IndexEntry. Symbol ranges are
@@ -43,10 +43,10 @@ fn build_index_entry(content string, enc PositionEncoding) IndexEntry {
 		}
 	}
 	return IndexEntry{
-		fingerprint:    content.hash()
-		module_name:    get_module_name(content)
-		doc_symbols:    doc_syms
-		docs:           docs
+		fingerprint: content.hash()
+		module_name: get_module_name(content)
+		doc_symbols: doc_syms
+		docs: docs
 		fn_completions: parse_module_fn_completions(content)
 	}
 }
@@ -61,12 +61,12 @@ fn encode_document_symbols(syms []DocumentSymbol, lines []string, enc PositionEn
 	mut out := []DocumentSymbol{cap: syms.len}
 	for sym in syms {
 		out << DocumentSymbol{
-			name:            sym.name
-			kind:            sym.kind
-			tags:            sym.tags
-			range:           encode_range_chars(sym.range, lines, enc)
+			name: sym.name
+			kind: sym.kind
+			tags: sym.tags
+			range: encode_range_chars(sym.range, lines, enc)
 			selection_range: encode_range_chars(sym.selection_range, lines, enc)
-			children:        encode_document_symbols(sym.children, lines, enc)
+			children: encode_document_symbols(sym.children, lines, enc)
 		}
 	}
 	return out
@@ -90,7 +90,7 @@ fn encode_range_chars(r LSPRange, lines []string, enc PositionEncoding) LSPRange
 			line: r.start.line
 			char: byte_to_encoded_col(start_line, r.start.char, enc)
 		}
-		end:   Position{
+		end: Position{
 			line: r.end.line
 			char: byte_to_encoded_col(end_line, r.end.char, enc)
 		}
@@ -142,9 +142,9 @@ fn add_identifier_occurrence(line_text string, line_idx int, start int, end int,
 	}
 	name := line_text[start..end]
 	occ[name] << TokenOccurrence{
-		line:       line_idx
+		line: line_idx
 		start_char: byte_to_encoded_col(line_text, start, enc)
-		end_char:   byte_to_encoded_col(line_text, end, enc)
+		end_char: byte_to_encoded_col(line_text, end, enc)
 	}
 }
 
@@ -175,8 +175,7 @@ fn scan_literal_identifier_occurrences(line_text string, line_idx int, start int
 			state.interpolations << OccurrenceInterpolationState{
 				quote: quote
 			}
-			return scan_code_identifier_occurrences(line_text, line_idx, col + 2, enc, mut state, mut
-				occ)
+			return scan_code_identifier_occurrences(line_text, line_idx, col + 2, enc, mut state, mut occ)
 		}
 		col++
 	}
@@ -190,8 +189,7 @@ fn scan_code_identifier_occurrences(line_text string, line_idx int, start int, e
 	mut col := start
 	for col < line_text.len {
 		if state.quote != 0 {
-			col = scan_literal_identifier_occurrences(line_text, line_idx, col, enc, mut state, mut
-				occ)
+			col = scan_literal_identifier_occurrences(line_text, line_idx, col, enc, mut state, mut occ)
 			continue
 		}
 		c := line_text[col]
@@ -220,8 +218,7 @@ fn scan_code_identifier_occurrences(line_text string, line_idx int, start int, e
 		if c in [`r`, `c`] && col + 1 < line_text.len
 			&& (line_text[col + 1] == `"` || line_text[col + 1] == `'`) {
 			state.raw_string = c == `r`
-			col = scan_literal_identifier_occurrences(line_text, line_idx, col + 1, enc, mut state, mut
-				occ)
+			col = scan_literal_identifier_occurrences(line_text, line_idx, col + 1, enc, mut state, mut occ)
 			continue
 		}
 		if c == `"` || c == `'` || c == 96 {
@@ -294,7 +291,7 @@ fn (mut app App) occurrences_for(uri string) map[string][]TokenOccurrence {
 	occ := extract_identifier_occurrences(content, app.position_encoding)
 	app.ref_occurrences[uri] = OccEntry{
 		fingerprint: fp
-		occ:         occ
+		occ: occ
 	}
 	return occ
 }
@@ -752,13 +749,13 @@ fn (app &App) index_scope_for_uri(uri string) IndexScope {
 	if project_root != '' && project_root != '/'
 		&& (workspace_root == '' || path_is_within(project_root, workspace_root)) {
 		return IndexScope{
-			dir:       project_root
+			dir: project_root
 			recursive: true
 		}
 	}
 	if workspace_root != '' {
 		return IndexScope{
-			dir:       workspace_root
+			dir: workspace_root
 			recursive: true
 		}
 	}
@@ -940,13 +937,11 @@ fn (app &App) query_workspace_symbols(query string) []WorkspaceSymbol {
 		entry := app.symbol_index[uri] or { continue }
 		for sym in entry.doc_symbols {
 			if q == '' || sym.name.to_lower().contains(q) {
-				add_workspace_symbol(mut results, mut seen, sym.name, sym.kind, uri,
-					sym.selection_range)
+				add_workspace_symbol(mut results, mut seen, sym.name, sym.kind, uri, sym.selection_range)
 			}
 			for child in sym.children {
 				if q == '' || child.name.to_lower().contains(q) {
-					add_workspace_symbol(mut results, mut seen, '${sym.name}.${child.name}',
-						child.kind, uri, child.selection_range)
+					add_workspace_symbol(mut results, mut seen, '${sym.name}.${child.name}', child.kind, uri, child.selection_range)
 				}
 			}
 		}

--- a/index_test.v
+++ b/index_test.v
@@ -9,7 +9,7 @@ import time
 fn index_test_app() &App {
 	return &App{
 		open_files: map[string]string{}
-		temp_dir:   os.temp_dir()
+		temp_dir: os.temp_dir()
 	}
 }
 
@@ -105,7 +105,7 @@ fn test_watched_file_reindex_drops_oversized_disk_entry() {
 	app.on_did_change_watched_files(Request{
 		params: json2.encode(DidChangeWatchedFilesParams{
 			changes: [FileEvent{
-				uri:        uri
+				uri: uri
 				event_type: 1
 			}]
 		})
@@ -121,7 +121,7 @@ fn test_watched_file_reindex_drops_oversized_disk_entry() {
 	app.on_did_change_watched_files(Request{
 		params: json2.encode(DidChangeWatchedFilesParams{
 			changes: [FileEvent{
-				uri:        uri
+				uri: uri
 				event_type: 2
 			}]
 		})
@@ -148,7 +148,7 @@ fn test_watched_file_reindex_obeys_total_entry_limit() {
 	app.on_did_change_watched_files(Request{
 		params: json2.encode(DidChangeWatchedFilesParams{
 			changes: [FileEvent{
-				uri:        uri
+				uri: uri
 				event_type: 1
 			}]
 		})
@@ -177,7 +177,7 @@ fn test_watched_file_reuses_equivalent_open_document_uri() {
 	app.on_did_change_watched_files(Request{
 		params: json2.encode(DidChangeWatchedFilesParams{
 			changes: [FileEvent{
-				uri:        event_uri
+				uri: event_uri
 				event_type: 2
 			}]
 		})
@@ -1020,15 +1020,14 @@ fn test_index_large_multifile_project_stays_complete_and_incremental() {
 
 	changed_path := os.join_path(root, 'module_14', 'file_0749.v')
 	changed_uri := path_to_uri(changed_path)
-	os.write_file(changed_path,
-		'module large_index_test\n\nfn stress_symbol_reindexed() int {\n\treturn 749\n}\n') or {
+	os.write_file(changed_path, 'module large_index_test\n\nfn stress_symbol_reindexed() int {\n\treturn 749\n}\n') or {
 		assert false, 'rewrite stress file failed: ${err}'
 		return
 	}
 	app.on_did_change_watched_files(Request{
 		params: json2.encode(DidChangeWatchedFilesParams{
 			changes: [FileEvent{
-				uri:        changed_uri
+				uri: changed_uri
 				event_type: 2
 			}]
 		})
@@ -1068,8 +1067,7 @@ fn test_large_vlang_v_workspace_from_env() {
 
 	if main_uri, main_symbol := app.find_indexed_fn('main', false, [
 		os.join_path(root, 'cmd'),
-	])
-	{
+	]) {
 		assert main_uri.starts_with(path_to_uri(os.join_path(root, 'cmd')))
 		assert main_symbol.name == 'main'
 	} else {

--- a/integration_test.v
+++ b/integration_test.v
@@ -32,9 +32,9 @@ fn create_integration_test_env() (&App, string) {
 	integration_test_must_mkdir_all(project_dir)
 
 	app := &App{
-		text:       ''
+		text: ''
 		open_files: map[string]string{}
-		temp_dir:   temp_dir
+		temp_dir: temp_dir
 	}
 	return app, project_dir
 }
@@ -47,20 +47,20 @@ fn cleanup_integration_test_env(_ &App, project_dir string) {
 fn test_integration_initialize_capabilities() {
 	// Simulate what the server returns for initialize
 	response := Response{
-		id:     0
+		id: 0
 		result: Capabilities{
 			capabilities: Capability{
-				text_document_sync:      TextDocumentSyncOptions{
+				text_document_sync: TextDocumentSyncOptions{
 					open_close: true
-					change:     1
+					change: 1
 				}
-				completion_provider:     CompletionProvider{
+				completion_provider: CompletionProvider{
 					trigger_characters: ['.']
 				}
 				signature_help_provider: SignatureHelpOptions{
 					trigger_characters: ['(', ',']
 				}
-				definition_provider:     true
+				definition_provider: true
 			}
 		}
 	}
@@ -81,7 +81,7 @@ fn test_integration_initialize_capabilities() {
 fn test_integration_initialize_response_structure() {
 	// Verify response has proper JSON-RPC structure
 	response := Response{
-		id:     0
+		id: 0
 		result: Capabilities{
 			capabilities: Capability{
 				definition_provider: true
@@ -99,7 +99,7 @@ fn test_integration_initialize_response_structure() {
 
 fn test_integration_initialize_does_not_advertise_client_snippet_support() {
 	response := Response{
-		id:     0
+		id: 0
 		result: Capabilities{
 			capabilities: Capability{
 				completion_provider: CompletionProvider{
@@ -115,14 +115,14 @@ fn test_integration_initialize_does_not_advertise_client_snippet_support() {
 
 fn test_integration_initialize_workspace_capabilities() {
 	response := Response{
-		id:     0
+		id: 0
 		result: Capabilities{
 			capabilities: Capability{
 				execute_command_provider: ExecuteCommandOptions{
 					commands: ['vls.runFile', 'vls.runTests']
 				}
-				workspace:                WorkspaceCapability{
-					file_operations:   WorkspaceFileOperations{
+				workspace: WorkspaceCapability{
+					file_operations: WorkspaceFileOperations{
 						will_create: FileOperationRegistrationOptions{
 							filters: [
 								FileOperationFilter{
@@ -152,7 +152,7 @@ fn test_integration_initialize_workspace_capabilities() {
 						}
 					}
 					workspace_folders: WorkspaceFoldersServerCapability{
-						supported:            true
+						supported: true
 						change_notifications: true
 					}
 				}
@@ -183,10 +183,10 @@ fn test_integration_document_lifecycle() {
 
 	// 1. Open document
 	open_request := Request{
-		id:      1
-		method:  'textDocument/didOpen'
+		id: 1
+		method: 'textDocument/didOpen'
 		jsonrpc: '2.0'
-		params:  json2.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
@@ -202,11 +202,11 @@ fn test_integration_document_lifecycle() {
 	// 2. Change document
 	new_content := "module main\n\nfn main() {\n\tprintln('world')\n}\n"
 	change_request := Request{
-		id:      2
-		method:  'textDocument/didChange'
+		id: 2
+		method: 'textDocument/didChange'
 		jsonrpc: '2.0'
-		params:  json2.encode(Params{
-			text_document:   TextDocumentIdentifier{
+		params: json2.encode(Params{
+			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
 			content_changes: [ContentChange{
@@ -421,7 +421,7 @@ fn test_integration_diagnostics_syntax_error() {
 	// Trigger change to get diagnostics
 	change_request := Request{
 		params: json2.encode(Params{
-			text_document:   TextDocumentIdentifier{
+			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
 			content_changes: [ContentChange{
@@ -467,7 +467,7 @@ fn test_integration_diagnostics_valid_code() {
 
 	change_request := Request{
 		params: json2.encode(Params{
-			text_document:   TextDocumentIdentifier{
+			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
 			content_changes: [ContentChange{
@@ -495,17 +495,17 @@ fn test_integration_diagnostics_deduplication() {
 	errors := [
 		JsonError{
 			line_nr: 5
-			col:     10
+			col: 10
 			message: 'first error'
 		},
 		JsonError{
 			line_nr: 5
-			col:     10
+			col: 10
 			message: 'duplicate error'
 		}, // Same position
 		JsonError{
 			line_nr: 6
-			col:     1
+			col: 1
 			message: 'different position'
 		},
 	]
@@ -547,7 +547,7 @@ fn test_integration_diagnostics_empty_file() {
 	// Empty content should be processed and return diagnostics for the empty file
 	result := app.on_did_change(Request{
 		params: json2.encode(Params{
-			text_document:   TextDocumentIdentifier{
+			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
 			content_changes: [ContentChange{
@@ -592,14 +592,14 @@ fn test_integration_completion_request() {
 
 	// Request completion at the position after "os."
 	request := Request{
-		id:      1
-		method:  'textDocument/completion'
+		id: 1
+		method: 'textDocument/completion'
 		jsonrpc: '2.0'
-		params:  json2.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-			position:      Position{
+			position: Position{
 				line: 3
 				char: 4
 			} // After "os."
@@ -630,12 +630,12 @@ fn test_integration_completion_request_id_preserved() {
 	// Test with various IDs
 	for id in [1, 42, 100, 999] {
 		request := Request{
-			id:     id
+			id: id
 			params: json2.encode(Params{
 				text_document: TextDocumentIdentifier{
 					uri: uri
 				}
-				position:      Position{
+				position: Position{
 					line: 2
 					char: 0
 				}
@@ -663,12 +663,12 @@ fn test_integration_completion_at_function_call() {
 	app.open_files[uri] = content
 
 	request := Request{
-		id:     1
+		id: 1
 		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-			position:      Position{
+			position: Position{
 				line: 3
 				char: 9
 			}
@@ -707,14 +707,14 @@ fn test_integration_definition_request() {
 
 	// Request definition at the call site of helper()
 	request := Request{
-		id:      2
-		method:  'textDocument/definition'
+		id: 2
+		method: 'textDocument/definition'
 		jsonrpc: '2.0'
-		params:  json2.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-			position:      Position{
+			position: Position{
 				line: 5
 				char: 2
 			} // At "helper()"
@@ -776,12 +776,12 @@ fn test_integration_definition_multifile() {
 
 	// Request definition from main file
 	request := Request{
-		id:     3
+		id: 3
 		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: main_uri
 			}
-			position:      Position{
+			position: Position{
 				line: 3
 				char: 2
 			}
@@ -799,8 +799,7 @@ fn test_integration_cross_module_features_use_unsaved_project_overlay() {
 	defer {
 		cleanup_integration_test_env(app, project_dir)
 	}
-	integration_test_must_write_file(os.join_path(project_dir, 'v.mod'),
-		"Module {\n\tname: 'cross_module_test'\n}\n")
+	integration_test_must_write_file(os.join_path(project_dir, 'v.mod'), "Module {\n\tname: 'cross_module_test'\n}\n")
 	source_dir := os.join_path(project_dir, 'src')
 	module_dir := os.join_path(source_dir, 'mathutil')
 	integration_test_must_mkdir_all(module_dir)
@@ -830,13 +829,13 @@ fn test_integration_cross_module_features_use_unsaved_project_overlay() {
 	app.text = open_content
 
 	definition := app.operation_at_pos(.definition, Request{
-		id:     31
+		id: 31
 		method: 'textDocument/definition'
 		params: json2.encode(TextDocumentPositionParams{
 			text_document: TextDocumentIdentifier{
 				uri: main_uri
 			}
-			position:      Position{
+			position: Position{
 				line: 5
 				char: 20
 			}
@@ -850,13 +849,13 @@ fn test_integration_cross_module_features_use_unsaved_project_overlay() {
 	assert definition_location.range.start.line == 2
 
 	hover := app.operation_at_pos(.hover, Request{
-		id:     32
+		id: 32
 		method: 'textDocument/hover'
 		params: json2.encode(TextDocumentPositionParams{
 			text_document: TextDocumentIdentifier{
 				uri: main_uri
 			}
-			position:      Position{
+			position: Position{
 				line: 5
 				char: 20
 			}
@@ -868,13 +867,13 @@ fn test_integration_cross_module_features_use_unsaved_project_overlay() {
 	assert (hover.result as Hover).contents.value.contains('answer')
 
 	signature := app.operation_at_pos(.signature_help, Request{
-		id:     33
+		id: 33
 		method: 'textDocument/signatureHelp'
 		params: json2.encode(TextDocumentPositionParams{
 			text_document: TextDocumentIdentifier{
 				uri: main_uri
 			}
-			position:      Position{
+			position: Position{
 				line: 5
 				char: 25
 			}
@@ -887,13 +886,13 @@ fn test_integration_cross_module_features_use_unsaved_project_overlay() {
 	assert signature_help.signatures.any(it.label.contains('answer'))
 
 	completion := app.operation_at_pos(.completion, Request{
-		id:     34
+		id: 34
 		method: 'textDocument/completion'
 		params: json2.encode(TextDocumentPositionParams{
 			text_document: TextDocumentIdentifier{
 				uri: main_uri
 			}
-			position:      Position{
+			position: Position{
 				line: 5
 				char: 18
 			}
@@ -958,12 +957,12 @@ fn test_integration_vlang_v_cross_module_features_from_env() {
 
 	for i, method in [Method.definition, .declaration, .type_definition, .implementation] {
 		response := app.operation_at_pos(method, Request{
-			id:     40 + i
+			id: 40 + i
 			params: json2.encode(TextDocumentPositionParams{
 				text_document: TextDocumentIdentifier{
 					uri: main_uri
 				}
-				position:      Position{
+				position: Position{
 					line: call_line
 					char: compile_col + 2
 				}
@@ -978,12 +977,12 @@ fn test_integration_vlang_v_cross_module_features_from_env() {
 	}
 
 	hover := app.operation_at_pos(.hover, Request{
-		id:     44
+		id: 44
 		params: json2.encode(TextDocumentPositionParams{
 			text_document: TextDocumentIdentifier{
 				uri: main_uri
 			}
-			position:      Position{
+			position: Position{
 				line: call_line
 				char: compile_col + 2
 			}
@@ -997,12 +996,12 @@ fn test_integration_vlang_v_cross_module_features_from_env() {
 	open_paren_col := lines[call_line].index('builder.compile(') or { -1 }
 	assert open_paren_col >= 0
 	signature := app.operation_at_pos(.signature_help, Request{
-		id:     45
+		id: 45
 		params: json2.encode(TextDocumentPositionParams{
 			text_document: TextDocumentIdentifier{
 				uri: main_uri
 			}
-			position:      Position{
+			position: Position{
 				line: call_line
 				char: open_paren_col + 'builder.compile('.len
 			}
@@ -1021,12 +1020,12 @@ fn test_integration_vlang_v_cross_module_features_from_env() {
 	app.open_files[main_uri] = completion_content
 	app.text = completion_content
 	completion := app.operation_at_pos(.completion, Request{
-		id:     46
+		id: 46
 		params: json2.encode(TextDocumentPositionParams{
 			text_document: TextDocumentIdentifier{
 				uri: main_uri
 			}
-			position:      Position{
+			position: Position{
 				line: call_line
 				char: dot_col + 'builder.'.len
 			}
@@ -1064,14 +1063,14 @@ fn test_integration_signature_help_request() {
 
 	// Request signature help after opening paren
 	request := Request{
-		id:      3
-		method:  'textDocument/signatureHelp'
+		id: 3
+		method: 'textDocument/signatureHelp'
 		jsonrpc: '2.0'
-		params:  json2.encode(Params{
+		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-			position:      Position{
+			position: Position{
 				line: 5
 				char: 7
 			} // After "greet("
@@ -1105,12 +1104,12 @@ fn test_integration_signature_help_with_params() {
 
 	// At second parameter position
 	request := Request{
-		id:     4
+		id: 4
 		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-			position:      Position{
+			position: Position{
 				line: 5
 				char: 7
 			}
@@ -1274,7 +1273,7 @@ fn test_integration_json_error_with_special_chars() {
 
 fn test_integration_response_encoding() {
 	response := Response{
-		id:     42
+		id: 42
 		result: 'null'
 	}
 
@@ -1290,20 +1289,20 @@ fn test_integration_notification_encoding() {
 	notification := Notification{
 		method: 'textDocument/publishDiagnostics'
 		params: PublishDiagnosticsParams{
-			uri:         'file:///test.v'
+			uri: 'file:///test.v'
 			diagnostics: [
 				LSPDiagnostic{
-					range:    LSPRange{
+					range: LSPRange{
 						start: Position{
 							line: 0
 							char: 0
 						}
-						end:   Position{
+						end: Position{
 							line: 0
 							char: 5
 						}
 					}
-					message:  'test error'
+					message: 'test error'
 					severity: 1
 				},
 			]
@@ -1345,7 +1344,7 @@ fn test_integration_begin_progress_with_client_support_emits_create_and_begin() 
 	assert app.captured_output.len == 2
 	assert app.captured_output[0].contains('"method":"window/workDoneProgress/create"')
 	assert app.captured_output[0].contains('"token":"${token}"')
-	assert app.captured_output[1].contains('"method":"$/progress"')
+	assert app.captured_output[1].contains('"method":"\$/progress"')
 	assert app.captured_output[1].contains('"kind":"begin"')
 	assert app.captured_output[1].contains('"title":"Searching workspace symbols')
 }
@@ -1353,19 +1352,19 @@ fn test_integration_begin_progress_with_client_support_emits_create_and_begin() 
 fn test_integration_completion_response_encoding() {
 	details := [
 		Detail{
-			kind:   6
-			label:  'println'
+			kind: 6
+			label: 'println'
 			detail: 'fn println(s string)'
 		},
 		Detail{
-			kind:   6
-			label:  'print'
+			kind: 6
+			label: 'print'
 			detail: 'fn print(s string)'
 		},
 	]
 
 	response := Response{
-		id:     1
+		id: 1
 		result: details
 	}
 
@@ -1376,15 +1375,15 @@ fn test_integration_completion_response_encoding() {
 
 fn test_integration_location_response_encoding() {
 	response := Response{
-		id:     1
+		id: 1
 		result: Location{
-			uri:   'file:///test/main.v'
+			uri: 'file:///test/main.v'
 			range: LSPRange{
 				start: Position{
 					line: 10
 					char: 5
 				}
-				end:   Position{
+				end: Position{
 					line: 10
 					char: 15
 				}
@@ -1399,11 +1398,11 @@ fn test_integration_location_response_encoding() {
 
 fn test_integration_signature_help_response_encoding() {
 	response := Response{
-		id:     1
+		id: 1
 		result: SignatureHelp{
-			signatures:       [
+			signatures: [
 				SignatureInformation{
-					label:      'fn test(a int, b string)'
+					label: 'fn test(a int, b string)'
 					parameters: [
 						ParameterInformation{
 							label: 'a int'
@@ -1442,13 +1441,13 @@ fn test_integration_request_id_preserved() {
 	// Test with different request IDs
 	for id in [1, 42, 999, 0] {
 		request := Request{
-			id:     id
+			id: id
 			method: 'textDocument/completion'
 			params: json2.encode(Params{
 				text_document: TextDocumentIdentifier{
 					uri: uri
 				}
-				position:      Position{
+				position: Position{
 					line: 2
 					char: 0
 				}
@@ -1561,17 +1560,17 @@ fn test_integration_full_lifecycle() {
 	// 2. Simulate initialize (verify capabilities)
 	caps := Capabilities{
 		capabilities: Capability{
-			text_document_sync:      TextDocumentSyncOptions{
+			text_document_sync: TextDocumentSyncOptions{
 				open_close: true
-				change:     1
+				change: 1
 			}
-			completion_provider:     CompletionProvider{
+			completion_provider: CompletionProvider{
 				trigger_characters: ['.']
 			}
 			signature_help_provider: SignatureHelpOptions{
 				trigger_characters: ['(', ',']
 			}
-			definition_provider:     true
+			definition_provider: true
 		}
 	}
 	assert caps.capabilities.definition_provider == true
@@ -1592,7 +1591,7 @@ fn test_integration_full_lifecycle() {
 	modified_content := 'module main\n\nfn helper() {}\n\nfn main() {\n\thelper()\n}\n'
 	app.on_did_change(Request{
 		params: json2.encode(Params{
-			text_document:   TextDocumentIdentifier{
+			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
 			content_changes: [ContentChange{
@@ -1606,12 +1605,12 @@ fn test_integration_full_lifecycle() {
 
 	// 5. Request completion
 	comp_response := app.operation_at_pos(.completion, Request{
-		id:     1
+		id: 1
 		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-			position:      Position{
+			position: Position{
 				line: 5
 				char: 2
 			}
@@ -1623,12 +1622,12 @@ fn test_integration_full_lifecycle() {
 
 	// 6. Request definition
 	def_response := app.operation_at_pos(.definition, Request{
-		id:     2
+		id: 2
 		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-			position:      Position{
+			position: Position{
 				line: 5
 				char: 2
 			}
@@ -1645,7 +1644,7 @@ fn test_integration_full_lifecycle() {
 fn test_integration_shutdown_response() {
 	// Verify shutdown response structure
 	shutdown_resp := Response{
-		id:     1
+		id: 1
 		result: 'null'
 	}
 
@@ -1774,8 +1773,7 @@ fn test_integration_pre_initialize_notification_is_ignored() {
 
 	did_open_before_init := '{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{"uri":"file:///tmp/preinit.v","text":"module main"}}}'
 	initialize := '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}'
-	framed := integration_test_frame_message(did_open_before_init) +
-		integration_test_frame_message(initialize)
+	framed := integration_test_frame_message(did_open_before_init) + integration_test_frame_message(initialize)
 	input_path := os.join_path(project_dir, 'pre_init_notification_input.txt')
 	integration_test_must_write_file(input_path, framed)
 
@@ -1806,8 +1804,7 @@ fn test_integration_initialized_notification_after_initialize_registers_watcher(
 
 	initialize := '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"capabilities":{"workspace":{"didChangeWatchedFiles":{"dynamicRegistration":true}}}}}'
 	initialized := '{"jsonrpc":"2.0","method":"initialized","params":{}}'
-	framed := integration_test_frame_message(initialize) +
-		integration_test_frame_message(initialized)
+	framed := integration_test_frame_message(initialize) + integration_test_frame_message(initialized)
 	input_path := os.join_path(project_dir, 'initialized_notification_input.txt')
 	integration_test_must_write_file(input_path, framed)
 
@@ -1840,8 +1837,7 @@ fn test_integration_initialized_notification_without_dynamic_support_skips_regis
 
 	initialize := '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}'
 	initialized := '{"jsonrpc":"2.0","method":"initialized","params":{}}'
-	framed := integration_test_frame_message(initialize) +
-		integration_test_frame_message(initialized)
+	framed := integration_test_frame_message(initialize) + integration_test_frame_message(initialized)
 	input_path := os.join_path(project_dir, 'initialized_no_dynamic_support_input.txt')
 	integration_test_must_write_file(input_path, framed)
 
@@ -1874,9 +1870,7 @@ fn test_integration_duplicate_initialized_sends_single_registration() {
 	initialize := '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"capabilities":{"workspace":{"didChangeWatchedFiles":{"dynamicRegistration":true}}}}}'
 	initialized_1 := '{"jsonrpc":"2.0","method":"initialized","params":{}}'
 	initialized_2 := '{"jsonrpc":"2.0","method":"initialized","params":{}}'
-	framed := integration_test_frame_message(initialize) +
-		integration_test_frame_message(initialized_1) +
-		integration_test_frame_message(initialized_2)
+	framed := integration_test_frame_message(initialize) + integration_test_frame_message(initialized_1) + integration_test_frame_message(initialized_2)
 	input_path := os.join_path(project_dir, 'duplicate_initialized_input.txt')
 	integration_test_must_write_file(input_path, framed)
 
@@ -1910,8 +1904,7 @@ fn test_integration_post_initialize_notification_updates_state() {
 	content := 'module main\n\nfn main() {}\n'
 	initialize := '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}'
 	did_open_after_init := '{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{"uri":"${uri}","text":"${content}"}}}'
-	framed := integration_test_frame_message(initialize) +
-		integration_test_frame_message(did_open_after_init)
+	framed := integration_test_frame_message(initialize) + integration_test_frame_message(did_open_after_init)
 	input_path := os.join_path(project_dir, 'post_init_notification_input.txt')
 	integration_test_must_write_file(input_path, framed)
 
@@ -1946,10 +1939,9 @@ fn test_integration_pre_initialize_cancel_request_is_ignored() {
 		cleanup_integration_test_env(app, project_dir)
 	}
 
-	cancel_before_init := '{"jsonrpc":"2.0","method":"$/cancelRequest","params":{"id":99}}'
+	cancel_before_init := '{"jsonrpc":"2.0","method":"\$/cancelRequest","params":{"id":99}}'
 	initialize := '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}'
-	framed := integration_test_frame_message(cancel_before_init) +
-		integration_test_frame_message(initialize)
+	framed := integration_test_frame_message(cancel_before_init) + integration_test_frame_message(initialize)
 	input_path := os.join_path(project_dir, 'pre_init_cancel_input.txt')
 	integration_test_must_write_file(input_path, framed)
 
@@ -1981,8 +1973,7 @@ fn test_integration_second_initialize_rejected_with_invalid_request() {
 
 	initialize_1 := '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}'
 	initialize_2 := '{"jsonrpc":"2.0","id":2,"method":"initialize","params":{}}'
-	framed := integration_test_frame_message(initialize_1) +
-		integration_test_frame_message(initialize_2)
+	framed := integration_test_frame_message(initialize_1) + integration_test_frame_message(initialize_2)
 	input_path := os.join_path(project_dir, 'double_initialize_input.txt')
 	integration_test_must_write_file(input_path, framed)
 
@@ -2017,9 +2008,7 @@ fn test_integration_post_shutdown_request_rejected_with_invalid_request() {
 	initialize := '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}'
 	shutdown := '{"jsonrpc":"2.0","id":2,"method":"shutdown","params":{}}'
 	completion_after_shutdown := '{"jsonrpc":"2.0","id":3,"method":"textDocument/completion","params":{"textDocument":{"uri":"file:///tmp/a.v"},"position":{"line":0,"character":0}}}'
-	framed := integration_test_frame_message(initialize) +
-		integration_test_frame_message(shutdown) +
-		integration_test_frame_message(completion_after_shutdown)
+	framed := integration_test_frame_message(initialize) + integration_test_frame_message(shutdown) + integration_test_frame_message(completion_after_shutdown)
 	input_path := os.join_path(project_dir, 'post_shutdown_request_input.txt')
 	integration_test_must_write_file(input_path, framed)
 
@@ -2051,8 +2040,7 @@ fn test_integration_exit_after_shutdown_emits_no_exit_response() {
 	initialize := '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}'
 	shutdown := '{"jsonrpc":"2.0","id":2,"method":"shutdown","params":{}}'
 	exit_notification := '{"jsonrpc":"2.0","method":"exit","params":{}}'
-	framed := integration_test_frame_message(initialize) +
-		integration_test_frame_message(shutdown) + integration_test_frame_message(exit_notification)
+	framed := integration_test_frame_message(initialize) + integration_test_frame_message(shutdown) + integration_test_frame_message(exit_notification)
 	input_path := os.join_path(project_dir, 'shutdown_exit_input.txt')
 	integration_test_must_write_file(input_path, framed)
 
@@ -2130,12 +2118,12 @@ fn test_integration_completion_includes_sibling_pub_fn() {
 
 	// Request completion at `helper` on line 3, col 1 (not after '.')
 	response := app.operation_at_pos(.completion, Request{
-		id:     1
+		id: 1
 		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: main_uri
 			}
-			position:      Position{
+			position: Position{
 				line: 3
 				char: 1
 			}
@@ -2176,12 +2164,12 @@ fn test_integration_completion_includes_private_sibling_fn() {
 	app.text = main_content
 
 	response := app.operation_at_pos(.completion, Request{
-		id:     1
+		id: 1
 		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: main_uri
 			}
-			position:      Position{
+			position: Position{
 				line: 3
 				char: 2
 			}
@@ -2215,12 +2203,12 @@ fn test_integration_completion_includes_current_file_fns() {
 	app.text = content
 
 	response := app.operation_at_pos(.completion, Request{
-		id:     1
+		id: 1
 		params: json2.encode(Params{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-			position:      Position{
+			position: Position{
 				line: 5 // inside fn main, after `he`
 				char: 2
 			}
@@ -2315,13 +2303,13 @@ fn test_integration_prepare_rename_returns_symbol_range() {
 	app.open_files[uri] = content
 
 	response := app.handle_prepare_rename(Request{
-		id:     301
+		id: 301
 		method: 'textDocument/prepareRename'
 		params: json2.encode(TextDocumentPositionParams{
 			text_document: TextDocumentIdentifier{
 				uri: uri
 			}
-			position:      Position{
+			position: Position{
 				line: 4
 				char: 12
 			}
@@ -2350,7 +2338,7 @@ fn test_integration_workspace_symbol_query_matches() {
 	app.open_files[uri] = content
 
 	response := app.handle_workspace_symbol(Request{
-		id:     302
+		id: 302
 		method: 'workspace/symbol'
 		params: json2.encode(WorkspaceSymbolParams{
 			query: 'name'
@@ -2383,7 +2371,7 @@ fn test_integration_workspace_symbol_indexes_loose_module_sibling() {
 	assert find_project_root(project_dir) == ''
 
 	response := app.handle_workspace_symbol(Request{
-		id:     303
+		id: 303
 		method: 'workspace/symbol'
 		params: json2.encode(WorkspaceSymbolParams{
 			query: 'unopened_loose'
@@ -2415,13 +2403,13 @@ fn test_integration_alias_navigation_methods_preserve_id() {
 	mut request_id := 410
 	for m in methods {
 		resp := app.operation_at_pos(m, Request{
-			id:     request_id
+			id: request_id
 			method: m.str()
 			params: json2.encode(TextDocumentPositionParams{
 				text_document: TextDocumentIdentifier{
 					uri: uri
 				}
-				position:      Position{
+				position: Position{
 					line: 5
 					char: 2
 				}
@@ -2436,17 +2424,17 @@ fn test_integration_alias_navigation_methods_preserve_id() {
 
 fn test_integration_capability_flags_for_new_features() {
 	caps := Capability{
-		text_document_sync:        TextDocumentSyncOptions{
+		text_document_sync: TextDocumentSyncOptions{
 			open_close: true
-			change:     2
-			save:       SaveOptions{
+			change: 2
+			save: SaveOptions{
 				include_text: true
 			}
 		}
-		declaration_provider:      true
-		type_definition_provider:  true
-		implementation_provider:   true
-		rename_provider:           RenameOptions{
+		declaration_provider: true
+		type_definition_provider: true
+		implementation_provider: true
+		rename_provider: RenameOptions{
 			prepare_provider: true
 		}
 		workspace_symbol_provider: true
@@ -2592,7 +2580,7 @@ fn test_integration_string_id_cancel_does_not_collide_with_numeric_zero() {
 	// Cancel string id "a".
 	app.current_request_raw_id = ''
 	app.on_cancel_request(Request{
-		method: '$/cancelRequest'
+		method: '\$/cancelRequest'
 		params: '{"id":"a"}'
 	})
 	// A numeric id-0 request is NOT cancelled by the string cancel.
@@ -2614,7 +2602,7 @@ fn test_integration_numeric_and_string_cancel_are_independent() {
 	// Cancel numeric id 7.
 	app.current_request_raw_id = ''
 	app.on_cancel_request(Request{
-		method: '$/cancelRequest'
+		method: '\$/cancelRequest'
 		params: '{"id":7}'
 	})
 	app.current_request_raw_id = '7'
@@ -2631,7 +2619,7 @@ fn test_integration_numeric_cancel_ids_match_exact_raw_token() {
 	}
 
 	app.on_cancel_request(Request{
-		method: '$/cancelRequest'
+		method: '\$/cancelRequest'
 		params: '{"id":1.25}'
 	})
 	assert app.cancelled_requests.len == 0
@@ -2643,7 +2631,7 @@ fn test_integration_numeric_cancel_ids_match_exact_raw_token() {
 	assert !app.request_is_cancelled(1)
 
 	app.on_cancel_request(Request{
-		method: '$/cancelRequest'
+		method: '\$/cancelRequest'
 		params: '{"id":9223372036854775808}'
 	})
 	app.current_request_raw_id = '9223372036854775809'
@@ -2654,7 +2642,7 @@ fn test_integration_numeric_cancel_ids_match_exact_raw_token() {
 
 fn test_integration_diagnostics_contain_real_compiler_errors() {
 	// Regression guard: the server must surface actual compiler errors, not an
-	// empty diagnostics list (the compiler writes -json-errors output to stderr).
+	// empty diagnostics list (the compiler writes checker output to stderr).
 	mut app, project_dir := create_integration_test_env()
 	defer {
 		cleanup_integration_test_env(app, project_dir)

--- a/interop.v
+++ b/interop.v
@@ -219,8 +219,7 @@ fn make_unique_temp_path(tag string, real_path string) string {
 	safe_ext := if ext == '' { '.v' } else { ext }
 	name := os.file_name(real_path)
 	base := if name.contains('.') { name.all_before_last('.') } else { name }
-	return os.join_path(os.temp_dir(),
-		'${tag}_${os.getpid()}_${time.now().unix_nano()}_${base}${safe_ext}')
+	return os.join_path(os.temp_dir(), '${tag}_${os.getpid()}_${time.now().unix_nano()}_${base}${safe_ext}')
 }
 
 fn make_singlefile_temp_path(temp_root string, real_path string, purpose string) string {
@@ -260,13 +259,39 @@ fn build_v_check_args_multifile() []string {
 }
 
 fn build_v_line_info_args_multifile(rel_file string, line_info string) []string {
-	return ['-w', '-check', '-json-errors', '-nocolor', '-vls-mode', '-line-info',
-		'${rel_file}:${line_info}', '.']
+	return ['-w', '-check', '-nocolor', '-vls-mode', '-line-info', '${rel_file}:${line_info}', '.']
 }
 
 fn build_v_line_info_args_single(file_to_check string, line_info string, compile_target string) []string {
-	return ['-w', '-check', '-json-errors', '-nocolor', '-vls-mode', '-line-info',
-		'${file_to_check}:${line_info}', compile_target]
+	return ['-w', '-check', '-nocolor', '-vls-mode', '-line-info', '${file_to_check}:${line_info}',
+		compile_target]
+}
+
+// normalize_v_line_info_output extracts the actual line-info payload from the
+// compatibility compiler's combined stdout/stderr. Newer launchers may prepend
+// an option notice before delegating to the established compiler.
+fn normalize_v_line_info_output(output string, method Method) string {
+	trimmed := output.trim_space()
+	if method in [.completion, .signature_help, .hover] {
+		start := trimmed.index('{') or { return '' }
+		end := trimmed.last_index('}') or { return '' }
+		if end < start {
+			return ''
+		}
+		return trimmed[start..end + 1]
+	}
+	if method in [.definition, .declaration, .type_definition, .implementation] {
+		lines := trimmed.split_into_lines()
+		for i := lines.len - 1; i >= 0; i-- {
+			line := lines[i].trim_space()
+			fields := line.split(':')
+			if fields.len >= 3 && fields[fields.len - 2].is_int()
+				&& fields[fields.len - 1].is_int() {
+				return line
+			}
+		}
+	}
+	return ''
 }
 
 fn build_v_fmt_args(temp_file string) []string {
@@ -342,8 +367,8 @@ fn diagnostic_source_path_is_valid(path string, source_dir string) bool {
 fn parse_v_check_diagnostic_header(line string, source_dir string) ?JsonError {
 	mut best_marker_idx := -1
 	mut best := JsonError{}
-	for level in ['builder error', 'parser error', 'checker error', 'cgen error', 'error',
-		'warning', 'notice'] {
+	for level in ['builder error', 'parser error', 'checker error', 'cgen error', 'error', 'warning',
+		'notice'] {
 		marker := ': ${level}: '
 		mut search_end := line.len
 		for search_end > 0 {
@@ -369,11 +394,11 @@ fn parse_v_check_diagnostic_header(line string, source_dir string) ?JsonError {
 			if marker_idx > best_marker_idx {
 				best_marker_idx = marker_idx
 				best = JsonError{
-					path:    path
+					path: path
 					message: line[marker_idx + marker.len..]
 					line_nr: line_nr_text.int()
-					col:     col_text.int()
-					level:   if level.contains('error') { 'error' } else { level }
+					col: col_text.int()
+					level: if level.contains('error') { 'error' } else { level }
 				}
 			}
 			break
@@ -421,8 +446,8 @@ fn (mut app App) cache_v_check_result(path string, content_hash int, generation 
 	}
 	app.diag_cache[path] = DiagCacheEntry{
 		content_hash: content_hash
-		generation:   generation
-		errors:       errors
+		generation: generation
+		errors: errors
 	}
 }
 
@@ -447,8 +472,8 @@ fn resolve_compiler_timeout_ms() i64 {
 // run_v_argv executes the V compiler with the given argument vector in
 // `work_folder` (set on the child process, never via a process-global chdir).
 // stdout and stderr are merged into one combined buffer because the compiler
-// writes its `-json-errors` / `-line-info` output to STDERR; returning stdout
-// alone would silently drop every diagnostic. The child is killed if it exceeds
+// writes diagnostics and `-line-info` output to STDERR; returning stdout alone
+// would silently drop them. The child is killed if it exceeds
 // compiler_timeout_ms. This is the single, shell-free entry point for all
 // compiler invocations.
 fn run_v_argv(args []string, work_folder string) os.Result {
@@ -457,19 +482,27 @@ fn run_v_argv(args []string, work_folder string) os.Result {
 		log(msg)
 		return os.Result{
 			exit_code: 1
-			output:    msg
+			output: msg
 		}
 	}
 	v_exe := resolve_v_compiler_exe()
 	timeout_ms := resolve_compiler_timeout_ms()
 	mut p := os.new_process(v_exe)
 	p.set_args(args)
+	if '-line-info' in args {
+		// CI enforces V3 for VLS itself, but line-info is still served by the
+		// established compiler. Do not leak the macOS no-fallback guard into this
+		// compatibility subprocess.
+		mut child_env := os.environ()
+		child_env.delete('V_MACOS_V3_NO_FALLBACK')
+		p.set_environment(child_env)
+	}
 	if work_folder != '' {
 		p.set_work_folder(work_folder)
 	}
 	p.set_redirect_stdio()
 	p.run()
-	// The V compiler writes its `-json-errors` / `-line-info` output to STDERR,
+	// The V compiler writes diagnostics and `-line-info` output to STDERR,
 	// so both streams are captured into one combined buffer (equivalent to the
 	// shell `2>&1` the previous implementation relied on). Returning stdout alone
 	// would silently drop every diagnostic.
@@ -511,12 +544,12 @@ fn run_v_argv(args []string, work_folder string) os.Result {
 	if timed_out {
 		return os.Result{
 			exit_code: compiler_exit_timeout
-			output:    ''
+			output: ''
 		}
 	}
 	return os.Result{
 		exit_code: code
-		output:    out.str()
+		output: out.str()
 	}
 }
 
@@ -624,12 +657,12 @@ fn (mut app App) prepare_compilation_overlay(real_path string) !CompilationOverl
 		}
 	}
 	return CompilationOverlay{
-		source_root:         source_root
+		source_root: source_root
 		source_display_root: source_display_root
-		temp_root:           temp_root
-		source_work_dir:     source_work_dir
-		temp_work_dir:       temp_work_dir
-		temp_source_file:    os.join_path(temp_root, file_rel)
+		temp_root: temp_root
+		source_work_dir: source_work_dir
+		temp_work_dir: temp_work_dir
+		temp_source_file: os.join_path(temp_root, file_rel)
 	}
 }
 
@@ -646,8 +679,7 @@ fn source_path_from_overlay_with_windows_rules(reported_path string, overlay Com
 	temp_root := normalize_overlay_path_with_windows_rules(overlay.temp_root, windows)
 	if path_is_within_with_case(candidate, temp_root, windows) {
 		rel := path_relative_to_with_case(candidate, temp_root, windows) or { return candidate }
-		return normalize_overlay_path_with_windows_rules(os.join_path(overlay.source_display_root,
-			rel), windows)
+		return normalize_overlay_path_with_windows_rules(os.join_path(overlay.source_display_root, rel), windows)
 	}
 	return candidate
 }
@@ -721,9 +753,8 @@ fn (mut app App) run_v_check(path string, text string) []JsonError {
 
 	log('Check - RUN RES ${x}')
 
-	// `-json-errors`, `-w`, and `-vls-mode` select the established compiler.
-	// Parse V3's native flat-AST checker diagnostics instead so ordinary
-	// diagnostics stay on the default backend.
+	// Parse V3's native flat-AST checker diagnostics so ordinary diagnostics stay
+	// on the default backend.
 	diagnostic_source_dir := if use_multifile { exec_dir } else { os.dir(file_to_check) }
 	v_errors := parse_v_check_diagnostics(x.output, diagnostic_source_dir)
 	cleanup_compilation_temp(temp_project_dir, singlefile_tmppath)
@@ -736,12 +767,12 @@ fn (mut app App) run_v_check(path string, text string) []JsonError {
 			err_file := source_path_from_overlay(err.path, overlay)
 			if normalized_index_path(err_file) == normalized_index_path(real_path) {
 				updated_err := JsonError{
-					path:    real_path
+					path: real_path
 					message: err.message
 					line_nr: err.line_nr
-					col:     err.col
-					len:     err.len
-					level:   err.level
+					col: err.col
+					len: err.len
+					level: err.level
 				}
 				filtered_errors << updated_err
 				log('INCLUDING ERROR from err_file=${err_file}: ${err.message}')
@@ -751,8 +782,7 @@ fn (mut app App) run_v_check(path string, text string) []JsonError {
 		}
 
 		log('FILTERED ERRORS: ${filtered_errors.len} of ${v_errors.len}')
-		app.cache_v_check_result(path, content_hash, gen, filtered_errors, x.exit_code,
-			v_errors.len)
+		app.cache_v_check_result(path, content_hash, gen, filtered_errors, x.exit_code, v_errors.len)
 		return filtered_errors
 	}
 
@@ -913,13 +943,11 @@ fn materialize_overlay_file_with_linker(source_path string, target_path string, 
 }
 
 fn materialize_overlay_file(source_path string, target_path string, mut budget OverlayCopyBudget) !bool {
-	return materialize_overlay_file_with_linker(source_path, target_path, create_overlay_hard_link, mut
-		budget)
+	return materialize_overlay_file_with_linker(source_path, target_path, create_overlay_hard_link, mut budget)
 }
 
 fn symlink_untracked_files(source_root string, source_module_dir string, temp_dir string, tracked_files map[string]string) ! {
-	symlink_untracked_files_with_linker(source_root, source_module_dir, temp_dir, tracked_files,
-		create_overlay_symlink)!
+	symlink_untracked_files_with_linker(source_root, source_module_dir, temp_dir, tracked_files, create_overlay_symlink)!
 }
 
 fn symlink_untracked_files_with_linker(source_root string, source_module_dir string, temp_dir string, tracked_files map[string]string, link_fn OverlayLinkFn) ! {
@@ -933,15 +961,11 @@ fn symlink_untracked_files_with_linker(source_root string, source_module_dir str
 			tracked_rel_paths << normalize_overlay_path(rel)
 		}
 	}
-	local_import_dirs := local_import_rel_dirs(normalized_source_root, normalized_module_dir,
-		tracked_files)
+	local_import_dirs := local_import_rel_dirs(normalized_source_root, normalized_module_dir, tracked_files)
 	mut copy_budget := new_overlay_copy_budget()
-	thirdparty_references := referenced_thirdparty_rel_paths(normalized_source_root,
-		normalized_module_dir, tracked_files, local_import_dirs)
-	materialize_referenced_thirdparty_inputs(normalized_source_root, temp_dir,
-		thirdparty_references, mut copy_budget)!
-	symlink_untracked_tree(normalized_source_root, normalized_source_root, temp_dir, '',
-		tracked_rel_paths, local_import_dirs, link_fn, mut copy_budget)!
+	thirdparty_references := referenced_thirdparty_rel_paths(normalized_source_root, normalized_module_dir, tracked_files, local_import_dirs)
+	materialize_referenced_thirdparty_inputs(normalized_source_root, temp_dir, thirdparty_references, mut copy_budget)!
+	symlink_untracked_tree(normalized_source_root, normalized_source_root, temp_dir, '', tracked_rel_paths, local_import_dirs, link_fn, mut copy_budget)!
 }
 
 // local_import_rel_dirs returns project-local module directories imported by
@@ -1148,8 +1172,7 @@ fn copy_bounded_overlay_entry_pass(source_path string, target_path string, compi
 		visited[real_path] = true
 		mut copied := 0
 		for entry in os.ls(source_path)! {
-			copied += copy_bounded_overlay_entry_pass(os.join_path(source_path, entry), os.join_path(target_path,
-				entry), compilation_files, mut budget, mut visited)!
+			copied += copy_bounded_overlay_entry_pass(os.join_path(source_path, entry), os.join_path(target_path, entry), compilation_files, mut budget, mut visited)!
 		}
 		return copied
 	}
@@ -1173,11 +1196,9 @@ fn copy_bounded_overlay_entry_pass(source_path string, target_path string, compi
 // detection keep the copy bounded. Compiler inputs are copied before assets, and
 // files beyond the limit are skipped without invalidating the partial overlay.
 fn copy_bounded_overlay_entry(source_path string, target_path string, mut budget OverlayCopyBudget, mut visited map[string]bool) !int {
-	mut copied := copy_bounded_overlay_entry_pass(source_path, target_path, true, mut budget, mut
-		visited)!
+	mut copied := copy_bounded_overlay_entry_pass(source_path, target_path, true, mut budget, mut visited)!
 	mut asset_visited := map[string]bool{}
-	copied += copy_bounded_overlay_entry_pass(source_path, target_path, false, mut budget, mut
-		asset_visited)!
+	copied += copy_bounded_overlay_entry_pass(source_path, target_path, false, mut budget, mut asset_visited)!
 	return copied
 }
 
@@ -1189,12 +1210,10 @@ fn materialize_referenced_thirdparty_inputs(source_root string, target_root stri
 			mut visited := map[string]bool{}
 			if os.file_name(source_path) == 'thirdparty' {
 				for entry in os.ls(source_path)! {
-					copy_bounded_overlay_entry_pass(os.join_path(source_path, entry), os.join_path(target_path,
-						entry), true, mut budget, mut visited)!
+					copy_bounded_overlay_entry_pass(os.join_path(source_path, entry), os.join_path(target_path, entry), true, mut budget, mut visited)!
 				}
 			} else {
-				copy_bounded_overlay_entry_pass(source_path, target_path, true, mut budget, mut
-					visited)!
+				copy_bounded_overlay_entry_pass(source_path, target_path, true, mut budget, mut visited)!
 			}
 			continue
 		}
@@ -1264,8 +1283,7 @@ fn symlink_untracked_tree(source_root string, source_dir string, target_dir stri
 			if !os.exists(target_path) {
 				os.mkdir_all(target_path)!
 			}
-			symlink_untracked_tree(source_root, source_path, target_path, relative_path,
-				tracked_rel_paths, local_import_dirs, link_fn, mut copy_budget)!
+			symlink_untracked_tree(source_root, source_path, target_path, relative_path, tracked_rel_paths, local_import_dirs, link_fn, mut copy_budget)!
 			continue
 		}
 		if os.exists(target_path) || os.is_link(target_path) {
@@ -1283,8 +1301,7 @@ fn symlink_untracked_tree(source_root string, source_dir string, target_dir stri
 		link_fn(source_path, target_path) or {
 			log('Failed to symlink ${source_path}; using bounded overlay copy: ${err}')
 			mut visited := map[string]bool{}
-			copied := copy_bounded_overlay_entry(source_path, target_path, mut copy_budget, mut
-				visited)!
+			copied := copy_bounded_overlay_entry(source_path, target_path, mut copy_budget, mut visited)!
 			log('Copied ${copied} project files from ${source_path} into the overlay')
 			continue
 		}
@@ -1297,7 +1314,9 @@ fn symlink_untracked_tree(source_root string, source_dir string, target_dir stri
 // this notification keeps the in-memory open_files map consistent.
 fn (mut app App) on_did_change_watched_files(request Request) {
 	params := json2.decode[DidChangeWatchedFilesParams](request.params) or {
-		$if debug { log('Failed to decode DidChangeWatchedFilesParams: ${err}') }
+		$if debug {
+			log('Failed to decode DidChangeWatchedFilesParams: ${err}')
+		}
 		return
 	}
 	open_uris_by_path := app.open_index_uris_by_path()
@@ -1434,11 +1453,11 @@ fn (mut app App) run_v_line_info(method Method, path string, line_info string) R
 
 	exec_dir := if use_multifile { compile_target } else { working_dir }
 	mut x := run_v_argv(cmd_args, exec_dir)
+	mut output := normalize_v_line_info_output(x.output, method)
 
 	if (method == .definition || method == .declaration || method == .type_definition
 		|| method == .implementation) && use_multifile
-		&& (x.exit_code != 0 || x.output.trim_space() == ''
-		|| x.output.trim_space() == '[]') {
+		&& (x.exit_code != 0 || output == '') {
 		if temp_project_dir != '' {
 			os.rmdir_all(temp_project_dir) or { log('Failed to clean up temp project dir: ${err}') }
 			temp_project_dir = ''
@@ -1448,6 +1467,7 @@ fn (mut app App) run_v_line_info(method Method, path string, line_info string) R
 		cmd_fallback := build_v_line_info_args_single(file_to_check, line_info, compile_target)
 		log('cmd_fallback=v ${cmd_fallback.join(' ')}')
 		x = run_v_argv(cmd_fallback, working_dir)
+		output = normalize_v_line_info_output(x.output, method)
 		log('Fallback RUN RES ${x}')
 	}
 
@@ -1458,11 +1478,11 @@ fn (mut app App) run_v_line_info(method Method, path string, line_info string) R
 	mut result := ResponseResult('null')
 	match method {
 		.completion {
-			result_tmp := json2.decode[JsonVarAC](x.output) or { JsonVarAC{} }
+			result_tmp := json2.decode[JsonVarAC](output) or { JsonVarAC{} }
 			result = result_tmp.details
 		}
 		.signature_help {
-			sig := json2.decode[SignatureHelp](x.output) or { SignatureHelp{} }
+			sig := json2.decode[SignatureHelp](output) or { SignatureHelp{} }
 			// Return null when the compiler found no active signature so editors do not show
 			// empty signature popups (LSP spec: SignatureHelp | null).
 			if sig.signatures.len == 0 {
@@ -1473,7 +1493,7 @@ fn (mut app App) run_v_line_info(method Method, path string, line_info string) R
 		}
 		.hover {
 			// Decode the Hover JSON emitted by the compiler's hv^ mode.
-			hover_result := json2.decode[Hover](x.output) or { Hover{} }
+			hover_result := json2.decode[Hover](output) or { Hover{} }
 			// Extract vdoc comment via cross-file search as a fallback when the
 			// compiler does not provide documentation.
 			mut doc := ''
@@ -1492,10 +1512,8 @@ fn (mut app App) run_v_line_info(method Method, path string, line_info string) R
 				if cursor_line >= 0 && cursor_line < file_lines.len {
 					cursor_symbol = get_word_at_col(file_lines[cursor_line], cursor_col, .utf8)
 					if cursor_symbol != '' {
-						imported_module := imported_module_at_symbol(file_lines[cursor_line],
-							cursor_col, file_content)
-						doc = app.find_doc_comment_for_symbol(cursor_symbol, file_lines, path,
-							imported_module)
+						imported_module := imported_module_at_symbol(file_lines[cursor_line], cursor_col, file_content)
+						doc = app.find_doc_comment_for_symbol(cursor_symbol, file_lines, path, imported_module)
 					}
 				}
 			}
@@ -1507,7 +1525,7 @@ fn (mut app App) run_v_line_info(method Method, path string, line_info string) R
 				}
 				result = Hover{
 					contents: MarkupContent{
-						kind:  'markdown'
+						kind: 'markdown'
 						value: value
 					}
 				}
@@ -1515,7 +1533,7 @@ fn (mut app App) run_v_line_info(method Method, path string, line_info string) R
 				// Compiler returned no info but we found a vdoc comment
 				result = Hover{
 					contents: MarkupContent{
-						kind:  'markdown'
+						kind: 'markdown'
 						value: doc
 					}
 				}
@@ -1527,8 +1545,8 @@ fn (mut app App) run_v_line_info(method Method, path string, line_info string) R
 		}
 		.definition, .declaration, .type_definition, .implementation {
 			// file.v:line:col => Location
-			fields := x.output.trim_space().split(':')
-			if fields.len < 3 || x.output.trim_space() == '' {
+			fields := output.split(':')
+			if fields.len < 3 || output == '' {
 				// No definition found — return null so the client does not navigate anywhere.
 				result = 'null'
 			} else {
@@ -1560,13 +1578,13 @@ fn (app &App) compiler_location(path string, line int, byte_col int) Location {
 	target_uri := index_uri_for_path(path, app.open_index_uris_by_path())
 	client_col := app.byte_col_to_client_col(target_uri, line, byte_col)
 	return Location{
-		uri:   target_uri
+		uri: target_uri
 		range: LSPRange{
 			start: Position{
 				line: line
 				char: client_col
 			}
-			end:   Position{
+			end: Position{
 				line: line
 				char: client_col
 			}

--- a/interop_test.v
+++ b/interop_test.v
@@ -164,16 +164,15 @@ fn test_normalize_overlay_path_preserves_posix_backslashes() {
 fn test_source_path_from_overlay_normalizes_windows_relative_join() {
 	overlay := CompilationOverlay{
 		source_display_root: r'C:\repo'
-		temp_root:           r'C:\temp\overlay'
-		temp_work_dir:       r'C:\temp\overlay\src'
+		temp_root: r'C:\temp\overlay'
+		temp_work_dir: r'C:\temp\overlay\src'
 	}
 	mapped := source_path_from_overlay_with_windows_rules('./main.v', overlay, true)
 	assert mapped == 'C:/repo/src/main.v'
 }
 
 fn test_overlay_relative_path_prefers_nested_symlink_layout() {
-	temp_dir := os.join_path(os.temp_dir(),
-		'vls_overlay_relative_symlink_${os.getpid()}_${time.now().unix_nano()}')
+	temp_dir := os.join_path(os.temp_dir(), 'vls_overlay_relative_symlink_${os.getpid()}_${time.now().unix_nano()}')
 	defer {
 		os.rmdir_all(temp_dir) or {}
 	}
@@ -253,7 +252,7 @@ fn test_compiler_location_reuses_equivalent_open_uri() {
 	canonical_uri := path_to_uri(path)
 	open_uri := canonical_uri.replace_once('file:///', 'file://localhost/')
 	mut app := &App{
-		open_files:        map[string]string{}
+		open_files: map[string]string{}
 		position_encoding: .utf16
 	}
 	app.open_files[open_uri] = '🚀 target\n'
@@ -318,8 +317,7 @@ fn test_make_singlefile_temp_path_avoids_test_suffix_regression() {
 }
 
 fn test_cleanup_compilation_temp_removes_singlefile_path() {
-	tmppath := os.join_path(os.temp_dir(),
-		'vls_cleanup_single_${os.getpid()}_${time.now().unix_nano()}.v')
+	tmppath := os.join_path(os.temp_dir(), 'vls_cleanup_single_${os.getpid()}_${time.now().unix_nano()}.v')
 	interop_test_must_write_file(tmppath, 'module main\n')
 	assert os.exists(tmppath)
 	cleanup_compilation_temp('', tmppath)
@@ -327,8 +325,7 @@ fn test_cleanup_compilation_temp_removes_singlefile_path() {
 }
 
 fn test_cleanup_compilation_temp_removes_project_dir() {
-	project_dir := os.join_path(os.temp_dir(),
-		'vls_cleanup_project_${os.getpid()}_${time.now().unix_nano()}')
+	project_dir := os.join_path(os.temp_dir(), 'vls_cleanup_project_${os.getpid()}_${time.now().unix_nano()}')
 	interop_test_must_mkdir_all(project_dir)
 	interop_test_must_write_file(os.join_path(project_dir, 'main.v'), 'module main\n')
 	assert os.exists(project_dir)
@@ -374,7 +371,7 @@ fn test_build_v_check_args_multifile_uses_v3_compatible_flags() {
 
 fn test_build_v_check_args_single_no_shell_injection() {
 	// A path containing command substitution must remain one literal argv element.
-	malicious := '/tmp/$(touch /tmp/pwned)/x.v'
+	malicious := '/tmp/\$(touch /tmp/pwned)/x.v'
 	args := build_v_check_args_single(malicious)
 	assert malicious in args
 	// The dangerous text is never split or interpreted; it is exactly one element.
@@ -422,6 +419,16 @@ fn test_build_v_line_info_args_single_embeds_line_info() {
 	args := build_v_line_info_args_single('/tmp/a.v', '10:gd^5', '/tmp/a.v')
 	assert '/tmp/a.v:10:gd^5' in args
 	assert '-line-info' in args
+	assert '-json-errors' !in args
+	assert '-vls-mode' in args
+}
+
+fn test_normalize_v_line_info_output_ignores_launcher_notices() {
+	signature := 'unknown option `-vls-mode`\n{"signatures":[],"activeSignature":0}'
+	assert normalize_v_line_info_output(signature, .signature_help) == '{"signatures":[],"activeSignature":0}'
+	definition := 'unknown option `-vls-mode`\n./main.v:3:7\n'
+	assert normalize_v_line_info_output(definition, .definition) == './main.v:3:7'
+	assert normalize_v_line_info_output('unknown option `-vls-mode`', .definition) == ''
 }
 
 fn test_parse_v_check_diagnostics_reads_v3_output() {
@@ -438,12 +445,12 @@ fn test_parse_v_check_diagnostics_reads_v3_output() {
 	diagnostics := parse_v_check_diagnostics(output, '')
 	assert diagnostics.len == 2
 	assert diagnostics[0] == JsonError{
-		path:    '/tmp/main.v'
+		path: '/tmp/main.v'
 		message: 'undefined variable: `missing_name`'
 		line_nr: 4
-		col:     7
-		len:     12
-		level:   'error'
+		col: 7
+		len: 12
+		level: 'error'
 	}
 	assert diagnostics[1].level == 'warning'
 	assert diagnostics[1].line_nr == 8
@@ -458,12 +465,12 @@ fn test_parse_v_check_diagnostics_maps_v3_builder_error_to_error() {
 '
 	diagnostics := parse_v_check_diagnostics(output, '')
 	assert diagnostics == [JsonError{
-		path:    '/tmp/main.v'
+		path: '/tmp/main.v'
 		message: 'cannot import module "missing" (not found)'
 		line_nr: 3
-		col:     1
-		len:     14
-		level:   'error'
+		col: 1
+		len: 14
+		level: 'error'
 	}]
 }
 
@@ -511,8 +518,7 @@ fn test_parse_v_check_diagnostics_preserves_severity_marker_in_message() {
 }
 
 fn test_parse_v_check_diagnostics_rejects_header_marker_in_message() {
-	temp_dir := os.join_path(os.temp_dir(),
-		'vls_diagnostic_source_${os.getpid()}_${time.now().unix_nano()}')
+	temp_dir := os.join_path(os.temp_dir(), 'vls_diagnostic_source_${os.getpid()}_${time.now().unix_nano()}')
 	interop_test_must_mkdir_all(temp_dir)
 	defer {
 		os.rmdir_all(temp_dir) or {}
@@ -541,8 +547,8 @@ fn test_cache_v_check_result_retries_failure_without_diagnostics() {
 	path := 'file:///tmp/main.v'
 	app.diag_cache[path] = DiagCacheEntry{
 		content_hash: 1
-		generation:   1
-		errors:       []
+		generation: 1
+		errors: []
 	}
 	app.cache_v_check_result(path, 2, 2, [], compiler_exit_timeout, 0)
 	assert path !in app.diag_cache
@@ -553,16 +559,16 @@ fn test_cache_v_check_result_retries_timeout_with_partial_diagnostics() {
 	path := 'file:///tmp/main.v'
 	app.diag_cache[path] = DiagCacheEntry{
 		content_hash: 1
-		generation:   1
-		errors:       []
+		generation: 1
+		errors: []
 	}
 	partial_errors := [
 		JsonError{
-			path:    '/tmp/main.v'
+			path: '/tmp/main.v'
 			message: 'partial compiler output'
 			line_nr: 1
-			col:     1
-			level:   'error'
+			col: 1
+			level: 'error'
 		},
 	]
 	app.cache_v_check_result(path, 2, 2, partial_errors, compiler_exit_timeout, partial_errors.len)
@@ -583,8 +589,7 @@ fn test_cache_v_check_result_keeps_valid_clean_and_diagnostic_results() {
 }
 
 fn test_run_v_argv_reports_missing_working_dir() {
-	missing_dir := os.join_path(os.temp_dir(),
-		'vls_missing_dir_${os.getpid()}_${time.now().unix_nano()}')
+	missing_dir := os.join_path(os.temp_dir(), 'vls_missing_dir_${os.getpid()}_${time.now().unix_nano()}')
 	original := os.getwd()
 	result := run_v_argv(build_v_check_args_multifile(), missing_dir)
 	assert result.exit_code != 0
@@ -598,11 +603,11 @@ fn test_run_v_argv_reports_missing_working_dir() {
 
 fn test_v_error_to_lsp_diagnostic_basic() {
 	v_err := JsonError{
-		path:    '/test/file.v'
+		path: '/test/file.v'
 		message: 'undefined identifier `foo`'
 		line_nr: 10
-		col:     5
-		len:     3
+		col: 5
+		len: 3
 	}
 	diag := v_error_to_lsp_diagnostic(v_err)
 
@@ -617,11 +622,11 @@ fn test_v_error_to_lsp_diagnostic_basic() {
 
 fn test_v_error_to_lsp_diagnostic_first_line() {
 	v_err := JsonError{
-		path:    '/test/file.v'
+		path: '/test/file.v'
 		message: 'syntax error'
 		line_nr: 1
-		col:     1
-		len:     1
+		col: 1
+		len: 1
 	}
 	diag := v_error_to_lsp_diagnostic(v_err)
 
@@ -632,11 +637,11 @@ fn test_v_error_to_lsp_diagnostic_first_line() {
 
 fn test_v_error_to_lsp_diagnostic_long_error() {
 	v_err := JsonError{
-		path:    '/test/file.v'
+		path: '/test/file.v'
 		message: 'unexpected token'
 		line_nr: 100
-		col:     50
-		len:     20
+		col: 50
+		len: 20
 	}
 	diag := v_error_to_lsp_diagnostic(v_err)
 
@@ -647,11 +652,11 @@ fn test_v_error_to_lsp_diagnostic_long_error() {
 
 fn test_v_error_to_lsp_diagnostic_zero_length() {
 	v_err := JsonError{
-		path:    '/test/file.v'
+		path: '/test/file.v'
 		message: 'error at position'
 		line_nr: 5
-		col:     10
-		len:     0
+		col: 10
+		len: 0
 	}
 	diag := v_error_to_lsp_diagnostic(v_err)
 
@@ -661,11 +666,11 @@ fn test_v_error_to_lsp_diagnostic_zero_length() {
 
 fn test_v_error_to_lsp_diagnostic_large_line_numbers() {
 	v_err := JsonError{
-		path:    '/test/file.v'
+		path: '/test/file.v'
 		message: 'error in large file'
 		line_nr: 10000
-		col:     200
-		len:     50
+		col: 200
+		len: 50
 	}
 	diag := v_error_to_lsp_diagnostic(v_err)
 
@@ -676,11 +681,11 @@ fn test_v_error_to_lsp_diagnostic_large_line_numbers() {
 
 fn test_v_error_to_lsp_diagnostic_column_one() {
 	v_err := JsonError{
-		path:    '/test/file.v'
+		path: '/test/file.v'
 		message: 'error at start of line'
 		line_nr: 5
-		col:     1
-		len:     5
+		col: 1
+		len: 5
 	}
 	diag := v_error_to_lsp_diagnostic(v_err)
 
@@ -716,7 +721,7 @@ fn test_lsp_range_struct() {
 			line: 0
 			char: 0
 		}
-		end:   Position{
+		end: Position{
 			line: 0
 			char: 10
 		}
@@ -731,7 +736,7 @@ fn test_lsp_range_multiline() {
 			line: 5
 			char: 10
 		}
-		end:   Position{
+		end: Position{
 			line: 10
 			char: 5
 		}
@@ -741,17 +746,17 @@ fn test_lsp_range_multiline() {
 
 fn test_lsp_diagnostic_struct() {
 	diag := LSPDiagnostic{
-		range:    LSPRange{
+		range: LSPRange{
 			start: Position{
 				line: 5
 				char: 0
 			}
-			end:   Position{
+			end: Position{
 				line: 5
 				char: 10
 			}
 		}
-		message:  'test error'
+		message: 'test error'
 		severity: 1
 	}
 	assert diag.message == 'test error'
@@ -764,8 +769,8 @@ fn test_lsp_diagnostic_severities() {
 	severities := [1, 2, 3, 4] // Error, Warning, Information, Hint
 	for sev in severities {
 		diag := LSPDiagnostic{
-			range:    LSPRange{}
-			message:  'test'
+			range: LSPRange{}
+			message: 'test'
 			severity: sev
 		}
 		assert diag.severity == sev
@@ -774,13 +779,13 @@ fn test_lsp_diagnostic_severities() {
 
 fn test_location_struct() {
 	loc := Location{
-		uri:   'file:///test/file.v'
+		uri: 'file:///test/file.v'
 		range: LSPRange{
 			start: Position{
 				line: 10
 				char: 5
 			}
-			end:   Position{
+			end: Position{
 				line: 10
 				char: 15
 			}
@@ -798,9 +803,9 @@ fn test_location_empty() {
 
 fn test_detail_struct() {
 	detail := Detail{
-		kind:          6 // Function
-		label:         'my_function'
-		detail:        'fn my_function() string'
+		kind: 6 // Function
+		label: 'my_function'
+		detail: 'fn my_function() string'
 		documentation: 'A helper function'
 	}
 	assert detail.kind == 6
@@ -813,7 +818,7 @@ fn test_detail_kinds() {
 	kinds := [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] // Text, Method, Function, etc.
 	for k in kinds {
 		detail := Detail{
-			kind:  k
+			kind: k
 			label: 'test'
 		}
 		assert detail.kind == k
@@ -822,11 +827,11 @@ fn test_detail_kinds() {
 
 fn test_detail_struct_with_snippet() {
 	detail := Detail{
-		kind:               6
-		label:              'println'
-		detail:             'fn println(s string)'
-		documentation:      'Prints a string'
-		insert_text:        'println(\${1:s})'
+		kind: 6
+		label: 'println'
+		detail: 'fn println(s string)'
+		documentation: 'Prints a string'
+		insert_text: 'println(\${1:s})'
 		insert_text_format: 2 // Snippet format
 	}
 	assert detail.insert_text? == 'println(\${1:s})'
@@ -835,7 +840,7 @@ fn test_detail_struct_with_snippet() {
 
 fn test_detail_without_snippet() {
 	detail := Detail{
-		kind:  6
+		kind: 6
 		label: 'println'
 	}
 	assert detail.insert_text == none
@@ -844,9 +849,9 @@ fn test_detail_without_snippet() {
 
 fn test_signature_help_struct() {
 	sig := SignatureHelp{
-		signatures:       [
+		signatures: [
 			SignatureInformation{
-				label:      'fn my_func(a int, b string) bool'
+				label: 'fn my_func(a int, b string) bool'
 				parameters: [
 					ParameterInformation{
 						label: 'a int'
@@ -867,7 +872,7 @@ fn test_signature_help_struct() {
 
 fn test_signature_help_multiple_signatures() {
 	sig := SignatureHelp{
-		signatures:       [
+		signatures: [
 			SignatureInformation{
 				label: 'fn overload1(a int)'
 			},
@@ -895,17 +900,17 @@ fn test_signature_help_empty() {
 fn test_capabilities_struct() {
 	cap := Capabilities{
 		capabilities: Capability{
-			text_document_sync:      TextDocumentSyncOptions{
+			text_document_sync: TextDocumentSyncOptions{
 				open_close: true
-				change:     1
+				change: 1
 			}
-			completion_provider:     CompletionProvider{
+			completion_provider: CompletionProvider{
 				trigger_characters: ['.']
 			}
 			signature_help_provider: SignatureHelpOptions{
 				trigger_characters: ['(', ',']
 			}
-			definition_provider:     true
+			definition_provider: true
 		}
 	}
 	assert cap.capabilities.definition_provider == true
@@ -926,11 +931,11 @@ fn test_capabilities_minimal() {
 
 fn test_request_struct() {
 	req := Request{
-		id:      1
-		method:  'textDocument/completion'
+		id: 1
+		method: 'textDocument/completion'
 		jsonrpc: '2.0'
-		params:  json2.encode(Params{
-			position:      Position{
+		params: json2.encode(Params{
+			position: Position{
 				line: 5
 				char: 10
 			}
@@ -961,7 +966,7 @@ fn test_request_params_decode_malformed_returns_error() {
 
 fn test_response_struct() {
 	resp := Response{
-		id:     1
+		id: 1
 		result: 'null'
 	}
 	assert resp.id == 1
@@ -970,7 +975,7 @@ fn test_response_struct() {
 
 fn test_response_with_capabilities() {
 	resp := Response{
-		id:     0
+		id: 0
 		result: Capabilities{
 			capabilities: Capability{
 				definition_provider: true
@@ -987,7 +992,7 @@ fn test_notification_struct() {
 	notif := Notification{
 		method: 'textDocument/publishDiagnostics'
 		params: PublishDiagnosticsParams{
-			uri:         'file:///test.v'
+			uri: 'file:///test.v'
 			diagnostics: []
 		}
 	}
@@ -999,16 +1004,16 @@ fn test_notification_with_diagnostics() {
 	notif := Notification{
 		method: 'textDocument/publishDiagnostics'
 		params: PublishDiagnosticsParams{
-			uri:         'file:///test.v'
+			uri: 'file:///test.v'
 			diagnostics: [
 				LSPDiagnostic{
-					range:    LSPRange{}
-					message:  'error 1'
+					range: LSPRange{}
+					message: 'error 1'
 					severity: 1
 				},
 				LSPDiagnostic{
-					range:    LSPRange{}
-					message:  'error 2'
+					range: LSPRange{}
+					message: 'error 2'
 					severity: 1
 				},
 			]
@@ -1051,7 +1056,7 @@ fn test_write_tracked_files_to_temp_single_file() {
 	interop_test_must_write_file(test_file, 'module main')
 
 	mut app := &App{
-		temp_dir:   temp_dir
+		temp_dir: temp_dir
 		open_files: map[string]string{}
 	}
 
@@ -1089,7 +1094,7 @@ fn test_write_tracked_files_to_temp_multiple_files() {
 	}
 
 	mut app := &App{
-		temp_dir:   temp_dir
+		temp_dir: temp_dir
 		open_files: map[string]string{}
 	}
 
@@ -1130,7 +1135,7 @@ fn test_write_tracked_files_to_temp_nested_directories() {
 	interop_test_must_write_file(nested_file, 'module internal')
 
 	mut app := &App{
-		temp_dir:   temp_dir
+		temp_dir: temp_dir
 		open_files: map[string]string{}
 	}
 
@@ -1151,8 +1156,7 @@ fn test_write_tracked_files_to_temp_nested_directories() {
 }
 
 fn test_prepare_compilation_overlay_preserves_nested_symlink_layout() {
-	temp_dir := os.join_path(os.temp_dir(),
-		'vls_overlay_nested_symlink_${os.getpid()}_${time.now().unix_nano()}')
+	temp_dir := os.join_path(os.temp_dir(), 'vls_overlay_nested_symlink_${os.getpid()}_${time.now().unix_nano()}')
 	defer {
 		os.rmdir_all(temp_dir) or {}
 	}
@@ -1163,8 +1167,7 @@ fn test_prepare_compilation_overlay_preserves_nested_symlink_layout() {
 	interop_test_must_mkdir_all(project_dir)
 	interop_test_must_mkdir_all(shared_src)
 	interop_test_must_mkdir_all(app_temp_dir)
-	interop_test_must_write_file(os.join_path(project_dir, 'v.mod'),
-		"Module {\n\tname: 'nested_symlink_test'\n}\n")
+	interop_test_must_write_file(os.join_path(project_dir, 'v.mod'), "Module {\n\tname: 'nested_symlink_test'\n}\n")
 	os.symlink(shared_src, lexical_src) or { return }
 
 	main_file := os.join_path(lexical_src, 'main.v')
@@ -1172,7 +1175,7 @@ fn test_prepare_compilation_overlay_preserves_nested_symlink_layout() {
 	main_uri := path_to_uri(main_file)
 	unsaved_content := 'module main\n\nfn unsaved() {}\n'
 	mut app := &App{
-		temp_dir:   app_temp_dir
+		temp_dir: app_temp_dir
 		open_files: {
 			main_uri: unsaved_content
 		}
@@ -1198,8 +1201,7 @@ fn test_prepare_compilation_overlay_preserves_nested_symlink_layout() {
 
 fn test_prepare_compilation_overlay_preserves_posix_backslashes() {
 	$if !windows {
-		temp_dir := os.join_path(os.temp_dir(),
-			'vls_overlay_posix_backslash_${os.getpid()}_${time.now().unix_nano()}')
+		temp_dir := os.join_path(os.temp_dir(), 'vls_overlay_posix_backslash_${os.getpid()}_${time.now().unix_nano()}')
 		defer {
 			os.rmdir_all(temp_dir) or {}
 		}
@@ -1207,15 +1209,14 @@ fn test_prepare_compilation_overlay_preserves_posix_backslashes() {
 		app_temp_dir := os.join_path(temp_dir, 'app-temp')
 		interop_test_must_mkdir_all(project_dir)
 		interop_test_must_mkdir_all(app_temp_dir)
-		interop_test_must_write_file(os.join_path(project_dir, 'v.mod'),
-			"Module {\n\tname: 'posix_backslash_test'\n}\n")
+		interop_test_must_write_file(os.join_path(project_dir, 'v.mod'), "Module {\n\tname: 'posix_backslash_test'\n}\n")
 		main_file := os.join_path(project_dir, 'main.v')
 		interop_test_must_write_file(main_file, 'module main\n')
 		main_uri := path_to_uri(main_file)
 		assert uri_to_path(main_uri) == main_file
 		unsaved_content := 'module main\n\nfn unsaved() {}\n'
 		mut app := &App{
-			temp_dir:   app_temp_dir
+			temp_dir: app_temp_dir
 			open_files: {
 				main_uri: unsaved_content
 			}
@@ -1253,7 +1254,7 @@ fn test_write_tracked_files_skips_files_outside_working_dir() {
 	interop_test_must_write_file(other_file, 'module other')
 
 	mut app := &App{
-		temp_dir:   temp_dir
+		temp_dir: temp_dir
 		open_files: map[string]string{}
 	}
 
@@ -1363,8 +1364,7 @@ fn test_symlink_untracked_files_empty_tracked() {
 }
 
 fn test_symlink_untracked_files_materializes_local_imports() {
-	temp_dir := os.join_path(os.temp_dir(),
-		'vls_symlink_local_import_${os.getpid()}_${time.now().unix_nano()}')
+	temp_dir := os.join_path(os.temp_dir(), 'vls_symlink_local_import_${os.getpid()}_${time.now().unix_nano()}')
 	defer {
 		os.rmdir_all(temp_dir) or {}
 	}
@@ -1398,8 +1398,7 @@ fn test_symlink_untracked_files_materializes_local_imports() {
 }
 
 fn test_symlink_untracked_files_materializes_import_relative_to_source_module() {
-	temp_dir := os.join_path(os.temp_dir(),
-		'vls_symlink_nested_import_${os.getpid()}_${time.now().unix_nano()}')
+	temp_dir := os.join_path(os.temp_dir(), 'vls_symlink_nested_import_${os.getpid()}_${time.now().unix_nano()}')
 	defer {
 		os.rmdir_all(temp_dir) or {}
 	}
@@ -1439,8 +1438,7 @@ fn deny_overlay_symlink(_ string, _ string) ! {
 
 fn test_symlink_untracked_files_matches_tracked_descendants_with_windows_case_rules() {
 	$if windows {
-		temp_dir := os.join_path(os.temp_dir(),
-			'vls_overlay_windows_case_${os.getpid()}_${time.now().unix_nano()}')
+		temp_dir := os.join_path(os.temp_dir(), 'vls_overlay_windows_case_${os.getpid()}_${time.now().unix_nano()}')
 		defer {
 			os.rmdir_all(temp_dir) or {}
 		}
@@ -1454,14 +1452,12 @@ fn test_symlink_untracked_files_matches_tracked_descendants_with_windows_case_ru
 		sibling_file := os.join_path(source_dir, 'sibling.v')
 		interop_test_must_write_file(main_file, 'module main\n')
 		interop_test_must_write_file(sibling_file, 'module main\n')
-		interop_test_must_write_file(os.join_path(target_source_dir, 'main.v'),
-			'module main\n\n// unsaved\n')
+		interop_test_must_write_file(os.join_path(target_source_dir, 'main.v'), 'module main\n\n// unsaved\n')
 
 		mut tracked := map[string]string{}
 		lowercase_main_file := os.join_path(project_dir, 'src', 'main.v')
 		tracked[path_to_uri(lowercase_main_file)] = 'module main\n\n// unsaved\n'
-		symlink_untracked_files_with_linker(project_dir, project_dir, target_dir, tracked,
-			deny_overlay_symlink) or {
+		symlink_untracked_files_with_linker(project_dir, project_dir, target_dir, tracked, deny_overlay_symlink) or {
 			assert false, 'Failed to populate case-insensitive overlay: ${err}'
 			return
 		}
@@ -1471,8 +1467,7 @@ fn test_symlink_untracked_files_matches_tracked_descendants_with_windows_case_ru
 }
 
 fn test_bounded_overlay_copy_caps_file_count_across_entries() {
-	temp_dir := os.join_path(os.temp_dir(),
-		'vls_overlay_file_limit_${os.getpid()}_${time.now().unix_nano()}')
+	temp_dir := os.join_path(os.temp_dir(), 'vls_overlay_file_limit_${os.getpid()}_${time.now().unix_nano()}')
 	defer {
 		os.rmdir_all(temp_dir) or {}
 	}
@@ -1486,15 +1481,13 @@ fn test_bounded_overlay_copy_caps_file_count_across_entries() {
 		max_bytes: 1024
 	}
 	mut first_visited := map[string]bool{}
-	copied := copy_bounded_overlay_entry(os.join_path(source_dir, 'one.txt'), os.join_path(target_dir,
-		'one.txt'), mut budget, mut first_visited) or {
+	copied := copy_bounded_overlay_entry(os.join_path(source_dir, 'one.txt'), os.join_path(target_dir, 'one.txt'), mut budget, mut first_visited) or {
 		assert false, 'Failed to copy the first bounded entry: ${err}'
 		return
 	}
 	assert copied == 1
 	mut second_visited := map[string]bool{}
-	second_copied := copy_bounded_overlay_entry(os.join_path(source_dir, 'two.txt'), os.join_path(target_dir,
-		'two.txt'), mut budget, mut second_visited) or {
+	second_copied := copy_bounded_overlay_entry(os.join_path(source_dir, 'two.txt'), os.join_path(target_dir, 'two.txt'), mut budget, mut second_visited) or {
 		assert false, 'The overlay file limit must not abort the fallback: ${err}'
 		return
 	}
@@ -1504,8 +1497,7 @@ fn test_bounded_overlay_copy_caps_file_count_across_entries() {
 }
 
 fn test_bounded_overlay_copy_caps_bytes() {
-	temp_dir := os.join_path(os.temp_dir(),
-		'vls_overlay_byte_limit_${os.getpid()}_${time.now().unix_nano()}')
+	temp_dir := os.join_path(os.temp_dir(), 'vls_overlay_byte_limit_${os.getpid()}_${time.now().unix_nano()}')
 	defer {
 		os.rmdir_all(temp_dir) or {}
 	}
@@ -1528,8 +1520,7 @@ fn test_bounded_overlay_copy_caps_bytes() {
 }
 
 fn test_symlink_denied_fallback_copies_external_symlink_targets() {
-	temp_dir := os.join_path(os.temp_dir(),
-		'vls_external_symlink_${os.getpid()}_${time.now().unix_nano()}')
+	temp_dir := os.join_path(os.temp_dir(), 'vls_external_symlink_${os.getpid()}_${time.now().unix_nano()}')
 	defer {
 		os.rmdir_all(temp_dir) or {}
 	}
@@ -1544,8 +1535,7 @@ fn test_symlink_denied_fallback_copies_external_symlink_targets() {
 	interop_test_must_write_file(os.join_path(external_dir, 'config.json'), '{"external":true}\n')
 	os.symlink(external_dir, linked_dir) or { return }
 
-	symlink_untracked_files_with_linker(project_dir, project_dir, target_dir, map[string]string{},
-		deny_overlay_symlink) or {
+	symlink_untracked_files_with_linker(project_dir, project_dir, target_dir, map[string]string{}, deny_overlay_symlink) or {
 		assert false, 'Failed to copy an external symlink target: ${err}'
 		return
 	}
@@ -1557,8 +1547,7 @@ fn test_symlink_denied_fallback_copies_external_symlink_targets() {
 }
 
 fn test_local_module_copy_fallback_shares_overlay_budget() {
-	temp_dir := os.join_path(os.temp_dir(),
-		'vls_local_module_budget_${os.getpid()}_${time.now().unix_nano()}')
+	temp_dir := os.join_path(os.temp_dir(), 'vls_local_module_budget_${os.getpid()}_${time.now().unix_nano()}')
 	defer {
 		os.rmdir_all(temp_dir) or {}
 	}
@@ -1575,14 +1564,12 @@ fn test_local_module_copy_fallback_shares_overlay_budget() {
 		max_bytes: 1024
 	}
 	mut visited := map[string]bool{}
-	copy_bounded_overlay_entry(asset_file, os.join_path(target_dir, 'asset.txt'), mut budget, mut
-		visited) or {
+	copy_bounded_overlay_entry(asset_file, os.join_path(target_dir, 'asset.txt'), mut budget, mut visited) or {
 		assert false, 'Failed to consume the first overlay budget slot: ${err}'
 		return
 	}
 	target_module := os.join_path(target_dir, 'helper.v')
-	materialized := materialize_overlay_file_with_linker(module_file, target_module,
-		deny_overlay_symlink, mut budget) or {
+	materialized := materialize_overlay_file_with_linker(module_file, target_module, deny_overlay_symlink, mut budget) or {
 		assert false, 'The local-module copy limit must not abort the overlay: ${err}'
 		return
 	}
@@ -1592,8 +1579,7 @@ fn test_local_module_copy_fallback_shares_overlay_budget() {
 }
 
 fn test_symlink_denied_fallback_keeps_sources_when_copy_limit_is_reached() {
-	temp_dir := os.join_path(os.temp_dir(),
-		'vls_overlay_partial_${os.getpid()}_${time.now().unix_nano()}')
+	temp_dir := os.join_path(os.temp_dir(), 'vls_overlay_partial_${os.getpid()}_${time.now().unix_nano()}')
 	defer {
 		os.rmdir_all(temp_dir) or {}
 	}
@@ -1610,8 +1596,7 @@ fn test_symlink_denied_fallback_keeps_sources_when_copy_limit_is_reached() {
 		max_files: 1
 		max_bytes: 1024
 	}
-	symlink_untracked_tree(source_dir, source_dir, target_dir, '', []string{}, []string{},
-		deny_overlay_symlink, mut budget) or {
+	symlink_untracked_tree(source_dir, source_dir, target_dir, '', []string{}, []string{}, deny_overlay_symlink, mut budget) or {
 		assert false, 'The copy limit must preserve the partial overlay: ${err}'
 		return
 	}
@@ -1622,8 +1607,7 @@ fn test_symlink_denied_fallback_keeps_sources_when_copy_limit_is_reached() {
 }
 
 fn test_symlink_untracked_files_copies_when_symlinks_are_denied() {
-	temp_dir := os.join_path(os.temp_dir(),
-		'vls_symlink_denied_${os.getpid()}_${time.now().unix_nano()}')
+	temp_dir := os.join_path(os.temp_dir(), 'vls_symlink_denied_${os.getpid()}_${time.now().unix_nano()}')
 	defer {
 		os.rmdir_all(temp_dir) or {}
 	}
@@ -1654,25 +1638,19 @@ fn test_symlink_untracked_files_copies_when_symlinks_are_denied() {
 	interop_test_must_write_file(module_file, module_content)
 	interop_test_must_write_file(os.join_path(project_dir, 'README.md'), 'project documentation\n')
 	interop_test_must_write_file(os.join_path(assets_dir, 'config.json'), '{"enabled":true}\n')
-	interop_test_must_write_file(os.join_path(assets_dir, 'template.txt'),
-		'Hello, embedded asset!\n')
+	interop_test_must_write_file(os.join_path(assets_dir, 'template.txt'), 'Hello, embedded asset!\n')
 	interop_test_must_write_file(os.join_path(assets_dir, 'logo.png'), 'fake png bytes')
 	interop_test_must_write_file(os.join_path(git_dir, 'metadata.json'), '{"git":true}\n')
-	interop_test_must_write_file(os.join_path(node_modules_dir, 'dependency.json'),
-		'{"dependency":true}\n')
-	interop_test_must_write_file(os.join_path(thirdparty_dir, 'dependency.json'),
-		'{"native_dependency":true}\n')
-	interop_test_must_write_file(os.join_path(thirdparty_dir, 'embedded.json'),
-		'{"embedded":true}\n')
-	interop_test_must_write_file(os.join_path(thirdparty_dir, 'dependency.h'),
-		'#define DEPENDENCY 1\n')
+	interop_test_must_write_file(os.join_path(node_modules_dir, 'dependency.json'), '{"dependency":true}\n')
+	interop_test_must_write_file(os.join_path(thirdparty_dir, 'dependency.json'), '{"native_dependency":true}\n')
+	interop_test_must_write_file(os.join_path(thirdparty_dir, 'embedded.json'), '{"embedded":true}\n')
+	interop_test_must_write_file(os.join_path(thirdparty_dir, 'dependency.h'), '#define DEPENDENCY 1\n')
 	interop_test_must_write_file(os.join_path(thirdparty_dir, 'dependency.a'), 'fake library bytes')
 	interop_test_must_write_file(os.join_path(build_dir, 'generated.json'), '{"build":true}\n')
 
 	mut tracked := map[string]string{}
 	tracked[path_to_uri(main_file)] = "module main\n\n#flag -I @VMODROOT/thirdparty/native_dependency\nconst embedded = \$embed_file('thirdparty/native_dependency/embedded.json')\n"
-	symlink_untracked_files_with_linker(project_dir, project_dir, target_dir, tracked,
-		deny_overlay_symlink) or {
+	symlink_untracked_files_with_linker(project_dir, project_dir, target_dir, tracked, deny_overlay_symlink) or {
 		assert false, 'Failed to copy denied symlinks: ${err}'
 		return
 	}
@@ -1737,8 +1715,8 @@ fn test_json_error_negative_values() {
 	// to 0 rather than emitted as negative positions (P1-09).
 	err := JsonError{
 		line_nr: -1
-		col:     -1
-		len:     -1
+		col: -1
+		len: -1
 	}
 	diag := v_error_to_lsp_diagnostic(err)
 	assert diag.severity == 1
@@ -1765,11 +1743,11 @@ fn test_params_struct_complete() {
 		content_changes: [ContentChange{
 			text: 'test'
 		}]
-		position:        Position{
+		position: Position{
 			line: 5
 			char: 10
 		}
-		text_document:   TextDocumentIdentifier{
+		text_document: TextDocumentIdentifier{
 			uri: 'file:///test.v'
 		}
 	}
@@ -1797,7 +1775,7 @@ fn test_signature_help_options_triggers() {
 fn test_text_document_sync_options() {
 	sync := TextDocumentSyncOptions{
 		open_close: true
-		change:     1 // Full sync
+		change: 1 // Full sync
 	}
 	assert sync.open_close == true
 	assert sync.change == 1
@@ -1806,7 +1784,7 @@ fn test_text_document_sync_options() {
 fn test_text_document_sync_incremental() {
 	sync := TextDocumentSyncOptions{
 		open_close: true
-		change:     2 // Incremental sync
+		change: 2 // Incremental sync
 	}
 	assert sync.change == 2
 }
@@ -1820,7 +1798,7 @@ fn test_parameter_information() {
 
 fn test_signature_information_with_params() {
 	sig := SignatureInformation{
-		label:      'fn test(a int, b string, c bool)'
+		label: 'fn test(a int, b string, c bool)'
 		parameters: [
 			ParameterInformation{
 				label: 'a int'
@@ -1839,11 +1817,11 @@ fn test_signature_information_with_params() {
 
 fn test_publish_diagnostics_params() {
 	params := PublishDiagnosticsParams{
-		uri:         'file:///test.v'
+		uri: 'file:///test.v'
 		diagnostics: [
 			LSPDiagnostic{
-				range:    LSPRange{}
-				message:  'error'
+				range: LSPRange{}
+				message: 'error'
 				severity: 1
 			},
 		]

--- a/interop_test.v
+++ b/interop_test.v
@@ -215,10 +215,15 @@ fn test_path_to_uri_relative() {
 fn test_path_to_uri_with_backslashes() {
 	// On POSIX a backslash is a valid, literal filename character. It must be
 	// percent-encoded in the URI (never left raw) and must round-trip exactly.
+	// Windows treats the same bytes as path separators and normalizes them.
 	original := '/home/user\\project\\main.v'
 	result := path_to_uri(original)
 	assert !result.contains('\\')
-	assert uri_to_path(result) == original
+	$if windows {
+		assert uri_to_path(result) == original.replace('\\', '/')
+	} $else {
+		assert uri_to_path(result) == original
+	}
 }
 
 fn test_path_to_uri_empty() {

--- a/lsp.v
+++ b/lsp.v
@@ -37,7 +37,7 @@ struct Params {
 	position        Position
 	range           LSPRange
 	text_document   TextDocumentIdentifier @[json: 'textDocument']
-	new_name        string                 @[json: 'newName']
+	new_name        string @[json: 'newName']
 }
 
 // Optional JSON integers use i64 because V3 emits a generic option ABI for struct fields, while
@@ -116,7 +116,7 @@ type ResponseResult = string
 struct WorkspaceSymbol {
 	name           string
 	kind           int
-	tags           ?[]int  @[json: 'tags']
+	tags           ?[]int @[json: 'tags']
 	container_name ?string @[json: 'containerName']
 	location       Location
 }
@@ -174,8 +174,8 @@ struct LSPDiagnostic {
 	message  string
 	severity int
 	source   ?string @[json: 'source'] // diagnostic source identifier, e.g. 'vlang'
-	code     ?string @[json: 'code']   // optional diagnostic code, e.g. 'unused_variable'
-	tags     ?[]int  @[json: 'tags']   // 1 = unnecessary, 2 = deprecated
+	code     ?string @[json: 'code'] // optional diagnostic code, e.g. 'unused_variable'
+	tags     ?[]int @[json: 'tags'] // 1 = unnecessary, 2 = deprecated
 }
 
 // LSPRange represents a range in a text document.
@@ -186,17 +186,17 @@ struct LSPRange {
 
 // Detail represents a completion or symbol detail item.
 struct Detail {
-	kind               int    // The type of item (e.g., Method, Function, Field)
+	kind               int // The type of item (e.g., Method, Function, Field)
 	label              string // The name of the completion item
 	detail             string // Additional info like the function signature or return type
 	declaration        string // Full fn declaration, e.g. "fn greet(name string) string"
 	documentation      string // The documentation for the item
-	sort_text          ?string @[json: 'sortText']   // sort key, defaults to label
+	sort_text          ?string @[json: 'sortText'] // sort key, defaults to label
 	filter_text        ?string @[json: 'filterText'] // filter key, defaults to label
 	insert_text        ?string @[json: 'insertText']
-	insert_text_format ?i64    @[json: 'insertTextFormat'] // 1 for PlainText, 2 for Snippet
-	tags               ?[]int  @[json: 'tags']             // 1 = deprecated
-	deprecated         ?bool   @[json: 'deprecated']       // legacy deprecated flag
+	insert_text_format ?i64 @[json: 'insertTextFormat'] // 1 for PlainText, 2 for Snippet
+	tags               ?[]int @[json: 'tags'] // 1 = deprecated
+	deprecated         ?bool @[json: 'deprecated'] // legacy deprecated flag
 }
 
 // Capabilities describes the server's capabilities.
@@ -254,7 +254,7 @@ struct WorkspaceFoldersServerCapability {
 
 // WorkspaceCapability advertises workspace-level server features.
 struct WorkspaceCapability {
-	file_operations   ?WorkspaceFileOperations          @[json: 'fileOperations']
+	file_operations   ?WorkspaceFileOperations @[json: 'fileOperations']
 	workspace_folders ?WorkspaceFoldersServerCapability @[json: 'workspaceFolders']
 }
 
@@ -265,39 +265,39 @@ struct CodeLensOptions {
 
 // Capability lists supported LSP features for the server.
 struct Capability {
-	completion_provider                CompletionProvider       @[json: 'completionProvider']
-	text_document_sync                 TextDocumentSyncOptions  @[json: 'textDocumentSync']
-	signature_help_provider            SignatureHelpOptions     @[json: 'signatureHelpProvider']
-	definition_provider                bool                     @[json: 'definitionProvider']
-	declaration_provider               bool                     @[json: 'declarationProvider']
-	type_definition_provider           bool                     @[json: 'typeDefinitionProvider']
-	implementation_provider            bool                     @[json: 'implementationProvider']
-	hover_provider                     bool                     @[json: 'hoverProvider']
-	references_provider                bool                     @[json: 'referencesProvider']
-	rename_provider                    RenameOptions            @[json: 'renameProvider']
-	execute_command_provider           ?ExecuteCommandOptions   @[json: 'executeCommandProvider']
-	document_formatting_provider       bool                     @[json: 'documentFormattingProvider']
-	document_range_formatting_provider bool                     @[json: 'documentRangeFormattingProvider']
-	document_symbol_provider           bool                     @[json: 'documentSymbolProvider']
-	workspace_symbol_provider          bool                     @[json: 'workspaceSymbolProvider']
-	inlay_hint_provider                bool                     @[json: 'inlayHintProvider']
-	code_action_provider               bool                     @[json: 'codeActionProvider']
-	code_lens_provider                 ?CodeLensOptions         @[json: 'codeLensProvider']
-	inline_value_provider              bool                     @[json: 'inlineValueProvider']
-	linked_editing_range_provider      bool                     @[json: 'linkedEditingRangeProvider']
+	completion_provider                CompletionProvider @[json: 'completionProvider']
+	text_document_sync                 TextDocumentSyncOptions @[json: 'textDocumentSync']
+	signature_help_provider            SignatureHelpOptions @[json: 'signatureHelpProvider']
+	definition_provider                bool @[json: 'definitionProvider']
+	declaration_provider               bool @[json: 'declarationProvider']
+	type_definition_provider           bool @[json: 'typeDefinitionProvider']
+	implementation_provider            bool @[json: 'implementationProvider']
+	hover_provider                     bool @[json: 'hoverProvider']
+	references_provider                bool @[json: 'referencesProvider']
+	rename_provider                    RenameOptions @[json: 'renameProvider']
+	execute_command_provider           ?ExecuteCommandOptions @[json: 'executeCommandProvider']
+	document_formatting_provider       bool @[json: 'documentFormattingProvider']
+	document_range_formatting_provider bool @[json: 'documentRangeFormattingProvider']
+	document_symbol_provider           bool @[json: 'documentSymbolProvider']
+	workspace_symbol_provider          bool @[json: 'workspaceSymbolProvider']
+	inlay_hint_provider                bool @[json: 'inlayHintProvider']
+	code_action_provider               bool @[json: 'codeActionProvider']
+	code_lens_provider                 ?CodeLensOptions @[json: 'codeLensProvider']
+	inline_value_provider              bool @[json: 'inlineValueProvider']
+	linked_editing_range_provider      bool @[json: 'linkedEditingRangeProvider']
 	on_type_formatting_provider        ?OnTypeFormattingOptions @[json: 'documentOnTypeFormattingProvider']
-	semantic_tokens_provider           SemanticTokensOptions    @[json: 'semanticTokensProvider']
-	folding_range_provider             bool                     @[json: 'foldingRangeProvider']
-	call_hierarchy_provider            bool                     @[json: 'callHierarchyProvider']
-	document_highlight_provider        bool                     @[json: 'documentHighlightProvider']
-	selection_range_provider           bool                     @[json: 'selectionRangeProvider']
+	semantic_tokens_provider           SemanticTokensOptions @[json: 'semanticTokensProvider']
+	folding_range_provider             bool @[json: 'foldingRangeProvider']
+	call_hierarchy_provider            bool @[json: 'callHierarchyProvider']
+	document_highlight_provider        bool @[json: 'documentHighlightProvider']
+	selection_range_provider           bool @[json: 'selectionRangeProvider']
 	workspace                          WorkspaceCapability
 	position_encoding                  ?string @[json: 'positionEncoding']
 }
 
 // OnTypeFormattingOptions describes the triggers for on-type formatting.
 struct OnTypeFormattingOptions {
-	first_trigger_character string   @[json: 'firstTriggerCharacter']
+	first_trigger_character string @[json: 'firstTriggerCharacter']
 	more_trigger_characters []string @[json: 'moreTriggerCharacters']
 }
 
@@ -674,8 +674,8 @@ struct OnTypeFormattingParams {
 
 // InitializeParams holds client startup parameters relevant to server workspace scope.
 struct InitializeParams {
-	root_uri          ?string            @[json: 'rootUri']
-	root_path         ?string            @[json: 'rootPath']
+	root_uri          ?string @[json: 'rootUri']
+	root_path         ?string @[json: 'rootPath']
 	workspace_folders ?[]WorkspaceFolder @[json: 'workspaceFolders']
 	capabilities      ?ClientCapabilities
 }
@@ -704,7 +704,7 @@ struct SaveOptions {
 // TextDocumentSyncOptions describes document synchronization options.
 struct TextDocumentSyncOptions {
 	open_close           bool @[json: 'openClose']
-	change               int         // 1 for Full, 2 for Incremental
+	change               int // 1 for Full, 2 for Incremental
 	save                 SaveOptions // emit {"includeText":true} to receive text in didSave
 	will_save            bool @[json: 'willSave']
 	will_save_wait_until bool @[json: 'willSaveWaitUntil']
@@ -776,7 +776,7 @@ const inlay_hint_kind_type = 1
 struct InlayHint {
 	position     Position
 	label        string
-	kind         int  @[json: 'kind']
+	kind         int @[json: 'kind']
 	padding_left bool @[json: 'paddingLeft']
 }
 
@@ -881,55 +881,55 @@ struct FileEvent {
 }
 
 enum Method {
-	unknown                                 @['unknown']
-	initialize                              @['initialize']
-	initialized                             @['initialized']
-	did_open                                @['textDocument/didOpen']
-	did_change                              @['textDocument/didChange']
-	did_close                               @['textDocument/didClose']
-	did_save                                @['textDocument/didSave']
-	definition                              @['textDocument/definition']
-	declaration                             @['textDocument/declaration']
-	type_definition                         @['textDocument/typeDefinition']
-	implementation                          @['textDocument/implementation']
-	completion                              @['textDocument/completion']
-	signature_help                          @['textDocument/signatureHelp']
-	hover                                   @['textDocument/hover']
-	references                              @['textDocument/references']
-	rename                                  @['textDocument/rename']
-	prepare_rename                          @['textDocument/prepareRename']
-	formatting                              @['textDocument/formatting']
-	document_symbols                        @['textDocument/documentSymbol']
-	workspace_symbol                        @['workspace/symbol']
-	inlay_hint                              @['textDocument/inlayHint']
-	code_action                             @['textDocument/codeAction']
-	semantic_tokens                         @['textDocument/semanticTokens/full']
-	folding_range                           @['textDocument/foldingRange']
-	callhierarchy_prepare                   @['textDocument/prepareCallHierarchy']
-	callhierarchy_incoming                  @['callHierarchy/incomingCalls']
-	callhierarchy_outgoing                  @['callHierarchy/outgoingCalls']
-	workspace_did_change_configuration      @['workspace/didChangeConfiguration']
-	workspace_did_change_workspace_folders  @['workspace/didChangeWorkspaceFolders']
-	document_highlight                      @['textDocument/documentHighlight']
-	selection_range                         @['textDocument/selectionRange']
-	semantic_tokens_range                   @['textDocument/semanticTokens/range']
-	range_formatting                        @['textDocument/rangeFormatting']
-	will_save                 @['textDocument/willSave']
-	will_save_wait_until      @['textDocument/willSaveWaitUntil']
-	did_change_watched_files  @['workspace/didChangeWatchedFiles']
-	code_lens                 @['textDocument/codeLens']
-	code_lens_resolve         @['codeLens/resolve']
-	execute_command           @['workspace/executeCommand']
-	inline_value              @['textDocument/inlineValue']
-	linked_editing_range      @['textDocument/linkedEditingRange']
-	will_create_files         @['workspace/willCreateFiles']
-	will_rename_files         @['workspace/willRenameFiles']
-	will_delete_files         @['workspace/willDeleteFiles']
-	on_type_formatting        @['textDocument/onTypeFormatting']
-	set_trace                 @['$/setTrace']
-	cancel_request            @['$/cancelRequest']
-	shutdown                  @['shutdown']
-	exit                      @['exit']
+	unknown
+	initialize
+	initialized
+	did_open
+	did_change
+	did_close
+	did_save
+	definition
+	declaration
+	type_definition
+	implementation
+	completion
+	signature_help
+	hover
+	references
+	rename
+	prepare_rename
+	formatting
+	document_symbols
+	workspace_symbol
+	inlay_hint
+	code_action
+	semantic_tokens
+	folding_range
+	callhierarchy_prepare
+	callhierarchy_incoming
+	callhierarchy_outgoing
+	workspace_did_change_configuration
+	workspace_did_change_workspace_folders
+	document_highlight
+	selection_range
+	semantic_tokens_range
+	range_formatting
+	will_save
+	will_save_wait_until
+	did_change_watched_files
+	code_lens
+	code_lens_resolve
+	execute_command
+	inline_value
+	linked_editing_range
+	will_create_files
+	will_rename_files
+	will_delete_files
+	on_type_formatting
+	set_trace
+	cancel_request
+	shutdown
+	exit
 }
 
 // TextDocumentPositionParams for position-based requests
@@ -955,7 +955,7 @@ struct DidOpenTextDocumentParams {
 // DidChangeTextDocumentParams for didChange
 struct DidChangeTextDocumentParams {
 	text_document   VersionedTextDocumentIdentifier @[json: 'textDocument']
-	content_changes []ContentChange                 @[json: 'contentChanges']
+	content_changes []ContentChange @[json: 'contentChanges']
 }
 
 // DidCloseTextDocumentParams for didClose
@@ -998,7 +998,7 @@ struct RenameParams {
 // FormattingOptions carries client formatting preferences (LSP §3.17).
 // VLS ignores these and always delegates to `v fmt`.
 struct FormattingOptions {
-	tab_size      int  @[json: 'tabSize']
+	tab_size      int @[json: 'tabSize']
 	insert_spaces bool @[json: 'insertSpaces']
 }
 
@@ -1025,19 +1025,114 @@ struct WorkspaceSymbolParams {
 }
 
 fn Method.from_string(s string) Method {
-	$for m in Method.values {
-		if s == m.attrs[0] {
-			return m.value
+	if s.len > 0 && s[0] == 36 {
+		return match s[1..] {
+			'/setTrace' { .set_trace }
+			'/cancelRequest' { .cancel_request }
+			else { .unknown }
 		}
 	}
-	return Method.unknown
+	return match s {
+		'initialize' { .initialize }
+		'initialized' { .initialized }
+		'textDocument/didOpen' { .did_open }
+		'textDocument/didChange' { .did_change }
+		'textDocument/didClose' { .did_close }
+		'textDocument/didSave' { .did_save }
+		'textDocument/definition' { .definition }
+		'textDocument/declaration' { .declaration }
+		'textDocument/typeDefinition' { .type_definition }
+		'textDocument/implementation' { .implementation }
+		'textDocument/completion' { .completion }
+		'textDocument/signatureHelp' { .signature_help }
+		'textDocument/hover' { .hover }
+		'textDocument/references' { .references }
+		'textDocument/rename' { .rename }
+		'textDocument/prepareRename' { .prepare_rename }
+		'textDocument/formatting' { .formatting }
+		'textDocument/documentSymbol' { .document_symbols }
+		'workspace/symbol' { .workspace_symbol }
+		'textDocument/inlayHint' { .inlay_hint }
+		'textDocument/codeAction' { .code_action }
+		'textDocument/semanticTokens/full' { .semantic_tokens }
+		'textDocument/foldingRange' { .folding_range }
+		'textDocument/prepareCallHierarchy' { .callhierarchy_prepare }
+		'callHierarchy/incomingCalls' { .callhierarchy_incoming }
+		'callHierarchy/outgoingCalls' { .callhierarchy_outgoing }
+		'workspace/didChangeConfiguration' { .workspace_did_change_configuration }
+		'workspace/didChangeWorkspaceFolders' { .workspace_did_change_workspace_folders }
+		'textDocument/documentHighlight' { .document_highlight }
+		'textDocument/selectionRange' { .selection_range }
+		'textDocument/semanticTokens/range' { .semantic_tokens_range }
+		'textDocument/rangeFormatting' { .range_formatting }
+		'textDocument/willSave' { .will_save }
+		'textDocument/willSaveWaitUntil' { .will_save_wait_until }
+		'workspace/didChangeWatchedFiles' { .did_change_watched_files }
+		'textDocument/codeLens' { .code_lens }
+		'codeLens/resolve' { .code_lens_resolve }
+		'workspace/executeCommand' { .execute_command }
+		'textDocument/inlineValue' { .inline_value }
+		'textDocument/linkedEditingRange' { .linked_editing_range }
+		'workspace/willCreateFiles' { .will_create_files }
+		'workspace/willRenameFiles' { .will_rename_files }
+		'workspace/willDeleteFiles' { .will_delete_files }
+		'textDocument/onTypeFormatting' { .on_type_formatting }
+		'shutdown' { .shutdown }
+		'exit' { .exit }
+		else { .unknown }
+	}
 }
 
 fn (m Method) str() string {
-	$for v in Method.values {
-		if m == v.value {
-			return v.attrs[0]
-		}
+	return match m {
+		.unknown { 'unknown' }
+		.initialize { 'initialize' }
+		.initialized { 'initialized' }
+		.did_open { 'textDocument/didOpen' }
+		.did_change { 'textDocument/didChange' }
+		.did_close { 'textDocument/didClose' }
+		.did_save { 'textDocument/didSave' }
+		.definition { 'textDocument/definition' }
+		.declaration { 'textDocument/declaration' }
+		.type_definition { 'textDocument/typeDefinition' }
+		.implementation { 'textDocument/implementation' }
+		.completion { 'textDocument/completion' }
+		.signature_help { 'textDocument/signatureHelp' }
+		.hover { 'textDocument/hover' }
+		.references { 'textDocument/references' }
+		.rename { 'textDocument/rename' }
+		.prepare_rename { 'textDocument/prepareRename' }
+		.formatting { 'textDocument/formatting' }
+		.document_symbols { 'textDocument/documentSymbol' }
+		.workspace_symbol { 'workspace/symbol' }
+		.inlay_hint { 'textDocument/inlayHint' }
+		.code_action { 'textDocument/codeAction' }
+		.semantic_tokens { 'textDocument/semanticTokens/full' }
+		.folding_range { 'textDocument/foldingRange' }
+		.callhierarchy_prepare { 'textDocument/prepareCallHierarchy' }
+		.callhierarchy_incoming { 'callHierarchy/incomingCalls' }
+		.callhierarchy_outgoing { 'callHierarchy/outgoingCalls' }
+		.workspace_did_change_configuration { 'workspace/didChangeConfiguration' }
+		.workspace_did_change_workspace_folders { 'workspace/didChangeWorkspaceFolders' }
+		.document_highlight { 'textDocument/documentHighlight' }
+		.selection_range { 'textDocument/selectionRange' }
+		.semantic_tokens_range { 'textDocument/semanticTokens/range' }
+		.range_formatting { 'textDocument/rangeFormatting' }
+		.will_save { 'textDocument/willSave' }
+		.will_save_wait_until { 'textDocument/willSaveWaitUntil' }
+		.did_change_watched_files { 'workspace/didChangeWatchedFiles' }
+		.code_lens { 'textDocument/codeLens' }
+		.code_lens_resolve { 'codeLens/resolve' }
+		.execute_command { 'workspace/executeCommand' }
+		.inline_value { 'textDocument/inlineValue' }
+		.linked_editing_range { 'textDocument/linkedEditingRange' }
+		.will_create_files { 'workspace/willCreateFiles' }
+		.will_rename_files { 'workspace/willRenameFiles' }
+		.will_delete_files { 'workspace/willDeleteFiles' }
+		.on_type_formatting { 'textDocument/onTypeFormatting' }
+		.set_trace { u8(36).ascii_str() + '/setTrace' }
+		.cancel_request { u8(36).ascii_str() + '/cancelRequest' }
+		.shutdown { 'shutdown' }
+		.exit { 'exit' }
 	}
-	return 'unknown'
 }

--- a/lsp_test.v
+++ b/lsp_test.v
@@ -90,11 +90,11 @@ fn test_method_from_string_signature_help() {
 }
 
 fn test_method_from_string_set_trace() {
-	assert Method.from_string('$/setTrace') == .set_trace
+	assert Method.from_string(u8(36).ascii_str() + '/setTrace') == .set_trace
 }
 
 fn test_method_from_string_cancel_request() {
-	assert Method.from_string('$/cancelRequest') == .cancel_request
+	assert Method.from_string(u8(36).ascii_str() + '/cancelRequest') == .cancel_request
 }
 
 fn test_method_from_string_shutdown() {
@@ -190,11 +190,11 @@ fn test_method_str_rename() {
 }
 
 fn test_method_str_set_trace() {
-	assert Method.set_trace.str() == '$/setTrace'
+	assert Method.set_trace.str() == u8(36).ascii_str() + '/setTrace'
 }
 
 fn test_method_str_cancel_request() {
-	assert Method.cancel_request.str() == '$/cancelRequest'
+	assert Method.cancel_request.str() == u8(36).ascii_str() + '/cancelRequest'
 }
 
 fn test_method_str_shutdown() {
@@ -219,11 +219,21 @@ fn test_method_roundtrip() {
 }
 
 fn test_method_roundtrip_all_values() {
-	// Ensure all Method enum values round-trip correctly
-	$for m in Method.values {
-		if m.value != Method.unknown {
-			assert Method.from_string(m.attrs[0]) == m.value
-		}
+	// Keep this runtime-only: V3 currently does not reliably dispatch methods on
+	// compile-time enum-value wrappers.
+	methods := [Method.initialize, .initialized, .did_open, .did_change, .did_close, .did_save,
+		.definition, .declaration, .type_definition, .implementation, .completion, .signature_help,
+		.hover, .references, .rename, .prepare_rename, .formatting, .document_symbols,
+		.workspace_symbol, .inlay_hint, .code_action, .semantic_tokens, .folding_range,
+		.callhierarchy_prepare, .callhierarchy_incoming, .callhierarchy_outgoing,
+		.workspace_did_change_configuration, .workspace_did_change_workspace_folders,
+		.document_highlight, .selection_range, .semantic_tokens_range, .range_formatting, .will_save,
+		.will_save_wait_until, .did_change_watched_files, .code_lens, .code_lens_resolve,
+		.execute_command, .inline_value, .linked_editing_range, .will_create_files,
+		.will_rename_files, .will_delete_files, .on_type_formatting, .set_trace, .cancel_request,
+		.shutdown, .exit]
+	for m in methods {
+		assert Method.from_string(m.str()) == m
 	}
 }
 
@@ -325,7 +335,7 @@ fn test_request_content_has_id_detects_presence() {
 }
 
 fn test_request_content_has_id_ignores_nested_id_in_params() {
-	assert !request_content_has_id('{"method":"$/cancelRequest","params":{"id":77}}')
+	assert !request_content_has_id('{"method":"\$/cancelRequest","params":{"id":77}}')
 }
 
 fn test_request_content_has_id_fallback_for_malformed_payload() {
@@ -345,26 +355,22 @@ fn test_validate_request_params_reports_missing_uri() {
 }
 
 fn test_validate_request_params_accepts_valid_completion_params() {
-	err := validate_request_params(.completion,
-		'{"textDocument":{"uri":"file:///tmp/a.v"},"position":{"line":0,"character":0}}')
+	err := validate_request_params(.completion, '{"textDocument":{"uri":"file:///tmp/a.v"},"position":{"line":0,"character":0}}')
 	assert err == none
 }
 
 fn test_validate_request_params_initialize_accepts_position_encodings_list() {
-	err := validate_request_params(.initialize,
-		'{"capabilities":{"general":{"positionEncodings":["utf-16"]}}}')
+	err := validate_request_params(.initialize, '{"capabilities":{"general":{"positionEncodings":["utf-16"]}}}')
 	assert err == none
 }
 
 fn test_validate_request_params_initialize_accepts_multiple_position_encodings() {
-	err := validate_request_params(.initialize,
-		'{"capabilities":{"general":{"positionEncodings":["utf-16","utf-32"]}}}')
+	err := validate_request_params(.initialize, '{"capabilities":{"general":{"positionEncodings":["utf-16","utf-32"]}}}')
 	assert err == none
 }
 
 fn test_validate_request_params_initialize_accepts_workspace_folders_with_uri() {
-	err := validate_request_params(.initialize,
-		'{"workspaceFolders":[{"uri":"file:///tmp/project","name":"project"}]}')
+	err := validate_request_params(.initialize, '{"workspaceFolders":[{"uri":"file:///tmp/project","name":"project"}]}')
 	assert err == none
 }
 
@@ -383,23 +389,19 @@ fn test_validate_request_params_reports_missing_call_hierarchy_item_uri() {
 }
 
 fn test_validate_request_params_accepts_valid_call_hierarchy_item_uri() {
-	err := validate_request_params(.callhierarchy_incoming,
-		'{"item":{"name":"foo","kind":12,"uri":"file:///tmp/a.v","range":{"start":{"line":0,"character":0},"end":{"line":0,"character":3}},"selectionRange":{"start":{"line":0,"character":0},"end":{"line":0,"character":3}},"detail":""}}')
+	err := validate_request_params(.callhierarchy_incoming, '{"item":{"name":"foo","kind":12,"uri":"file:///tmp/a.v","range":{"start":{"line":0,"character":0},"end":{"line":0,"character":3}},"selectionRange":{"start":{"line":0,"character":0},"end":{"line":0,"character":3}},"detail":""}}')
 	assert err == none
 }
 
 fn test_validate_request_params_reports_invalid_rename_new_name() {
-	err_empty := validate_request_params(.rename,
-		'{"textDocument":{"uri":"file:///tmp/a.v"},"position":{"line":0,"character":0},"newName":""}')
+	err_empty := validate_request_params(.rename, '{"textDocument":{"uri":"file:///tmp/a.v"},"position":{"line":0,"character":0},"newName":""}')
 	assert err_empty != none
-	err_bad := validate_request_params(.rename,
-		'{"textDocument":{"uri":"file:///tmp/a.v"},"position":{"line":0,"character":0},"newName":"1 bad"}')
+	err_bad := validate_request_params(.rename, '{"textDocument":{"uri":"file:///tmp/a.v"},"position":{"line":0,"character":0},"newName":"1 bad"}')
 	assert err_bad != none
 }
 
 fn test_validate_request_params_accepts_valid_rename_new_name() {
-	err := validate_request_params(.rename,
-		'{"textDocument":{"uri":"file:///tmp/a.v"},"position":{"line":0,"character":0},"newName":"new_name1"}')
+	err := validate_request_params(.rename, '{"textDocument":{"uri":"file:///tmp/a.v"},"position":{"line":0,"character":0},"newName":"new_name1"}')
 	assert err == none
 }
 
@@ -409,14 +411,12 @@ fn test_validate_notification_params_reports_missing_uri_for_did_open() {
 }
 
 fn test_validate_notification_params_accepts_valid_did_open() {
-	err := validate_notification_params(.did_open,
-		'{"textDocument":{"uri":"file:///tmp/a.v","text":"module main"}}')
+	err := validate_notification_params(.did_open, '{"textDocument":{"uri":"file:///tmp/a.v","text":"module main"}}')
 	assert err == none
 }
 
 fn test_validate_notification_params_accepts_workspace_configuration() {
-	err := validate_notification_params(.workspace_did_change_configuration,
-		'{"settings":{"vls":{"inlayHints":true}}}')
+	err := validate_notification_params(.workspace_did_change_configuration, '{"settings":{"vls":{"inlayHints":true}}}')
 	assert err == none
 }
 
@@ -426,8 +426,7 @@ fn test_validate_notification_params_reports_missing_watched_file_uri() {
 }
 
 fn test_validate_notification_params_accepts_valid_watched_file_uri() {
-	err := validate_notification_params(.did_change_watched_files,
-		'{"changes":[{"uri":"file:///tmp/a.v","type":2}]}')
+	err := validate_notification_params(.did_change_watched_files, '{"changes":[{"uri":"file:///tmp/a.v","type":2}]}')
 	assert err == none
 }
 
@@ -460,7 +459,7 @@ fn test_lsp_range_same_line() {
 			line: 5
 			char: 10
 		}
-		end:   Position{
+		end: Position{
 			line: 5
 			char: 20
 		}
@@ -475,7 +474,7 @@ fn test_lsp_range_multi_line() {
 			line: 5
 			char: 0
 		}
-		end:   Position{
+		end: Position{
 			line: 10
 			char: 15
 		}
@@ -489,7 +488,7 @@ fn test_lsp_range_json_encoding() {
 			line: 1
 			char: 2
 		}
-		end:   Position{
+		end: Position{
 			line: 3
 			char: 4
 		}
@@ -581,8 +580,8 @@ fn test_request_default_values() {
 
 fn test_request_with_values() {
 	req := Request{
-		id:      1
-		method:  'textDocument/completion'
+		id: 1
+		method: 'textDocument/completion'
 		jsonrpc: '2.0'
 	}
 	assert req.id == 1
@@ -632,7 +631,7 @@ fn test_request_json_decoding_initialize() {
 
 fn test_response_default_jsonrpc() {
 	resp := Response{
-		id:     1
+		id: 1
 		result: 'null'
 	}
 	assert resp.jsonrpc == '2.0'
@@ -640,7 +639,7 @@ fn test_response_default_jsonrpc() {
 
 fn test_response_json_encoding() {
 	resp := Response{
-		id:     42
+		id: 42
 		result: 'null'
 	}
 	encoded := json2.encode(resp, escape_unicode: true)
@@ -650,7 +649,7 @@ fn test_response_json_encoding() {
 
 fn test_encode_response_payload_uses_json_null_for_null_result() {
 	resp := Response{
-		id:     2
+		id: 2
 		result: 'null'
 	}
 	encoded := encode_response_payload(resp)
@@ -660,7 +659,7 @@ fn test_encode_response_payload_uses_json_null_for_null_result() {
 
 fn test_encode_response_payload_preserves_non_null_results() {
 	resp := Response{
-		id:     3
+		id: 3
 		result: []TextEdit{}
 	}
 	encoded := encode_response_payload(resp)
@@ -669,7 +668,7 @@ fn test_encode_response_payload_preserves_non_null_results() {
 
 fn test_encode_response_payload_strips_sum_type_tag_from_capabilities() {
 	resp := Response{
-		id:     4
+		id: 4
 		result: Capabilities{
 			capabilities: Capability{
 				definition_provider: true
@@ -683,14 +682,14 @@ fn test_encode_response_payload_strips_sum_type_tag_from_capabilities() {
 
 fn test_encode_response_payload_strips_sum_type_tag_from_prepare_rename() {
 	resp := Response{
-		id:     5
+		id: 5
 		result: PrepareRenameResult{
-			range:       LSPRange{
+			range: LSPRange{
 				start: Position{
 					line: 1
 					char: 2
 				}
-				end:   Position{
+				end: Position{
 					line: 1
 					char: 7
 				}
@@ -891,7 +890,7 @@ fn test_notification_json_encoding() {
 	notif := Notification{
 		method: 'textDocument/publishDiagnostics'
 		params: PublishDiagnosticsParams{
-			uri:         'file:///test.v'
+			uri: 'file:///test.v'
 			diagnostics: []
 		}
 	}
@@ -902,8 +901,8 @@ fn test_notification_json_encoding() {
 
 fn test_lsp_diagnostic_error_severity() {
 	diag := LSPDiagnostic{
-		range:    LSPRange{}
-		message:  'error message'
+		range: LSPRange{}
+		message: 'error message'
 		severity: 1
 	}
 	assert diag.severity == 1 // Error
@@ -912,8 +911,8 @@ fn test_lsp_diagnostic_error_severity() {
 
 fn test_lsp_diagnostic_warning_severity() {
 	diag := LSPDiagnostic{
-		range:    LSPRange{}
-		message:  'warning message'
+		range: LSPRange{}
+		message: 'warning message'
 		severity: 2
 	}
 	assert diag.severity == 2 // Warning
@@ -921,17 +920,17 @@ fn test_lsp_diagnostic_warning_severity() {
 
 fn test_lsp_diagnostic_json_encoding() {
 	diag := LSPDiagnostic{
-		range:    LSPRange{
+		range: LSPRange{
 			start: Position{
 				line: 5
 				char: 0
 			}
-			end:   Position{
+			end: Position{
 				line: 5
 				char: 10
 			}
 		}
-		message:  'undefined identifier'
+		message: 'undefined identifier'
 		severity: 1
 	}
 	encoded := json2.encode(diag, escape_unicode: true)
@@ -941,9 +940,9 @@ fn test_lsp_diagnostic_json_encoding() {
 
 fn test_detail_function_kind() {
 	detail := Detail{
-		kind:          6 // Function
-		label:         'my_function'
-		detail:        'fn my_function() string'
+		kind: 6 // Function
+		label: 'my_function'
+		detail: 'fn my_function() string'
 		documentation: 'A helper function'
 	}
 	assert detail.kind == 6
@@ -952,9 +951,9 @@ fn test_detail_function_kind() {
 
 fn test_detail_variable_kind() {
 	detail := Detail{
-		kind:          6
-		label:         'my_var'
-		detail:        'int'
+		kind: 6
+		label: 'my_var'
+		detail: 'int'
 		documentation: 'A variable'
 	}
 	assert detail.label == 'my_var'
@@ -962,10 +961,10 @@ fn test_detail_variable_kind() {
 
 fn test_detail_with_snippet() {
 	detail := Detail{
-		kind:               6
-		label:              'println'
-		detail:             'fn println(s string)'
-		insert_text:        'println(\${1:s})'
+		kind: 6
+		label: 'println'
+		detail: 'fn println(s string)'
+		insert_text: 'println(\${1:s})'
 		insert_text_format: 2 // Snippet
 	}
 	assert detail.insert_text? == 'println(\${1:s})'
@@ -974,7 +973,7 @@ fn test_detail_with_snippet() {
 
 fn test_detail_json_encoding() {
 	detail := Detail{
-		kind:  6
+		kind: 6
 		label: 'test_fn'
 	}
 	encoded := json2.encode(detail, escape_unicode: true)
@@ -984,13 +983,13 @@ fn test_detail_json_encoding() {
 
 fn test_location_basic() {
 	loc := Location{
-		uri:   'file:///test/file.v'
+		uri: 'file:///test/file.v'
 		range: LSPRange{
 			start: Position{
 				line: 10
 				char: 5
 			}
-			end:   Position{
+			end: Position{
 				line: 10
 				char: 15
 			}
@@ -1002,13 +1001,13 @@ fn test_location_basic() {
 
 fn test_location_json_encoding() {
 	loc := Location{
-		uri:   'file:///path/to/file.v'
+		uri: 'file:///path/to/file.v'
 		range: LSPRange{
 			start: Position{
 				line: 0
 				char: 0
 			}
-			end:   Position{
+			end: Position{
 				line: 0
 				char: 5
 			}
@@ -1028,9 +1027,9 @@ fn test_signature_help_empty() {
 
 fn test_signature_help_with_signature() {
 	sig := SignatureHelp{
-		signatures:       [
+		signatures: [
 			SignatureInformation{
-				label:      'fn test(a int, b string)'
+				label: 'fn test(a int, b string)'
 				parameters: [
 					ParameterInformation{
 						label: 'a int'
@@ -1051,7 +1050,7 @@ fn test_signature_help_with_signature() {
 
 fn test_signature_help_json_encoding() {
 	sig := SignatureHelp{
-		signatures:       [
+		signatures: [
 			SignatureInformation{
 				label: 'fn example()'
 			},
@@ -1067,17 +1066,17 @@ fn test_signature_help_json_encoding() {
 fn test_capabilities_full() {
 	caps := Capabilities{
 		capabilities: Capability{
-			text_document_sync:      TextDocumentSyncOptions{
+			text_document_sync: TextDocumentSyncOptions{
 				open_close: true
-				change:     1
+				change: 1
 			}
-			completion_provider:     CompletionProvider{
+			completion_provider: CompletionProvider{
 				trigger_characters: ['.']
 			}
 			signature_help_provider: SignatureHelpOptions{
 				trigger_characters: ['(', ',']
 			}
-			definition_provider:     true
+			definition_provider: true
 		}
 	}
 	assert caps.capabilities.definition_provider == true
@@ -1114,7 +1113,7 @@ fn test_completion_item_capability_snippet_support() {
 fn test_text_document_sync_full() {
 	sync := TextDocumentSyncOptions{
 		open_close: true
-		change:     1 // Full
+		change: 1 // Full
 	}
 	assert sync.open_close == true
 	assert sync.change == 1
@@ -1123,7 +1122,7 @@ fn test_text_document_sync_full() {
 fn test_text_document_sync_incremental() {
 	sync := TextDocumentSyncOptions{
 		open_close: true
-		change:     2 // Incremental
+		change: 2 // Incremental
 	}
 	assert sync.change == 2
 }
@@ -1148,7 +1147,7 @@ fn test_response_result_string() {
 fn test_response_result_details() {
 	details := [
 		Detail{
-			kind:  6
+			kind: 6
 			label: 'test'
 		},
 	]
@@ -1201,7 +1200,7 @@ fn test_response_result_location() {
 
 fn test_publish_diagnostics_params_empty() {
 	params := PublishDiagnosticsParams{
-		uri:         'file:///test.v'
+		uri: 'file:///test.v'
 		diagnostics: []
 	}
 	assert params.uri == 'file:///test.v'
@@ -1210,16 +1209,16 @@ fn test_publish_diagnostics_params_empty() {
 
 fn test_publish_diagnostics_params_with_diagnostics() {
 	params := PublishDiagnosticsParams{
-		uri:         'file:///test.v'
+		uri: 'file:///test.v'
 		diagnostics: [
 			LSPDiagnostic{
-				range:    LSPRange{}
-				message:  'error 1'
+				range: LSPRange{}
+				message: 'error 1'
 				severity: 1
 			},
 			LSPDiagnostic{
-				range:    LSPRange{}
-				message:  'error 2'
+				range: LSPRange{}
+				message: 'error 2'
 				severity: 1
 			},
 		]
@@ -1229,11 +1228,11 @@ fn test_publish_diagnostics_params_with_diagnostics() {
 
 fn test_json_error_struct() {
 	err := JsonError{
-		path:    '/test/file.v'
+		path: '/test/file.v'
 		message: 'undefined identifier'
 		line_nr: 10
-		col:     5
-		len:     3
+		col: 5
+		len: 3
 	}
 	assert err.path == '/test/file.v'
 	assert err.message == 'undefined identifier'
@@ -1272,11 +1271,11 @@ fn test_json_var_ac_with_details() {
 	ac := JsonVarAC{
 		details: [
 			Detail{
-				kind:  6
+				kind: 6
 				label: 'fn1'
 			},
 			Detail{
-				kind:  6
+				kind: 6
 				label: 'fn2'
 			},
 		]
@@ -1307,14 +1306,14 @@ fn test_document_symbol_default_values() {
 
 fn test_document_symbol_with_values() {
 	sym := DocumentSymbol{
-		name:            'greet'
-		kind:            sym_kind_function
-		range:           LSPRange{
+		name: 'greet'
+		kind: sym_kind_function
+		range: LSPRange{
 			start: Position{
 				line: 2
 				char: 0
 			}
-			end:   Position{
+			end: Position{
 				line: 2
 				char: 20
 			}
@@ -1324,12 +1323,12 @@ fn test_document_symbol_with_values() {
 				line: 2
 				char: 3
 			}
-			end:   Position{
+			end: Position{
 				line: 2
 				char: 8
 			}
 		}
-		children:        []DocumentSymbol{}
+		children: []DocumentSymbol{}
 	}
 	assert sym.name == 'greet'
 	assert sym.kind == sym_kind_function
@@ -1339,14 +1338,14 @@ fn test_document_symbol_with_values() {
 
 fn test_document_symbol_json_encoding() {
 	sym := DocumentSymbol{
-		name:            'Person'
-		kind:            sym_kind_struct
-		range:           LSPRange{
+		name: 'Person'
+		kind: sym_kind_struct
+		range: LSPRange{
 			start: Position{
 				line: 5
 				char: 0
 			}
-			end:   Position{
+			end: Position{
 				line: 5
 				char: 14
 			}
@@ -1356,12 +1355,12 @@ fn test_document_symbol_json_encoding() {
 				line: 5
 				char: 7
 			}
-			end:   Position{
+			end: Position{
 				line: 5
 				char: 13
 			}
 		}
-		children:        []DocumentSymbol{}
+		children: []DocumentSymbol{}
 	}
 	encoded := json2.encode(sym, escape_unicode: true)
 	assert encoded.contains('"name":"Person"')
@@ -1384,17 +1383,17 @@ fn test_document_symbol_json_decoding() {
 
 fn test_document_symbol_with_children() {
 	sym := DocumentSymbol{
-		name:            'App'
-		kind:            sym_kind_struct
-		range:           LSPRange{}
+		name: 'App'
+		kind: sym_kind_struct
+		range: LSPRange{}
 		selection_range: LSPRange{}
-		children:        [
+		children: [
 			DocumentSymbol{
-				name:            'run'
-				kind:            sym_kind_method
-				range:           LSPRange{}
+				name: 'run'
+				kind: sym_kind_method
+				range: LSPRange{}
 				selection_range: LSPRange{}
-				children:        []DocumentSymbol{}
+				children: []DocumentSymbol{}
 			},
 		]
 	}
@@ -1475,10 +1474,10 @@ fn test_method_roundtrip_new_methods() {
 fn test_response_result_workspace_symbols() {
 	result := ResponseResult([
 		WorkspaceSymbol{
-			name:     'main'
-			kind:     sym_kind_function
+			name: 'main'
+			kind: sym_kind_function
 			location: Location{
-				uri:   'file:///tmp/main.v'
+				uri: 'file:///tmp/main.v'
 				range: LSPRange{}
 			}
 		},
@@ -1493,12 +1492,12 @@ fn test_response_result_workspace_symbols() {
 
 fn test_response_result_prepare_rename_result() {
 	result := ResponseResult(PrepareRenameResult{
-		range:       LSPRange{
+		range: LSPRange{
 			start: Position{
 				line: 1
 				char: 2
 			}
-			end:   Position{
+			end: Position{
 				line: 1
 				char: 5
 			}
@@ -1526,18 +1525,18 @@ fn test_response_result_document_symbols_empty() {
 fn test_response_result_document_symbols_with_data() {
 	syms := [
 		DocumentSymbol{
-			name:            'main'
-			kind:            sym_kind_function
-			range:           LSPRange{}
+			name: 'main'
+			kind: sym_kind_function
+			range: LSPRange{}
 			selection_range: LSPRange{}
-			children:        []DocumentSymbol{}
+			children: []DocumentSymbol{}
 		},
 		DocumentSymbol{
-			name:            'App'
-			kind:            sym_kind_struct
-			range:           LSPRange{}
+			name: 'App'
+			kind: sym_kind_struct
+			range: LSPRange{}
 			selection_range: LSPRange{}
-			children:        []DocumentSymbol{}
+			children: []DocumentSymbol{}
 		},
 	]
 	result := ResponseResult(syms)
@@ -1555,14 +1554,14 @@ fn test_response_result_document_symbols_with_data() {
 fn test_response_with_document_symbols_json_encoding() {
 	syms := [
 		DocumentSymbol{
-			name:            'greet'
-			kind:            sym_kind_function
-			range:           LSPRange{
+			name: 'greet'
+			kind: sym_kind_function
+			range: LSPRange{
 				start: Position{
 					line: 2
 					char: 0
 				}
-				end:   Position{
+				end: Position{
 					line: 2
 					char: 25
 				}
@@ -1572,16 +1571,16 @@ fn test_response_with_document_symbols_json_encoding() {
 					line: 2
 					char: 3
 				}
-				end:   Position{
+				end: Position{
 					line: 2
 					char: 8
 				}
 			}
-			children:        []DocumentSymbol{}
+			children: []DocumentSymbol{}
 		},
 	]
 	resp := Response{
-		id:     7
+		id: 7
 		result: syms
 	}
 	encoded := json2.encode(resp, escape_unicode: true)
@@ -1607,7 +1606,7 @@ fn test_capability_document_symbol_provider_json_encoding() {
 	caps := Capabilities{
 		capabilities: Capability{
 			document_symbol_provider: true
-			definition_provider:      true
+			definition_provider: true
 		}
 	}
 	encoded := json2.encode(caps, escape_unicode: true)
@@ -1769,13 +1768,13 @@ fn test_encode_response_payload_strips_type_from_array_variant() {
 	// Array-of-struct result variants (e.g. []WorkspaceSymbol) must also have
 	// their per-element `_type` discriminators stripped (P1-10).
 	resp := Response{
-		id:     9
+		id: 9
 		result: [
 			WorkspaceSymbol{
-				name:     'helper_fn'
-				kind:     sym_kind_function
+				name: 'helper_fn'
+				kind: sym_kind_function
 				location: Location{
-					uri:   'file:///tmp/lib.v'
+					uri: 'file:///tmp/lib.v'
 					range: LSPRange{}
 				}
 			},

--- a/main.v
+++ b/main.v
@@ -12,41 +12,41 @@ import io
 // App represents the context of the server during its lifetime.
 pub struct App {
 	cur_mod string = 'main'
-	exit    bool   = os.args.contains('exit')
+	exit    bool = os.args.contains('exit')
 mut:
-	text                                        string            // Current file content
+	text                                        string // Current file content
 	open_files                                  map[string]string // Map of file URI to file content
-	open_files_versions                         map[string]i64    // Per-URI document version from the client
-	temp_dir                                    string            // Temporary directory for multi-file compilation
-	workspace_roots                             []string          // Workspace root directories from initialize
-	removed_workspace_roots                     []string          // Roots explicitly removed by the client
-	capture_output                              bool              // Test hook: capture outbound transport messages instead of writing
-	captured_output                             []string          // Test hook buffer for outbound transport messages
-	supports_dynamic_watched_files_registration bool              // Client supports dynamic workspace watcher registration
-	supports_work_done_progress                 bool              // Client supports window/workDoneProgress + $/progress
-	sent_watched_files_registration             bool              // client/registerCapability watcher registration was sent
-	watched_files_registration_id               string            // Raw id of the watcher registration request, to match its response
-	watched_files_active                        bool              // True once the client acknowledged watcher registration (not rejected)
+	open_files_versions                         map[string]i64 // Per-URI document version from the client
+	temp_dir                                    string // Temporary directory for multi-file compilation
+	workspace_roots                             []string // Workspace root directories from initialize
+	removed_workspace_roots                     []string // Roots explicitly removed by the client
+	capture_output                              bool // Test hook: capture outbound transport messages instead of writing
+	captured_output                             []string // Test hook buffer for outbound transport messages
+	supports_dynamic_watched_files_registration bool // Client supports dynamic workspace watcher registration
+	supports_work_done_progress                 bool // Client supports window/workDoneProgress + $/progress
+	sent_watched_files_registration             bool // client/registerCapability watcher registration was sent
+	watched_files_registration_id               string // Raw id of the watcher registration request, to match its response
+	watched_files_active                        bool // True once the client acknowledged watcher registration (not rejected)
 	inlay_hints_enabled                         bool = true // toggled via workspace/didChangeConfiguration
 	diagnostics_enabled                         bool = true // toggled via workspace/didChangeConfiguration
 	diag_cache                                  map[string]DiagCacheEntry // Per-URI cached diagnostics
-	open_files_generation                       int                       // Incremented on every workspace file mutation
-	project_generations                         map[string]int            // Per-project-dir revision, for scoped cache invalidation
-	cancelled_requests                          map[int]bool              // Request ids cancelled via $/cancelRequest
-	cancelled_raw_ids                           map[string]bool           // String/raw request ids cancelled via $/cancelRequest
-	current_request_raw_id                      string                    // Raw JSON id of the request being processed (echoed verbatim)
+	open_files_generation                       int // Incremented on every workspace file mutation
+	project_generations                         map[string]int // Per-project-dir revision, for scoped cache invalidation
+	cancelled_requests                          map[int]bool // Request ids cancelled via $/cancelRequest
+	cancelled_raw_ids                           map[string]bool // String/raw request ids cancelled via $/cancelRequest
+	current_request_raw_id                      string // Raw JSON id of the request being processed (echoed verbatim)
 	position_encoding                           PositionEncoding = .utf16 // Negotiated LSP position encoding (default UTF-16)
-	symbol_index                                map[string]IndexEntry        // Persistent per-URI symbol index (see index.v)
-	indexed_dirs                                map[string]bool              // Project dirs already walked into the index
-	indexed_dir_walk_ms                         map[string]i64               // Last walk time per dir, for watcher-less refresh
-	ref_occurrences                             map[string]OccEntry          // Per-URI identifier occurrences for references (see index.v)
-	index_skipped_uris                          map[string]bool              // Disk files omitted from the bounded index
-	index_incomplete_scopes                     map[string]bool              // Index walks that could not finish
+	symbol_index                                map[string]IndexEntry // Persistent per-URI symbol index (see index.v)
+	indexed_dirs                                map[string]bool // Project dirs already walked into the index
+	indexed_dir_walk_ms                         map[string]i64 // Last walk time per dir, for watcher-less refresh
+	ref_occurrences                             map[string]OccEntry // Per-URI identifier occurrences for references (see index.v)
+	index_skipped_uris                          map[string]bool // Disk files omitted from the bounded index
+	index_incomplete_scopes                     map[string]bool // Index walks that could not finish
 	vlib_fn_cache                               map[string]map[string]string // Per-vlib-module fn→return-type index (immutable during a session)
-	tcp_conn                                    ?&net.TcpConn                // Non-nil when serving a TCP client
-	is_shutdown                                 bool                         // True after shutdown request was acknowledged
-	exit_was_requested                          bool                         // True when the exit notification was received
-	received_initialize                         bool                         // True after initialize request was processed
+	tcp_conn                                    ?&net.TcpConn // Non-nil when serving a TCP client
+	is_shutdown                                 bool // True after shutdown request was acknowledged
+	exit_was_requested                          bool // True when the exit notification was received
+	received_initialize                         bool // True after initialize request was processed
 	next_request_id                             int = 1 // Counter for server-initiated request ids
 	diagnostics_scheduler                       ?&DiagnosticsScheduler // Production-only async diagnostics
 	run_command_manager                         ?&RunCommandManager // Async code-lens process lifecycle
@@ -201,7 +201,7 @@ fn (mut reader StdinBufferedReader) read_line(config io.BufferedReadLineConfig) 
 
 fn new_stdin_buffered_reader_for_fd(fd int, cap int) &StdinBufferedReader {
 	return &StdinBufferedReader{
-		fd:  fd
+		fd: fd
 		buf: []u8{len: cap}
 	}
 }
@@ -252,9 +252,9 @@ fn main() {
 		return
 	}
 	mut app := &App{
-		text:                  ''
-		open_files:            map[string]string{}
-		temp_dir:              temp_dir
+		text: ''
+		open_files: map[string]string{}
+		temp_dir: temp_dir
 		diagnostics_scheduler: new_diagnostics_scheduler()
 	}
 	// os.File.read uses C fread, which waits for the entire buffer on an open
@@ -264,7 +264,9 @@ fn main() {
 	app.handle_requests(mut reader)
 	log('VLS exiting.')
 	os.rmdir_all(temp_dir) or {
-		$if debug { log('Failed to clean up temp directory: ${err}') }
+		$if debug {
+			log('Failed to clean up temp directory: ${err}')
+		}
 	}
 	// LSP spec §3.5: exit after proper shutdown → 0; exit without shutdown → 1.
 	if app.exit_was_requested && !app.is_shutdown {
@@ -294,8 +296,7 @@ fn tcp_bind_address(host string, port string) string {
 fn run_tcp_server(host string, port string, allow_remote bool) {
 	if !is_loopback_host(host) && !allow_remote {
 		msg :=
-			'VLS: refusing to bind TCP to non-loopback host "${host}" without --unsafe-allow-remote. ' +
-			'The TCP transport is unauthenticated and unencrypted; exposing it on a network is unsafe.'
+			'VLS: refusing to bind TCP to non-loopback host "${host}" without --unsafe-allow-remote. ' + 'The TCP transport is unauthenticated and unencrypted; exposing it on a network is unsafe.'
 		log(msg)
 		eprintln(msg)
 		return
@@ -327,17 +328,19 @@ fn handle_tcp_client(mut conn net.TcpConn) {
 		return
 	}
 	mut app := &App{
-		text:                  ''
-		open_files:            map[string]string{}
-		temp_dir:              temp_dir
-		tcp_conn:              &conn
+		text: ''
+		open_files: map[string]string{}
+		temp_dir: temp_dir
+		tcp_conn: &conn
 		diagnostics_scheduler: new_diagnostics_scheduler()
 	}
 	mut reader := io.new_buffered_reader(reader: conn, cap: transport_buffer_cap)
 	app.handle_requests(mut reader)
 	log('TCP client disconnected')
 	os.rmdir_all(temp_dir) or {
-		$if debug { log('Failed to clean up TCP client temp directory: ${err}') }
+		$if debug {
+			log('Failed to clean up TCP client temp directory: ${err}')
+		}
 	}
 	conn.close() or {}
 }
@@ -401,7 +404,9 @@ fn read_request[T](mut reader T) !string {
 			if err is io.Eof {
 				return err
 			}
-			$if debug { log('read_request: error reading header line: ${err}') }
+			$if debug {
+				log('read_request: error reading header line: ${err}')
+			}
 			return err
 		}
 		header_bytes += line.len + 2 // account for the stripped CRLF
@@ -583,7 +588,9 @@ fn (mut app App) handle_requests[T](mut reader T) {
 				app.write_error_response(make_parse_error_response(err.msg()))
 				break
 			}
-			$if debug { log('Error reading request: ${err.msg()}') }
+			$if debug {
+				log('Error reading request: ${err.msg()}')
+			}
 			break
 		}
 		if content.len == 0 {
@@ -600,8 +607,7 @@ fn (mut app App) handle_requests[T](mut reader T) {
 		// determined — rather than dispatching and echoing a bogus id (P0-02).
 		if app.current_request_raw_id != '' && !raw_id_is_valid(app.current_request_raw_id) {
 			app.current_request_raw_id = 'null'
-			app.write_error_response(make_invalid_request_error_response(0,
-				'Request id must be a string, number, or null'))
+			app.write_error_response(make_invalid_request_error_response(0, 'Request id must be a string, number, or null'))
 			continue
 		}
 		// Decode the body WITHOUT the id field: json2 aborts the whole decode on
@@ -625,10 +631,10 @@ fn (mut app App) handle_requests[T](mut reader T) {
 			continue
 		}
 		lsp_request := Request{
-			id:      raw_id_to_int(app.current_request_raw_id)
-			method:  body.method
+			id: raw_id_to_int(app.current_request_raw_id)
+			method: body.method
 			jsonrpc: body.jsonrpc
-			params:  body.params
+			params: body.params
 		}
 		log('\n\nRECV (pretty): ${content}')
 		method := Method.from_string(lsp_request.method)
@@ -638,8 +644,7 @@ fn (mut app App) handle_requests[T](mut reader T) {
 		// without an id sent to a request-only method is dropped rather than
 		// processed into a response with a bogus id.
 		if has_id && method_is_notification_only(method) {
-			app.write_error_response(make_invalid_request_error_response(lsp_request.id,
-				'Method ${lsp_request.method} is a notification and cannot be sent as a request'))
+			app.write_error_response(make_invalid_request_error_response(lsp_request.id, 'Method ${lsp_request.method} is a notification and cannot be sent as a request'))
 			continue
 		}
 		if !has_id && method_requires_response(method) {
@@ -679,8 +684,7 @@ fn (mut app App) handle_requests[T](mut reader T) {
 			}
 		}
 		match method {
-			.completion, .signature_help, .definition, .hover, .declaration, .type_definition,
-			.implementation {
+			.completion, .signature_help, .definition, .hover, .declaration, .type_definition, .implementation {
 				resp := app.operation_at_pos(method, lsp_request)
 				app.write_response_or_cancelled(lsp_request.id, resp)
 			}
@@ -728,7 +732,7 @@ fn (mut app App) handle_requests[T](mut reader T) {
 				}
 				// Return all supported capabilities, matching the LSP spec and what is implemented.
 				response := Response{
-					id:     lsp_request.id
+					id: lsp_request.id
 					result: Capabilities{
 						capabilities: Capability{
 							// NOTE: Placeholder/stub capabilities are intentionally NOT
@@ -737,66 +741,66 @@ fn (mut app App) handle_requests[T](mut reader T) {
 							// (wrong abstraction), file-operation hooks (no-ops), and
 							// willSave (never dispatched). Advertising only working
 							// features gives a better editor experience than broken UI.
-							text_document_sync:           TextDocumentSyncOptions{
-								open_close:           true
-								change:               2 // Incremental
-								save:                 SaveOptions{
+							text_document_sync: TextDocumentSyncOptions{
+								open_close: true
+								change: 2 // Incremental
+								save: SaveOptions{
 									include_text: true
 								}
-								will_save:            false
+								will_save: false
 								will_save_wait_until: true
 							}
-							completion_provider:          CompletionProvider{
+							completion_provider: CompletionProvider{
 								trigger_characters: ['.']
 							}
-							signature_help_provider:      SignatureHelpOptions{
+							signature_help_provider: SignatureHelpOptions{
 								trigger_characters: ['(', ',']
 							}
-							definition_provider:          true
-							declaration_provider:         true
-							type_definition_provider:     true
-							implementation_provider:      true
-							hover_provider:               true
-							references_provider:          true
-							rename_provider:              RenameOptions{
+							definition_provider: true
+							declaration_provider: true
+							type_definition_provider: true
+							implementation_provider: true
+							hover_provider: true
+							references_provider: true
+							rename_provider: RenameOptions{
 								prepare_provider: true
 							}
 							document_formatting_provider: true
-							document_symbol_provider:     true
-							workspace_symbol_provider:    true
-							inlay_hint_provider:          true
-							code_action_provider:         true
-							execute_command_provider:     ExecuteCommandOptions{
+							document_symbol_provider: true
+							workspace_symbol_provider: true
+							inlay_hint_provider: true
+							code_action_provider: true
+							execute_command_provider: ExecuteCommandOptions{
 								commands: ['vls.runFile', 'vls.runTests']
 							}
-							code_lens_provider:           CodeLensOptions{}
-							semantic_tokens_provider:     SemanticTokensOptions{
+							code_lens_provider: CodeLensOptions{}
+							semantic_tokens_provider: SemanticTokensOptions{
 								legend: SemanticTokensLegend{
-									token_types:     semantic_token_types()
+									token_types: semantic_token_types()
 									token_modifiers: semantic_token_modifiers()
 								}
-								full:   true
-								range:  true
+								full: true
+								range: true
 							}
-							folding_range_provider:       true
-							call_hierarchy_provider:      true
-							document_highlight_provider:  true
-							selection_range_provider:     true
+							folding_range_provider: true
+							call_hierarchy_provider: true
+							document_highlight_provider: true
+							selection_range_provider: true
 							// Range formatting is NOT advertised: v fmt only formats whole
 							// files, so a correct range implementation needs a
 							// character-accurate, EOL-preserving diff restricted to the
 							// requested range, which is not yet implemented (P0-08).
 							document_range_formatting_provider: false
-							position_encoding:                  position_encoding_string(app.position_encoding)
-							workspace:                          WorkspaceCapability{
+							position_encoding: position_encoding_string(app.position_encoding)
+							workspace: WorkspaceCapability{
 								workspace_folders: WorkspaceFoldersServerCapability{
-									supported:            true
+									supported: true
 									change_notifications: true
 								}
 							}
 						}
-						server_info:  ServerInfo{
-							name:    'vls'
+						server_info: ServerInfo{
+							name: 'vls'
 							version: '0.0.2'
 						}
 					}
@@ -807,8 +811,7 @@ fn (mut app App) handle_requests[T](mut reader T) {
 				// available, instead of silently returning empty diagnostics,
 				// completion, and navigation for every request (P1-03).
 				if !compiler_is_available() {
-					app.send_show_message('vls: the V compiler (`v`) was not found on PATH. Diagnostics, completion, and navigation will not work until `v` is installed and on PATH.',
-						1)
+					app.send_show_message('vls: the V compiler (`v`) was not found on PATH. Diagnostics, completion, and navigation will not work until `v` is installed and on PATH.', 1)
 				}
 			}
 			.did_open {
@@ -827,7 +830,7 @@ fn (mut app App) handle_requests[T](mut reader T) {
 					app.write_notification(Notification{
 						method: 'textDocument/publishDiagnostics'
 						params: PublishDiagnosticsParams{
-							uri:         params.text_document.uri
+							uri: params.text_document.uri
 							diagnostics: []
 						}
 					})
@@ -931,7 +934,7 @@ fn (mut app App) handle_requests[T](mut reader T) {
 			.will_create_files, .will_rename_files, .will_delete_files {
 				// Return null — vls has no pre-operation file mutations to apply.
 				app.write_response(Response{
-					id:     lsp_request.id
+					id: lsp_request.id
 					result: 'null'
 				})
 			}
@@ -943,11 +946,9 @@ fn (mut app App) handle_requests[T](mut reader T) {
 				log('UNKNOWN method ${lsp_request.method}')
 				if has_id {
 					if method == .unknown {
-						app.write_error_response(make_method_not_found_error_response(lsp_request.id,
-							lsp_request.method))
+						app.write_error_response(make_method_not_found_error_response(lsp_request.id, lsp_request.method))
 					} else {
-						app.write_error_response(make_internal_error_response(lsp_request.id,
-							'Unhandled request dispatch for known method: ${lsp_request.method}'))
+						app.write_error_response(make_internal_error_response(lsp_request.id, 'Unhandled request dispatch for known method: ${lsp_request.method}'))
 					}
 				}
 			}
@@ -1012,8 +1013,9 @@ fn read_json_string_token(content string, start int) (string, int) {
 				`r` { u8(`\r`) }
 				`b` { u8(0x08) }
 				`f` { u8(0x0c) }
-				else { nxt } // `\"`, `\\`, `\/`, and any other: keep the char verbatim
+				else { nxt }
 			}
+			// `\"`, `\\`, `\/`, and any other: keep the char verbatim
 			sb << esc
 			i += 2
 			continue
@@ -1324,7 +1326,7 @@ fn (mut app App) accept_shutdown(id int) {
 	app.stop_run_commands()
 	app.is_shutdown = true
 	app.write_response(Response{
-		id:     id
+		id: id
 		result: 'null'
 	})
 }
@@ -1359,22 +1361,24 @@ fn v_error_to_lsp_diagnostic(e JsonError) LSPDiagnostic {
 		'warning' { 2 }
 		'notice' { 3 }
 		'hint' { 4 }
-		else { 1 } // default to Error
+		else { 1 }
 	}
+
+	// default to Error
 
 	code, tags := derive_diagnostic_code_and_tags(e.message)
 	return LSPDiagnostic{
-		message:  e.message
+		message: e.message
 		severity: severity
-		source:   'vlang'
-		code:     code
-		tags:     tags
-		range:    LSPRange{
+		source: 'vlang'
+		code: code
+		tags: tags
+		range: LSPRange{
 			start: Position{
 				line: start_line
 				char: start_char
 			}
-			end:   Position{
+			end: Position{
 				line: start_line
 				char: end_char
 			}
@@ -1409,14 +1413,7 @@ fn derive_diagnostic_code_and_tags(message string) (?string, ?[]int) {
 
 fn method_requires_response(method Method) bool {
 	return match method {
-		.initialize, .completion, .signature_help, .definition, .hover, .declaration,
-		.type_definition, .implementation, .references, .rename, .prepare_rename,
-		.workspace_symbol, .formatting, .document_symbols, .inlay_hint, .shutdown, .code_action,
-		.semantic_tokens, .folding_range, .callhierarchy_prepare, .callhierarchy_incoming,
-		.callhierarchy_outgoing, .document_highlight, .selection_range, .semantic_tokens_range,
-		.range_formatting, .code_lens, .code_lens_resolve, .execute_command, .inline_value,
-		.linked_editing_range, .will_create_files, .will_rename_files, .will_delete_files,
-		.on_type_formatting {
+		.initialize, .completion, .signature_help, .definition, .hover, .declaration, .type_definition, .implementation, .references, .rename, .prepare_rename, .workspace_symbol, .formatting, .document_symbols, .inlay_hint, .shutdown, .code_action, .semantic_tokens, .folding_range, .callhierarchy_prepare, .callhierarchy_incoming, .callhierarchy_outgoing, .document_highlight, .selection_range, .semantic_tokens_range, .range_formatting, .code_lens, .code_lens_resolve, .execute_command, .inline_value, .linked_editing_range, .will_create_files, .will_rename_files, .will_delete_files, .on_type_formatting {
 			true
 		}
 		else {
@@ -1431,9 +1428,7 @@ fn method_requires_response(method Method) bool {
 // regardless of whether a client mistakenly attaches an id.
 fn method_is_notification_only(method Method) bool {
 	return match method {
-		.initialized, .did_open, .did_change, .did_close, .did_save, .did_change_watched_files,
-		.workspace_did_change_configuration, .workspace_did_change_workspace_folders, .set_trace,
-		.cancel_request, .will_save {
+		.initialized, .did_open, .did_change, .did_close, .did_save, .did_change_watched_files, .workspace_did_change_configuration, .workspace_did_change_workspace_folders, .set_trace, .cancel_request, .will_save {
 			true
 		}
 		else {
@@ -1456,9 +1451,9 @@ fn (app &App) request_is_cancelled(id int) bool {
 fn make_invalid_request_error_response(id int, message string) ErrorResponse {
 	msg := if message != '' { message } else { 'Invalid request' }
 	return ErrorResponse{
-		id:    id
+		id: id
 		error: ResponseError{
-			code:    jsonrpc_err_invalid_request
+			code: jsonrpc_err_invalid_request
 			message: msg
 		}
 	}
@@ -1466,9 +1461,9 @@ fn make_invalid_request_error_response(id int, message string) ErrorResponse {
 
 fn make_server_not_initialized_error_response(id int) ErrorResponse {
 	return ErrorResponse{
-		id:    id
+		id: id
 		error: ResponseError{
-			code:    jsonrpc_err_server_not_initialized
+			code: jsonrpc_err_server_not_initialized
 			message: 'Server not yet initialized'
 		}
 	}
@@ -1476,9 +1471,9 @@ fn make_server_not_initialized_error_response(id int) ErrorResponse {
 
 fn make_server_already_initialized_error_response(id int) ErrorResponse {
 	return ErrorResponse{
-		id:    id
+		id: id
 		error: ResponseError{
-			code:    jsonrpc_err_invalid_request
+			code: jsonrpc_err_invalid_request
 			message: 'Server already initialized'
 		}
 	}
@@ -1486,9 +1481,9 @@ fn make_server_already_initialized_error_response(id int) ErrorResponse {
 
 fn make_server_shutdown_error_response(id int) ErrorResponse {
 	return ErrorResponse{
-		id:    id
+		id: id
 		error: ResponseError{
-			code:    jsonrpc_err_invalid_request
+			code: jsonrpc_err_invalid_request
 			message: 'Server has been shut down'
 		}
 	}
@@ -1496,9 +1491,9 @@ fn make_server_shutdown_error_response(id int) ErrorResponse {
 
 fn make_cancelled_error_response(id int) ErrorResponse {
 	return ErrorResponse{
-		id:    id
+		id: id
 		error: ResponseError{
-			code:    jsonrpc_err_request_cancelled
+			code: jsonrpc_err_request_cancelled
 			message: 'Request cancelled'
 		}
 	}
@@ -1507,9 +1502,9 @@ fn make_cancelled_error_response(id int) ErrorResponse {
 fn make_parse_error_response(message string) ErrorResponse {
 	msg := if message != '' { message } else { 'Invalid JSON' }
 	return ErrorResponse{
-		id:    0
+		id: 0
 		error: ResponseError{
-			code:    jsonrpc_err_parse_error
+			code: jsonrpc_err_parse_error
 			message: msg
 		}
 	}
@@ -1517,9 +1512,9 @@ fn make_parse_error_response(message string) ErrorResponse {
 
 fn make_method_not_found_error_response(id int, method string) ErrorResponse {
 	return ErrorResponse{
-		id:    id
+		id: id
 		error: ResponseError{
-			code:    jsonrpc_err_method_not_found
+			code: jsonrpc_err_method_not_found
 			message: 'Method not found: ${method}'
 		}
 	}
@@ -1528,9 +1523,9 @@ fn make_method_not_found_error_response(id int, method string) ErrorResponse {
 fn make_invalid_params_error_response(id int, message string) ErrorResponse {
 	msg := if message != '' { message } else { 'Invalid params' }
 	return ErrorResponse{
-		id:    id
+		id: id
 		error: ResponseError{
-			code:    jsonrpc_err_invalid_params
+			code: jsonrpc_err_invalid_params
 			message: msg
 		}
 	}
@@ -1539,9 +1534,9 @@ fn make_invalid_params_error_response(id int, message string) ErrorResponse {
 fn make_internal_error_response(id int, message string) ErrorResponse {
 	msg := if message != '' { message } else { 'Internal error' }
 	return ErrorResponse{
-		id:    id
+		id: id
 		error: ResponseError{
-			code:    jsonrpc_err_internal_error
+			code: jsonrpc_err_internal_error
 			message: msg
 		}
 	}
@@ -1561,8 +1556,7 @@ fn validate_request_params(method Method, params_json string) ?string {
 				}
 			}
 		}
-		.completion, .signature_help, .definition, .hover, .declaration, .type_definition,
-		.implementation, .prepare_rename, .document_highlight {
+		.completion, .signature_help, .definition, .hover, .declaration, .type_definition, .implementation, .prepare_rename, .document_highlight {
 			params := json2.decode[TextDocumentPositionParams](params_json) or {
 				return 'Invalid textDocument/position params: ${err.msg()}'
 			}
@@ -1825,7 +1819,7 @@ fn (mut app App) write_raw_request(id int, method string, params_json string) {
 // level: 1=Error, 2=Warning, 3=Info, 4=Log.
 fn (mut app App) send_show_message(msg string, level int) {
 	params := ShowMessageParams{
-		type_:   level
+		type_: level
 		message: msg
 	}
 	app.write_raw_notification('window/showMessage', json2.encode(params, escape_unicode: true))
@@ -1835,7 +1829,7 @@ fn (mut app App) send_show_message(msg string, level int) {
 // level: 1=Error, 2=Warning, 3=Info, 4=Log.
 fn (mut app App) send_log_message(msg string, level int) {
 	params := LogMessageParams{
-		type_:   level
+		type_: level
 		message: msg
 	}
 	app.write_raw_notification('window/logMessage', json2.encode(params, escape_unicode: true))
@@ -1863,7 +1857,7 @@ fn (mut app App) begin_progress(title string) string {
 		title: title
 	}
 	progress_json := '{"token":"${token}","value":${json2.encode(begin, escape_unicode: true)}}'
-	app.write_raw_notification('$/progress', progress_json)
+	app.write_raw_notification('\$/progress', progress_json)
 	return token
 }
 
@@ -1873,11 +1867,11 @@ fn (mut app App) report_progress(token string, message string, percentage int) {
 		return
 	}
 	report := WorkDoneProgressReport{
-		message:    message
+		message: message
 		percentage: percentage
 	}
 	progress_json := '{"token":"${token}","value":${json2.encode(report, escape_unicode: true)}}'
-	app.write_raw_notification('$/progress', progress_json)
+	app.write_raw_notification('\$/progress', progress_json)
 }
 
 // end_progress sends a $/progress end notification to finish a progress sequence.
@@ -1889,7 +1883,7 @@ fn (mut app App) end_progress(token string, message string) {
 		message: message
 	}
 	progress_json := '{"token":"${token}","value":${json2.encode(end, escape_unicode: true)}}'
-	app.write_raw_notification('$/progress', progress_json)
+	app.write_raw_notification('\$/progress', progress_json)
 }
 
 // on_initialized handles the initialized notification by registering dynamic
@@ -1905,12 +1899,12 @@ fn (mut app App) on_initialized(_ Request) {
 	}
 	reg_id := app.next_request_id
 	reg := RegisterCapabilityRequest{
-		id:     reg_id
+		id: reg_id
 		params: WatcherRegistrationParams{
 			registrations: [
 				WatcherRegistration{
-					id:               'vls-file-watcher'
-					method:           'workspace/didChangeWatchedFiles'
+					id: 'vls-file-watcher'
+					method: 'workspace/didChangeWatchedFiles'
 					register_options: WatcherRegisterOptions{
 						watchers: [
 							FileSystemWatcher{
@@ -1937,8 +1931,7 @@ fn (mut app App) write_response_or_cancelled(id int, response Response) {
 	}
 	// Defensive: catch response/request id mismatches caused by programming errors.
 	if response.id != id {
-		app.write_error_response(make_internal_error_response(id,
-			'Response id mismatch: expected ${id}, got ${response.id}'))
+		app.write_error_response(make_internal_error_response(id, 'Response id mismatch: expected ${id}, got ${response.id}'))
 		return
 	}
 	app.write_response(response)

--- a/run_command.v
+++ b/run_command.v
@@ -235,10 +235,15 @@ fn code_lens_v_string_literal(value string) string {
 // compile-time pseudo values. Hash directives retain their tokens so the compiler can resolve
 // native inputs from the materialized overlay.
 fn code_lens_source_with_original_pseudos(source string, source_path string,
-	temp_source_path string) string {
+	temp_source_path string, temp_work_dir string) string {
 	mask := code_lens_source_code_mask(source)
 	file_path := os.real_path(source_path)
 	file_dir := os.real_path(os.dir(source_path))
+	relative_temp_path := overlay_relative_path(temp_source_path, temp_work_dir) or {
+		os.file_name(temp_source_path)
+	}
+	windows_temp_location := '.\\' + relative_temp_path.replace('/', '\\')
+	posix_temp_location := './' + relative_temp_path.replace('\\', '/')
 	vmod_root := find_project_root(os.dir(source_path))
 	temp_vmod_root := find_project_root(os.dir(temp_source_path))
 	vmod_file_path := if temp_vmod_root != '' {
@@ -279,7 +284,9 @@ fn code_lens_source_with_original_pseudos(source string, source_path string,
 			if code_lens_mask_has_at_token(mask, pos, '@LOCATION') {
 				temp_literal := code_lens_v_string_literal(temp_source_path)
 				file_literal := code_lens_v_string_literal(file_path)
-				rewritten.write_string('(@LOCATION.replace(${temp_literal}, ${file_literal}))')
+				windows_literal := code_lens_v_string_literal(windows_temp_location)
+				posix_literal := code_lens_v_string_literal(posix_temp_location)
+				rewritten.write_string('(@LOCATION.replace(${temp_literal}, ${file_literal}).replace(${windows_literal}, ${file_literal}).replace(${posix_literal}, ${file_literal}))')
 				pos += '@LOCATION'.len
 				continue
 			}
@@ -324,7 +331,7 @@ fn preserve_code_lens_overlay_dir(overlay CompilationOverlay, temp_dir string,
 		rel_path := overlay_relative_path(temp_path, overlay.temp_root) or { continue }
 		source_path := normalize_overlay_path(os.join_path(overlay.source_root, rel_path))
 		source := open_sources[source_path] or { os.read_file(temp_path)! }
-		rewritten := code_lens_source_with_original_pseudos(source, source_path, temp_path)
+		rewritten := code_lens_source_with_original_pseudos(source, source_path, temp_path, overlay.temp_work_dir)
 		if rewritten == source {
 			continue
 		}

--- a/run_command.v
+++ b/run_command.v
@@ -227,8 +227,7 @@ fn code_lens_token_is_in_hash_directive(mask []u8, pos int) bool {
 }
 
 fn code_lens_v_string_literal(value string) string {
-	escaped := value.replace('\\', '\\\\').replace("'", "\\'").replace('$', '\\$').replace('\n',
-		'\\n').replace('\r', '\\r').replace('\t', '\\t')
+	escaped := value.replace('\\', '\\\\').replace("'", "\\'").replace('\$', '\\\$').replace('\n', '\\n').replace('\r', '\\r').replace('\t', '\\t')
 	return "'${escaped}'"
 }
 
@@ -359,8 +358,8 @@ mut:
 
 fn new_run_command_manager() &RunCommandManager {
 	return &RunCommandManager{
-		workers:        sync.new_waitgroup()
-		processes:      map[u64]&os.Process{}
+		workers: sync.new_waitgroup()
+		processes: map[u64]&os.Process{}
 		active_targets: map[string]u64{}
 	}
 }
@@ -500,7 +499,7 @@ fn run_managed_process(mut manager RunCommandManager, id u64, target string, exe
 		return ManagedRunResult{
 			result: os.Result{
 				exit_code: 1
-				output:    'Working dir does not exist: ${work_folder}'
+				output: 'Working dir does not exist: ${work_folder}'
 			}
 		}
 	}
@@ -544,7 +543,7 @@ fn run_managed_process(mut manager RunCommandManager, id u64, target string, exe
 	return ManagedRunResult{
 		result: os.Result{
 			exit_code: exit_code
-			output:    output.str()
+			output: output.str()
 		}
 		cancelled: !registered || manager.job_is_cancelled(id, target)
 	}
@@ -592,15 +591,14 @@ fn run_code_lens_job(mut manager RunCommandManager, id u64, target string,
 	}
 	temp_dir := os.join_path(os.temp_dir(), 'vls_run_${os.getpid()}_${id}_${time.now().unix_nano()}')
 	mut worker := App{
-		open_files:      job.open_files
-		temp_dir:        temp_dir
-		capture_output:  job.capture_output
-		write_mutex:     job.write_mutex
-		tcp_conn:        job.tcp_conn
+		open_files: job.open_files
+		temp_dir: temp_dir
+		capture_output: job.capture_output
+		write_mutex: job.write_mutex
+		tcp_conn: job.tcp_conn
 	}
 	os.mkdir_all(temp_dir) or {
-		worker.send_show_message('vls: ${job.title} could not create a temporary directory: ${err}',
-			1)
+		worker.send_show_message('vls: ${job.title} could not create a temporary directory: ${err}', 1)
 		return worker.captured_output.clone()
 	}
 	defer {
@@ -613,13 +611,11 @@ fn run_code_lens_job(mut manager RunCommandManager, id u64, target string,
 	mut overlay := CompilationOverlay{}
 	if job.uri in job.open_files {
 		overlay = worker.prepare_compilation_overlay(job.path) or {
-			worker.send_show_message('vls: ${job.title} could not prepare the open buffer: ${err}',
-				1)
+			worker.send_show_message('vls: ${job.title} could not prepare the open buffer: ${err}', 1)
 			return worker.captured_output.clone()
 		}
 		preserve_code_lens_overlay_source_paths(overlay, job.open_files) or {
-			worker.send_show_message('vls: ${job.title} could not preserve source paths: ${err}',
-				1)
+			worker.send_show_message('vls: ${job.title} could not preserve source paths: ${err}', 1)
 			return worker.captured_output.clone()
 		}
 		target_path = overlay.temp_source_file
@@ -630,15 +626,13 @@ fn run_code_lens_job(mut manager RunCommandManager, id u64, target string,
 	compile_args := code_lens_compile_args(job, target_path, executable_path)
 	display_args := code_lens_display_args(job)
 	worker.send_log_message('vls: ${job.title}: v ${display_args.join(' ')}', 3)
-	compile_result := run_managed_process(mut manager, id, target, resolve_v_compiler_exe(),
-		compile_args, compile_dir)
+	compile_result := run_managed_process(mut manager, id, target, resolve_v_compiler_exe(), compile_args, compile_dir)
 	if compile_result.cancelled {
 		return worker.captured_output.clone()
 	}
 	log_code_lens_output(mut worker, compile_result.result, overlay)
 	if compile_result.result.exit_code != 0 {
-		worker.send_show_message(
-			'vls: ${job.title} failed with exit code ${compile_result.result.exit_code}.', 1)
+		worker.send_show_message('vls: ${job.title} failed with exit code ${compile_result.result.exit_code}.', 1)
 		return worker.captured_output.clone()
 	}
 
@@ -648,8 +642,7 @@ fn run_code_lens_job(mut manager RunCommandManager, id u64, target string,
 	}
 	log_code_lens_output(mut worker, run_result.result, overlay)
 	if run_result.result.exit_code != 0 {
-		worker.send_show_message(
-			'vls: ${job.title} failed with exit code ${run_result.result.exit_code}.', 1)
+		worker.send_show_message('vls: ${job.title} failed with exit code ${run_result.result.exit_code}.', 1)
 		return worker.captured_output.clone()
 	}
 	worker.send_show_message('vls: ${job.title} finished successfully.', 3)

--- a/run_command.v
+++ b/run_command.v
@@ -97,9 +97,9 @@ fn (mut output RunOutputBuffer) str() string {
 	return result
 }
 
-// code_lens_source_code_mask keeps code bytes in place while hiding strings and comments.
+// v_source_code_mask keeps code bytes in place while hiding strings and comments.
 // Interpolation expressions remain visible because they can contain compile-time path tokens.
-fn code_lens_source_code_mask(source string) []u8 {
+fn v_source_code_mask(source string) []u8 {
 	mut mask := []u8{len: source.len, init: ` `}
 	mut state := ImportScanState{}
 	mut in_line_comment := false
@@ -236,7 +236,7 @@ fn code_lens_v_string_literal(value string) string {
 // native inputs from the materialized overlay.
 fn code_lens_source_with_original_pseudos(source string, source_path string,
 	temp_source_path string, temp_work_dir string) string {
-	mask := code_lens_source_code_mask(source)
+	mask := v_source_code_mask(source)
 	file_path := os.real_path(source_path)
 	file_dir := os.real_path(os.dir(source_path))
 	relative_temp_path := overlay_relative_path(temp_source_path, temp_work_dir) or {

--- a/semantic_tokens.v
+++ b/semantic_tokens.v
@@ -101,9 +101,9 @@ fn tokenize_v_line(line string, line_idx int, mut state TokenizeState, mut token
 		}
 		if col > start {
 			tokens << SemToken{
-				line:     line_idx
-				start:    start
-				length:   col - start
+				line: line_idx
+				start: start
+				length: col - start
 				type_idx: sem_tok_comment
 			}
 		}
@@ -138,9 +138,9 @@ fn tokenize_v_line(line string, line_idx int, mut state TokenizeState, mut token
 				state.in_block_comment = true
 			}
 			tokens << SemToken{
-				line:     line_idx
-				start:    start
-				length:   col - start
+				line: line_idx
+				start: start
+				length: col - start
 				type_idx: sem_tok_comment
 			}
 			continue
@@ -149,9 +149,9 @@ fn tokenize_v_line(line string, line_idx int, mut state TokenizeState, mut token
 		// Line comment: // …
 		if col + 1 < n && c == `/` && line[col + 1] == `/` {
 			tokens << SemToken{
-				line:     line_idx
-				start:    col
-				length:   n - col
+				line: line_idx
+				start: col
+				length: n - col
 				type_idx: sem_tok_comment
 			}
 			return
@@ -175,9 +175,9 @@ fn tokenize_v_line(line string, line_idx int, mut state TokenizeState, mut token
 				col++
 			}
 			tokens << SemToken{
-				line:     line_idx
-				start:    start
-				length:   col - start
+				line: line_idx
+				start: start
+				length: col - start
 				type_idx: sem_tok_string
 			}
 			continue
@@ -200,9 +200,9 @@ fn tokenize_v_line(line string, line_idx int, mut state TokenizeState, mut token
 				col++
 			}
 			tokens << SemToken{
-				line:     line_idx
-				start:    start
-				length:   col - start
+				line: line_idx
+				start: start
+				length: col - start
 				type_idx: sem_tok_string
 			}
 			continue
@@ -220,9 +220,9 @@ fn tokenize_v_line(line string, line_idx int, mut state TokenizeState, mut token
 				}
 			}
 			tokens << SemToken{
-				line:     line_idx
-				start:    start
-				length:   col - start
+				line: line_idx
+				start: start
+				length: col - start
 				type_idx: sem_tok_number
 			}
 			continue
@@ -243,9 +243,9 @@ fn tokenize_v_line(line string, line_idx int, mut state TokenizeState, mut token
 			tok_type := classify_v_identifier(word)
 			if tok_type >= 0 {
 				tokens << SemToken{
-					line:     line_idx
-					start:    start
-					length:   col - start
+					line: line_idx
+					start: start
+					length: col - start
 					type_idx: tok_type
 				}
 			}
@@ -291,7 +291,7 @@ fn convert_tokens_to_encoding(tokens []SemToken, lines []string, enc PositionEnc
 		enc_end := byte_to_encoded_col(line, tok.start + tok.length, enc)
 		out << SemToken{
 			...tok
-			start:  enc_start
+			start: enc_start
 			length: enc_end - enc_start
 		}
 	}
@@ -323,9 +323,11 @@ fn encode_semantic_tokens(raw_tokens []SemToken) []int {
 // returning semantic highlighting data for the entire document.
 fn (mut app App) handle_semantic_tokens(request Request) Response {
 	params := json2.decode[SemanticTokensParams](request.params) or {
-		$if debug { log('Failed to decode SemanticTokensParams: ${err}') }
+		$if debug {
+			log('Failed to decode SemanticTokensParams: ${err}')
+		}
 		return Response{
-			id:     request.id
+			id: request.id
 			result: 'null'
 		}
 	}
@@ -334,18 +336,17 @@ fn (mut app App) handle_semantic_tokens(request Request) Response {
 	if content == '' {
 		// An empty document has an empty token set, not a null result (P2-01).
 		return Response{
-			id:     request.id
+			id: request.id
 			result: SemanticTokens{
 				data: []
 			}
 		}
 	}
 	lines := content.split_into_lines()
-	raw_tokens := convert_tokens_to_encoding(tokenize_v_source(content), lines,
-		app.position_encoding)
+	raw_tokens := convert_tokens_to_encoding(tokenize_v_source(content), lines, app.position_encoding)
 	encoded := encode_semantic_tokens(raw_tokens)
 	return Response{
-		id:     request.id
+		id: request.id
 		result: SemanticTokens{
 			data: encoded
 		}
@@ -357,9 +358,11 @@ fn (mut app App) handle_semantic_tokens(request Request) Response {
 // which reduces payload size for large files.
 fn (mut app App) handle_semantic_tokens_range(request Request) Response {
 	params := json2.decode[SemanticTokensRangeParams](request.params) or {
-		$if debug { log('Failed to decode SemanticTokensRangeParams: ${err}') }
+		$if debug {
+			log('Failed to decode SemanticTokensRangeParams: ${err}')
+		}
 		return Response{
-			id:     request.id
+			id: request.id
 			result: 'null'
 		}
 	}
@@ -367,15 +370,14 @@ fn (mut app App) handle_semantic_tokens_range(request Request) Response {
 	content := app.open_files[uri] or { os.read_file(uri_to_path(uri)) or { '' } }
 	if content == '' {
 		return Response{
-			id:     request.id
+			id: request.id
 			result: SemanticTokens{
 				data: []
 			}
 		}
 	}
 	lines := content.split_into_lines()
-	raw_tokens := convert_tokens_to_encoding(tokenize_v_source(content), lines,
-		app.position_encoding)
+	raw_tokens := convert_tokens_to_encoding(tokenize_v_source(content), lines, app.position_encoding)
 	start_line := params.range.start.line
 	start_char := params.range.start.char
 	end_line := params.range.end.line
@@ -385,12 +387,11 @@ fn (mut app App) handle_semantic_tokens_range(request Request) Response {
 	// (line, start) is kept when its start position is >= the range start and <
 	// the range end in (line, char) order; this excludes tokens before the start
 	// character on the first line and at/after the end character on the last line.
-	range_tokens := raw_tokens.filter(
-		(it.line > start_line || (it.line == start_line && it.start >= start_char))
+	range_tokens := raw_tokens.filter((it.line > start_line || (it.line == start_line && it.start >= start_char))
 		&& (it.line < end_line || (it.line == end_line && it.start < end_char)))
 	encoded := encode_semantic_tokens(range_tokens)
 	return Response{
-		id:     request.id
+		id: request.id
 		result: SemanticTokens{
 			data: encoded
 		}


### PR DESCRIPTION
## Summary

- apply the pinned V formatter output and replace enum-attribute method dispatch with V3-safe mappings
- normalize established-compiler line-info output and retain hover/signature fallbacks for the V workspace
- isolate CI from stale V object caches and keep production tests free of assert side effects

## Validation

- pinned V: fmt verification
- pinned V: normal and production test suites (6/6 each)
- pinned V: default and explicit V3 project builds
- VS Code extension: npm test and VSIX packaging