### PR TITLE
fix: resolve static method hover documentation

### DIFF
--- a/handlers.v
+++ b/handlers.v
@@ -5111,6 +5111,20 @@ fn imported_module_at_symbol(line string, col int, content string) string {
 	return parse_import_aliases(content)[alias] or { '' }
 }
 
+// static_method_doc_symbol_at keeps the receiver type in a static method name,
+// e.g. `App.new` instead of bare `new`, so hover docs resolve to that method.
+fn static_method_doc_symbol_at(line string, col int, symbol string) string {
+	start, _ := find_word_bounds_at_col(line, col, .utf8)
+	if start <= 0 || line[start - 1] != `.` {
+		return symbol
+	}
+	receiver := get_word_before_dot(line, start - 1, .utf8)
+	if receiver == '' || receiver[0] < `A` || receiver[0] > `Z` {
+		return symbol
+	}
+	return '${receiver}.${symbol}'
+}
+
 // search_doc_in_vlib_dir searches all non-test .v files in `dir` for a
 // declaration of `symbol` and returns its vdoc comment, or '' if not found.
 fn search_doc_in_vlib_dir(dir string, symbol string) string {

--- a/handlers.v
+++ b/handlers.v
@@ -5100,7 +5100,7 @@ fn (mut app App) find_doc_comment_for_symbol(symbol string, current_lines []stri
 // imported_module_at_symbol returns the imported module path qualifying the
 // symbol at byte column `col`. It handles both `module.symbol` and
 // `module.Type.static_method` access.
-fn imported_module_at_symbol(line string, col int, content string) string {
+fn (app &App) imported_module_at_symbol(line string, col int, content string, position Position) string {
 	start, _ := find_word_bounds_at_col(line, col, .utf8)
 	if start <= 0 || line[start - 1] != `.` {
 		return ''
@@ -5111,6 +5111,9 @@ fn imported_module_at_symbol(line string, col int, content string) string {
 		return ''
 	}
 	if module_path := aliases[alias] {
+		if app.local_scope_bindings(content, position).any(it.name == alias) {
+			return ''
+		}
 		return module_path
 	}
 	qualifier_start, _ := find_word_bounds_at_col(line, start - 2, .utf8)
@@ -5118,7 +5121,11 @@ fn imported_module_at_symbol(line string, col int, content string) string {
 		return ''
 	}
 	module_alias := get_word_before_dot(line, qualifier_start - 1, .utf8)
-	return aliases[module_alias] or { '' }
+	module_path := aliases[module_alias] or { return '' }
+	if app.local_scope_bindings(content, position).any(it.name == module_alias) {
+		return ''
+	}
+	return module_path
 }
 
 // static_method_doc_symbol_at keeps the receiver type in a static method name,

--- a/handlers.v
+++ b/handlers.v
@@ -5098,17 +5098,27 @@ fn (mut app App) find_doc_comment_for_symbol(symbol string, current_lines []stri
 }
 
 // imported_module_at_symbol returns the imported module path qualifying the
-// symbol at byte column `col`, or '' for an unqualified symbol.
+// symbol at byte column `col`. It handles both `module.symbol` and
+// `module.Type.static_method` access.
 fn imported_module_at_symbol(line string, col int, content string) string {
 	start, _ := find_word_bounds_at_col(line, col, .utf8)
 	if start <= 0 || line[start - 1] != `.` {
 		return ''
 	}
+	aliases := parse_import_aliases(content)
 	alias := get_word_before_dot(line, start - 1, .utf8)
 	if alias == '' {
 		return ''
 	}
-	return parse_import_aliases(content)[alias] or { '' }
+	if module_path := aliases[alias] {
+		return module_path
+	}
+	qualifier_start, _ := find_word_bounds_at_col(line, start - 2, .utf8)
+	if qualifier_start <= 0 || line[qualifier_start - 1] != `.` {
+		return ''
+	}
+	module_alias := get_word_before_dot(line, qualifier_start - 1, .utf8)
+	return aliases[module_alias] or { '' }
 }
 
 // static_method_doc_symbol_at keeps the receiver type in a static method name,

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -8808,9 +8808,22 @@ fn test_operation_at_pos_hover_static_method_uses_receiver_documentation() {
 	}
 	test_dir := os.join_path(app.temp_dir, 'hover_static_method')
 	must_mkdir_all(test_dir)
+	must_write_file(os.join_path(test_dir, 'v.mod'), 'Module {}\n')
+	module_dir := os.join_path(test_dir, 'a')
+	must_mkdir_all(module_dir)
+	must_write_file(os.join_path(module_dir, 'a.v'), 'module a
+
+pub struct App {}
+
+// new creates a new instance of the imported App struct.
+pub fn App.new() App {
+	return App{}
+}
+')
 	test_file := os.join_path(test_dir, 'main.v')
 	content := 'module main
 
+import a
 import time
 
 struct App {}
@@ -8822,7 +8835,9 @@ fn App.new() App {
 
 fn main() {
 	mut app := App.new()
+	imported := a.App.new()
 	_ = app
+	_ = imported
 	_ = time.now()
 }
 '
@@ -8830,6 +8845,7 @@ fn main() {
 	uri := path_to_uri(test_file)
 	app.open_files[uri] = content
 	app.text = content
+	app.workspace_roots = [test_dir]
 	lines := content.split_into_lines()
 	call_line := lines.index('\tmut app := App.new()')
 	if call_line < 0 {
@@ -8861,6 +8877,36 @@ fn main() {
 	hover := response.result as Hover
 	assert hover.contents.value.contains('new creates a new instance of the App struct.')
 	assert !hover.contents.value.contains('new returns a time struct')
+
+	imported_line := lines.index('\timported := a.App.new()')
+	if imported_line < 0 {
+		assert false, 'expected module-qualified static method call line'
+		return
+	}
+	imported_col := lines[imported_line].index('new') or {
+		assert false, 'expected imported static method name'
+		return
+	}
+	imported_response := app.operation_at_pos(.hover, Request{
+		id: 903
+		method: 'textDocument/hover'
+		params: json2.encode(TextDocumentPositionParams{
+			text_document: TextDocumentIdentifier{
+				uri: uri
+			}
+			position: Position{
+				line: imported_line
+				char: imported_col + 1
+			}
+		},
+			escape_unicode: true
+		)
+	})
+
+	assert imported_response.result is Hover
+	imported_hover := imported_response.result as Hover
+	assert imported_hover.contents.value.contains('new creates a new instance of the imported App struct.')
+	assert !imported_hover.contents.value.contains('new creates a new instance of the App struct.')
 }
 
 fn test_find_references_returns_declaration_and_calls() {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -8801,6 +8801,68 @@ fn test_operation_at_pos_hover_returns_symbol_information() {
 	assert hover.contents.value.contains('helper returns the supplied value')
 }
 
+fn test_operation_at_pos_hover_static_method_uses_receiver_documentation() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	test_dir := os.join_path(app.temp_dir, 'hover_static_method')
+	must_mkdir_all(test_dir)
+	test_file := os.join_path(test_dir, 'main.v')
+	content := 'module main
+
+import time
+
+struct App {}
+
+// new creates a new instance of the App struct.
+fn App.new() App {
+	return App{}
+}
+
+fn main() {
+	mut app := App.new()
+	_ = app
+	_ = time.now()
+}
+'
+	must_write_file(test_file, content)
+	uri := path_to_uri(test_file)
+	app.open_files[uri] = content
+	app.text = content
+	lines := content.split_into_lines()
+	call_line := lines.index('\tmut app := App.new()')
+	if call_line < 0 {
+		assert false, 'expected static method call line'
+		return
+	}
+	new_col := lines[call_line].index('new') or {
+		assert false, 'expected static method name'
+		return
+	}
+
+	response := app.operation_at_pos(.hover, Request{
+		id: 902
+		method: 'textDocument/hover'
+		params: json2.encode(TextDocumentPositionParams{
+			text_document: TextDocumentIdentifier{
+				uri: uri
+			}
+			position: Position{
+				line: call_line
+				char: new_col + 1
+			}
+		},
+			escape_unicode: true
+		)
+	})
+
+	assert response.result is Hover
+	hover := response.result as Hover
+	assert hover.contents.value.contains('new creates a new instance of the App struct.')
+	assert !hover.contents.value.contains('new returns a time struct')
+}
+
 fn test_find_references_returns_declaration_and_calls() {
 	mut app := create_test_app()
 	defer {

--- a/handlers_test.v
+++ b/handlers_test.v
@@ -4421,11 +4421,79 @@ fn test_find_doc_comment_for_qualified_symbol_uses_imported_module() {
 		assert false, 'expected foo column'
 		return
 	}
-	imported_module := imported_module_at_symbol(lines[call_line], foo_col, content)
+	imported_module := app.imported_module_at_symbol(lines[call_line], foo_col, content, Position{
+		line: call_line
+		char: foo_col
+	})
 	assert imported_module == 'b'
 
 	doc := app.find_doc_comment_for_symbol('foo', lines, uri, imported_module)
 	assert doc == 'B foo docs'
+}
+
+fn test_operation_at_pos_hover_respects_shadowed_chained_module_alias() {
+	mut app := create_test_app()
+	defer {
+		cleanup_test_app(app)
+	}
+	test_dir := os.join_path(app.temp_dir, 'shadowed_chained_hover')
+	module_dir := os.join_path(test_dir, 'clock')
+	must_mkdir_all(module_dir)
+	must_write_file(os.join_path(test_dir, 'v.mod'), 'Module {}\n')
+	must_write_file(os.join_path(module_dir, 'clock.v'), 'module clock
+
+// start performs the imported operation.
+pub fn start() {}
+')
+	content := 'module main
+
+import clock
+
+struct Timer {}
+
+// start performs the local timer operation.
+fn (timer Timer) start() {}
+
+struct Clock {
+	timer Timer
+}
+
+fn main() {
+	clock := Clock{}
+	clock.timer.start()
+}
+'
+	main_file := os.join_path(test_dir, 'main.v')
+	must_write_file(main_file, content)
+	uri := path_to_uri(main_file)
+	app.open_files[uri] = content
+	app.workspace_roots = [test_dir]
+	lines := content.split_into_lines()
+	call_line := lines.index('\tclock.timer.start()')
+	assert call_line >= 0
+	start_col := lines[call_line].index('start') or { -1 }
+	assert start_col >= 0
+	position := Position{
+		line: call_line
+		char: start_col + 1
+	}
+	response := app.operation_at_pos(.hover, Request{
+		id: 904
+		method: 'textDocument/hover'
+		params: json2.encode(TextDocumentPositionParams{
+			text_document: TextDocumentIdentifier{
+				uri: uri
+			}
+			position: position
+		},
+			escape_unicode: true
+		)
+	})
+
+	assert response.result is Hover
+	hover := response.result as Hover
+	assert hover.contents.value.contains('start performs the local timer operation.')
+	assert !hover.contents.value.contains('start performs the imported operation.')
 }
 
 fn test_find_doc_comment_for_symbol_not_found() {

--- a/interop.v
+++ b/interop.v
@@ -1513,11 +1513,7 @@ fn (mut app App) run_v_line_info(method Method, path string, line_info string) R
 					cursor_symbol = get_word_at_col(file_lines[cursor_line], cursor_col, .utf8)
 					if cursor_symbol != '' {
 						imported_module := imported_module_at_symbol(file_lines[cursor_line], cursor_col, file_content)
-						doc_symbol := if imported_module == '' {
-							static_method_doc_symbol_at(file_lines[cursor_line], cursor_col, cursor_symbol)
-						} else {
-							cursor_symbol
-						}
+						doc_symbol := static_method_doc_symbol_at(file_lines[cursor_line], cursor_col, cursor_symbol)
 						doc = app.find_doc_comment_for_symbol(doc_symbol, file_lines, path, imported_module)
 					}
 				}

--- a/interop.v
+++ b/interop.v
@@ -1512,7 +1512,11 @@ fn (mut app App) run_v_line_info(method Method, path string, line_info string) R
 				if cursor_line >= 0 && cursor_line < file_lines.len {
 					cursor_symbol = get_word_at_col(file_lines[cursor_line], cursor_col, .utf8)
 					if cursor_symbol != '' {
-						imported_module := imported_module_at_symbol(file_lines[cursor_line], cursor_col, file_content)
+						cursor_position := Position{
+							line: cursor_line
+							char: byte_to_encoded_col(file_lines[cursor_line], cursor_col, app.position_encoding)
+						}
+						imported_module := app.imported_module_at_symbol(file_lines[cursor_line], cursor_col, file_content, cursor_position)
 						doc_symbol := static_method_doc_symbol_at(file_lines[cursor_line], cursor_col, cursor_symbol)
 						doc = app.find_doc_comment_for_symbol(doc_symbol, file_lines, path, imported_module)
 					}

--- a/interop.v
+++ b/interop.v
@@ -1513,7 +1513,12 @@ fn (mut app App) run_v_line_info(method Method, path string, line_info string) R
 					cursor_symbol = get_word_at_col(file_lines[cursor_line], cursor_col, .utf8)
 					if cursor_symbol != '' {
 						imported_module := imported_module_at_symbol(file_lines[cursor_line], cursor_col, file_content)
-						doc = app.find_doc_comment_for_symbol(cursor_symbol, file_lines, path, imported_module)
+						doc_symbol := if imported_module == '' {
+							static_method_doc_symbol_at(file_lines[cursor_line], cursor_col, cursor_symbol)
+						} else {
+							cursor_symbol
+						}
+						doc = app.find_doc_comment_for_symbol(doc_symbol, file_lines, path, imported_module)
 					}
 				}
 			}


### PR DESCRIPTION
Hovering a static method such as `App.new()` could append documentation for an imported
same-named function such as `time.new`. The hover fallback now preserves the receiver type and
looks up `App.new`, while imported module calls remain scoped to their module.

Adds an end-to-end regression test covering the `App.new`/`time.new` collision.

## Validation

- `v .`
- `v -no-memory-limit test .` (6 test files passed)
- `npm test` in `vscode-extension` (6 tests passed)
- Framed stdio LSP initialize/open/hover/shutdown exchange against the rebuilt server
